### PR TITLE
Slight tweaks to states page

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -4,6 +4,11 @@ const pluginRss = require("@11ty/eleventy-plugin-rss");
 module.exports = function(eleventyConfig) {
 	const CleanCSS = require('clean-css');
 
+	eleventyConfig.setBrowserSyncConfig({
+		ghostMode: false,
+		open: true
+	});
+
 	eleventyConfig.addPlugin(pluginRss);
 
 	eleventyConfig.addFilter("readableDate", dateObj => {

--- a/_src/_assets/css/_layout.scss
+++ b/_src/_assets/css/_layout.scss
@@ -79,7 +79,7 @@
   }
 
   li ul {
-	margin-left: 15px;
+    margin-left: 15px;
     margin-top: 10px;
     li {
 	  @media (min-width: $viewport-md) {
@@ -97,7 +97,36 @@
   }
 
   p.updated {
-    font-size: $size-2;
     color: $alert-color;
+  }
+}
+
+table {
+  border-collapse: collapse;
+  font-size: $size-1;
+  @media (min-width: $viewport-md) {
+    font-size: $size-2;
+  }
+  width: 100%;
+
+  &,
+  th,
+  td {
+    border: 1px solid #AAA;
+  }
+  caption,
+  th,
+  td {
+    padding: 0.25em;
+    @media (min-width: $viewport-md) {
+      padding: 0.45em;
+    }
+  }
+  caption {
+    font-size: $size-3;
+    font-weight: bold;
+  }
+  th {
+    font-weight: normal;
   }
 }

--- a/_src/_assets/css/_states.scss
+++ b/_src/_assets/css/_states.scss
@@ -1,35 +1,12 @@
 // Specificity hack is specific
-
-// Please fix to be how you want? Just a temporary thing to get totals to show up.
 .us-totals {
+  max-width: 60em;
   table {
-    border-collapse: collapse;
-    font-size: $size-1;
-    @media (min-width: $viewport-md) {
-      font-size: $size-2;
-    }
-    max-width: 60em;
-    width: 100%;
     margin-bottom: 4em;
-    &,
-    th,
-    td {
-      border: 1px solid #AAA;
-    }
-    caption {
-      font-weight: bold;
-    }
-    caption,
-    th,
-    td {
-      padding: 0.25em;
-      @media (min-width: $viewport-md) {
-        padding: 0.45em;
-      }
-    }
-    th {
-      font-weight: normal;
-    }
+  }
+  caption {
+    padding-left: 0;
+    text-align: left;
   }
 }
 
@@ -63,18 +40,15 @@
     &:focus {
       text-decoration: none;
     }
+    img {
+      vertical-align: bottom;
+    }
   }
   .state-name {
-    flex: 1;
-    margin: 0;
+    margin: 0 0.75em 0 0;
   }
 
   .state-table {
-    border-collapse: collapse;
-    font-size: $size-1;
-    @media (min-width: $viewport-md) {
-      font-size: $size-2;
-    }
     width: 100%;
 
     &,
@@ -91,18 +65,19 @@
       }
     }
     caption {
-      font-size: $size-1;
       caption-side: bottom;
-    }
-    th {
+      font-size: $size-1;
       font-weight: normal;
+      text-align: right;
     }
   }
 
-  .state-notes p {
-    color: $text-color-light;
-    font-size: $size-2;
+  .state-notes {
     max-width: 26rem;
-    width: inherit;
+    & > * {
+      color: $text-color-light;
+      font-size: $size-2;
+      width: inherit;
+    }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,19 @@
           "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.22.0.tgz",
           "integrity": "sha512-3sLvlfbFo+AxVEY3IqxymbumtnlgBwjDExxK60W3d+trrUzErNAz/PfvPT+mva+vEUrdIodeCOs7fB6zHtRSrw==",
           "dev": true
+        },
+        "markdown-it": {
+          "version": "8.4.2",
+          "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
+          "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "entities": "~1.1.1",
+            "linkify-it": "^2.0.0",
+            "mdurl": "^1.0.1",
+            "uc.micro": "^1.0.5"
+          }
         }
       }
     },
@@ -261,7 +274,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -4215,7 +4227,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
       "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
-      "dev": true,
       "requires": {
         "uc.micro": "^1.0.1"
       }
@@ -4383,16 +4394,22 @@
       }
     },
     "markdown-it": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.2.tgz",
-      "integrity": "sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==",
-      "dev": true,
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
       "requires": {
         "argparse": "^1.0.7",
-        "entities": "~1.1.1",
+        "entities": "~2.0.0",
         "linkify-it": "^2.0.0",
         "mdurl": "^1.0.1",
         "uc.micro": "^1.0.5"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.0.tgz",
+          "integrity": "sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw=="
+        }
       }
     },
     "maximatch": {
@@ -4445,8 +4462,7 @@
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
-      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
-      "dev": true
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "memory-fs": {
       "version": "0.5.0",
@@ -6640,8 +6656,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -7073,8 +7088,7 @@
     "uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
-      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
-      "dev": true
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA=="
     },
     "uglify-js": {
       "version": "3.8.0",


### PR DESCRIPTION
Did a quick tightening-up on yesterday’s states page work (#13):

- Pulled the Twitter icon closer to the state name, so that these tables don’t look like things Twitter generated. Because they are not.
- Refactored the table styles a bit (https://github.com/COVID19Tracking/website/commit/38769b3c3340b6d97006a80278824d703da8126d#diff-21411f591eb93a949eb6f1f8fd79ad70R104) so there’s a common `table` component that’s centrally accessible. (@webmasterkai, I think your summary table still looks 💖great💖, but please let me know if I donked anything up.)
- Bumped up the size on the `.updates` block, just to make it look a little more…page level-y yes this is a word now

Here’s a before & after GIF!

![states](https://user-images.githubusercontent.com/124493/76649339-d5edeb00-6536-11ea-8cb0-af560454d342.gif)

Would love to hear folks’ thoughts.

In addition to the above, I tweaked the BrowserSync config _very slightly_ in https://github.com/COVID19Tracking/website/commit/8b8a1b91caab409612d60b30c0e0ad837737cd67. @Wilto (or anyone else), does that seem okay to you? Happy to revert if not.