### PR TITLE
documentation had a what seemed like an old route in the example. 

### DIFF
--- a/_src/api.md
+++ b/_src/api.md
@@ -4,7 +4,7 @@ nav: API
 summary: Information about accessing the data via JSON or CSV.
 ---
 
-The default response is JSON using normal GET requests. If you'd like CSV just append `.csv` at the end of the url. For example https://covidtracking.com/states.csv
+The default response is JSON using normal GET requests. If you'd like CSV just append `.csv` at the end of the url. For example https://covidtracking.com/api/states.csv
 
 The API format could and probably will change slightly in the future.
 

--- a/_src/api.md
+++ b/_src/api.md
@@ -4,7 +4,7 @@ nav: API
 summary: Information about accessing the data via JSON or CSV.
 ---
 
-The default response is JSON using normal GET requests. If you'd like CSV just append `.csv` at the end of the url. For example https://covid.cape.io/states.csv
+The default response is JSON using normal GET requests. If you'd like CSV just append `.csv` at the end of the url. For example https://covidtracking.com/states.csv
 
 The API format could and probably will change slightly in the future.
 


### PR DESCRIPTION
Appending any of the detail routes to that sample did not work.

For example, this link does not work: https://covid.cape.io/api/states

Maybe this is better handled via the CMS, maybe I should have just made an issue.
