### PR TITLE
[US Daily Data] Fix date formatting

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,66 +1,75 @@
-const { DateTime } = require("luxon");
-const pluginRss = require("@11ty/eleventy-plugin-rss");
+const { DateTime } = require('luxon')
+const pluginRss = require('@11ty/eleventy-plugin-rss')
 
 module.exports = function(eleventyConfig) {
-	const CleanCSS = require('clean-css');
+  const CleanCSS = require('clean-css')
 
-	eleventyConfig.setBrowserSyncConfig({
-		ghostMode: false,
-		open: true
-	});
+  eleventyConfig.setBrowserSyncConfig({
+    ghostMode: false,
+    open: true,
+  })
 
-	eleventyConfig.addPlugin(pluginRss);
+  eleventyConfig.addPlugin(pluginRss)
 
-	eleventyConfig.addFilter("readableDate", dateObj => {
-		return DateTime.fromJSDate(dateObj).toFormat("dd LLL yyyy");
-	});
+  eleventyConfig.addFilter('readableDate', dateObj => {
+    return DateTime.fromJSDate(dateObj).toFormat('dd LLL yyyy')
+  })
 
-	eleventyConfig.addPassthroughCopy("_src/_assets");
-	eleventyConfig.addPassthroughCopy("_src/sw.js");
-	eleventyConfig.addPassthroughCopy("_src/admin/");
-	eleventyConfig.addPassthroughCopy("_redirects");
+  eleventyConfig.addFilter('readableYYYYMMDD', day => {
+    let dayStr = day + '' // It looks like these values are getting passed as an integer
+    try {
+      return DateTime.fromFormat(dayStr + '', 'yyyyMMdd').toFormat(
+        'dd LLL yyyy ccc',
+      )
+    } catch (e) {
+      console.error(`Couldn't parse date ${dayStr}`)
+      return day
+    }
+  })
 
-	eleventyConfig.addFilter(
-		'cssmin',
-		code => new CleanCSS({}).minify(code).styles
-	);
+  eleventyConfig.addPassthroughCopy('_src/_assets')
+  eleventyConfig.addPassthroughCopy('_src/sw.js')
+  eleventyConfig.addPassthroughCopy('_src/admin/')
+  eleventyConfig.addPassthroughCopy('_redirects')
 
-	// All posts:
-	eleventyConfig.addCollection("posts", function(collection) {
-		return collection.getAllSorted().filter(function(item) {
-			return item;
-		});
-	});
+  eleventyConfig.addFilter(
+    'cssmin',
+    code => new CleanCSS({}).minify(code).styles,
+  )
 
-	const md = require('markdown-it')({
-		html: false,
-		breaks: true,
-		linkify: true
-	});
-	eleventyConfig.addNunjucksFilter("markdownify", markdownString => md.render(markdownString));
+  // All posts:
+  eleventyConfig.addCollection('posts', function(collection) {
+    return collection.getAllSorted().filter(function(item) {
+      return item
+    })
+  })
 
-	eleventyConfig.addNunjucksFilter(
-		"thousands",
-		x => x ? x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",") : x,
-	)
+  const md = require('markdown-it')({
+    html: false,
+    breaks: true,
+    linkify: true,
+  })
+  eleventyConfig.addNunjucksFilter('markdownify', markdownString =>
+    md.render(markdownString),
+  )
 
-	return {
-		templateFormats: [
-			"md",
-			"njk",
-			"html"
-		],
+  eleventyConfig.addNunjucksFilter('thousands', x =>
+    x ? x.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',') : x,
+  )
 
-		pathPrefix: "/",
-		markdownTemplateEngine: "njk",
-		htmlTemplateEngine: "njk",
-		dataTemplateEngine: "njk",
-		passthroughFileCopy: true,
-		dir: {
-			input: "_src",
-			includes: "_templates",
-			data: "_data",
-			output: "_site"
-		}
-	};
-};
+  return {
+    templateFormats: ['md', 'njk', 'html'],
+
+    pathPrefix: '/',
+    markdownTemplateEngine: 'njk',
+    htmlTemplateEngine: 'njk',
+    dataTemplateEngine: 'njk',
+    passthroughFileCopy: true,
+    dir: {
+      input: '_src',
+      includes: '_templates',
+      data: '_data',
+      output: '_site',
+    },
+  }
+}

--- a/_src/_templates/us-daily.njk
+++ b/_src/_templates/us-daily.njk
@@ -27,7 +27,7 @@ layout: base.njk
         {% for day in sheets.usDaily %}
           <tr>
             {# [{"date":20200304,"states":14,"positive":118,"negative":748,"posNeg":866,"pending":103,"death":null,"total":969}, #}
-            <td>{{ day.date }}</td>
+            <td>{{ day.date | readableYYYYMMDD }}</td>
             <td>{{ day.states | thousands }}</td>
             <td>{{ day.positive | thousands }}</td>
             <td>{{ day.negative | thousands }}</td>


### PR DESCRIPTION
This makes the dates more readable and more consistent with other dates
on the site.

I also included the 3 letter abbrev for day of the week at the end of the
date since I think that is what I would want to see (weekends are sometimes
anomalous, sometimes easier to think in terms of days of the week when
thinking about the recent past)

This can be changed by adjusting the format string here:
    +      return DateTime.fromFormat(dayStr + '', 'yyyyMMdd').toFormat(
    +        'dd LLL yyyy ccc',

Taking out the ` ccc` will remove the day of the week

New look is this:
![image](https://user-images.githubusercontent.com/56719/76816451-80773f80-67bd-11ea-92b1-3588a232218f.png)
