### PR TITLE
Add custom `markdownify` filter

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -27,6 +27,13 @@ module.exports = function(eleventyConfig) {
 		});
 	});
 
+	const md = require('markdown-it')({
+		html: false,
+		breaks: true,
+		linkify: true
+	});
+	eleventyConfig.addNunjucksFilter("markdownify", markdownString => md.render(markdownString));
+
 	return {
 		templateFormats: [
 			"md",

--- a/_src/_assets/css/_states.scss
+++ b/_src/_assets/css/_states.scss
@@ -65,7 +65,7 @@
     }
   }
 
-  .state-notes {
+  .state-notes p {
     color: $text-color-light;
     font-size: $size-2;
     max-width: 26rem;

--- a/_src/_templates/states.njk
+++ b/_src/_templates/states.njk
@@ -36,7 +36,9 @@ layout: base.njk
     </table>
 
     {% if state.notes %}
-    <p class="state-notes">{{ state.notes }}</p>
+    <div class="state-notes">
+      {{ state.notes | markdownify | safe }}
+    </div>
     {% endif %}
 
     {% if state.comments %}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "homepage": "https://covidtracking.com",
   "dependencies": {
     "@11ty/eleventy-plugin-rss": "^1.0.5",
-    "luxon": "^0.3.1"
+    "luxon": "^0.3.1",
+    "markdown-it": "^10.0.0"
   },
   "devDependencies": {
     "@11ty/eleventy": "^0.7.1",


### PR DESCRIPTION
This allows us to pass any data—in this case, state notes pulledin via the remote JSON files—through a Markdown parser to render it as expected at the template level.

Note that this will require folks to re-run `npm install` once merged.