### PR TITLE
Refactor CSS and design iterations

### DIFF
--- a/_src/_assets/css/_button.scss
+++ b/_src/_assets/css/_button.scss
@@ -1,0 +1,27 @@
+.btn {
+  display: inline-block;
+  padding: .75em 1.25em;
+  font-size: 1em;
+  font-weight: 500;
+  color: #fff;
+  text-align: center;
+  text-decoration: none;
+  vertical-align: middle;
+  cursor: pointer;
+  user-select: none;
+  background-color: $link-color;
+  border: 1px solid $link-color;
+  border-radius: .5em;
+
+  &:hover,
+  &:focus {
+    color: #fff;
+    border-color: darken($link-color, 5%);
+  }
+
+  &:active {
+    color: #fff;
+    background-color: darken($link-color, 5%);
+    border-color: darken($link-color, 5%);
+  }
+}

--- a/_src/_assets/css/_globals.scss
+++ b/_src/_assets/css/_globals.scss
@@ -1,39 +1,70 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+:root {
+  font-size: 16px;
+}
+
 body, h1, h2, h3, h4,
 ol, ul {
-	margin: 0;
-	padding: 0;
+  margin: 0;
+  padding: 0;
 }
 img, svg {
-	max-width: 100%;
+  max-width: 100%;
 }
 
 .a11y-only {
-	border: 0;
-	clip: rect(0 0 0 0);
-	height: 1px;
-	margin: -1px;
-	overflow: hidden;
-	padding: 0;
-	position: absolute;
-	width: 1px;
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
 }
 .a11y-only.focusable:active,
 .a11y-only.focusable:focus {
-	clip: auto;
-	height: auto;
-	margin: 0;
-	overflow: visible;
-	position: static;
-	width: auto;
+  clip: auto;
+  height: auto;
+  margin: 0;
+  overflow: visible;
+  position: static;
+  width: auto;
 }
 [aria-hidden="true"] {
-	display: none;
+  display: none;
 }
 
 *:focus {
-	outline: 2px dotted $fore;
+  outline: 2px dotted $fore;
 }
 
 body {
-	font-family: $body;
+  font-family: $body;
+  line-height: 1.4;
+  color: $text-color-dark;
+  background-color: #fff;
+}
+
+// Content between header and footer
+.body {
+  font-size: $size-3;
+}
+
+a {
+  color: $link-color;
+
+  &:hover,
+  &:focus {
+    color: darken($link-color, 10%);
+  }
+}
+
+.text-left {
+  text-align: left;
 }

--- a/_src/_assets/css/_header.scss
+++ b/_src/_assets/css/_header.scss
@@ -1,23 +1,60 @@
 .site-header {
+  padding-top: 2rem;
+  padding-bottom: 2rem;
+  margin-bottom: 2rem;
   border-bottom: 3px solid $border-color;
-  padding: 30px 0;
 
   @media (min-width: $viewport-md) {
-    padding: 50px 0;
+    padding-top: 3rem;
+    padding-bottom: 3rem;
+    margin-bottom: 3rem;
   }
 
-    a {
-      font-size: $size-2;
-      font-weight: 700;
-
-      @media (min-width: $viewport-md) {
-        font-size: $size-4;
-      }
-      color: black;
-      text-decoration: none;
-      transition: opacity 0.3s;
-      &:hover {
-        opacity: 0.5;
-      }
+  .container {
+    @media (min-width: $viewport-md) {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
     }
+  }
+}
+
+.site-title {
+  display: inline-block;
+  margin-bottom: 1rem;
+  font-size: $size-3;
+  font-weight: 700;
+  color: #000;
+  text-decoration: none;
+  transition: opacity 0.3s;
+
+  @media (min-width: $viewport-md) {
+    font-size: $size-4;
+    margin-bottom: 0;
+  }
+
+  &:hover,
+  &:focus {
+    opacity: 0.5;
+  }
+}
+
+.site-nav {
+  display: flex;
+  list-style-type: none;
+
+  li + li {
+    margin-left: 1rem;
+  }
+
+  a {
+    padding-top: .5em;
+    padding-bottom: .5em;
+    font-weight: 700;
+
+    &:hover,
+    &:focus {
+      opacity: .5;
+    }
+  }
 }

--- a/_src/_assets/css/_layout.scss
+++ b/_src/_assets/css/_layout.scss
@@ -1,132 +1,78 @@
 .container {
-  margin: 0 30px;
+  margin-right: 2rem;
+  margin-left: 2rem;
 
   @media (min-width: $viewport-md) {
-    margin: 0 auto;
+    margin-right: auto;
+    margin-left: auto;
   }
 
   @media (min-width: $viewport-md) { width: 80%; }
   @media (min-width: $viewport-lg) { width: 95%; }
   @media (min-width: $viewport-xl) { max-width: 1200px; }
-  
 }
 
-.body {
-  padding: 30px 0;
-  @media (min-width: $viewport-md) { padding: 50px 0; }
+h1 {
+  margin-bottom: 2rem;
+  text-transform: uppercase;
+  font-size: $size-4;
 
-  h1 {
-    text-transform: uppercase;
-    font-size: $size-4;
-    margin-bottom: 30px;
-
-    @media (min-width: $viewport-md) {
-      font-size: $size-5;
-      margin-bottom: 50px;
-    }
-  }
-
-  h2 {
-    font-size: $size-3;
-    margin-top: 30px;
-    margin-bottom: 15px;
-
-    @media (min-width: $viewport-md) {
-      margin-top: 50px;
-      margin-bottom: 15px;
-    }
-  }
-
-  h3, h4 {
-    font-size: $size-2;
-    margin-top: 30px;
-    margin-bottom: 15px;
-  }
-
-  // Temporary style for emphasis
-  h3 a {
-    color: white;
-    font-size: $size-5;
-    text-decoration: none;
-    background-color: black;
-    padding: 15px;
-    display: inline-block;
-  }
-
-  p, li {
-    color: $text-color-dark;
-    font-size: $size-3;
-    line-height: 1.4;
-
-    margin-bottom: 15px;
-
-    @media (min-width: $viewport-md) {
-      margin-bottom: 30px;
-      width: 75%;
-    }
-
-    a {
-      color: $text-color-dark;
-      text-decoration-color: $text-color-light;
-    }
-  }
-
-  li {
-    margin-bottom: 7px;
-    @media (min-width: $viewport-md) {
-      margin-bottom: 15px;
-    }
-  }
-
-  li ul {
-    margin-left: 15px;
-    margin-top: 10px;
-    li {
-	  @media (min-width: $viewport-md) {
-		width: auto;
-	  }
-    }
-  }
-
-  p.lede {
-    @media (min-width: $viewport-md) {
-      font-size: $size-5;
-      line-height: 1.6;
-      width: 90%;
-    }
-  }
-
-  p.updated {
-    color: $alert-color;
-  }
-}
-
-table {
-  border-collapse: collapse;
-  font-size: $size-1;
   @media (min-width: $viewport-md) {
-    font-size: $size-2;
+    margin-bottom: 3rem;
+    font-size: $size-5;
   }
-  width: 100%;
+}
 
-  &,
-  th,
-  td {
-    border: 1px solid #AAA;
+h2 {
+  font-size: $size-3;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+
+  @media (min-width: $viewport-md) {
+    margin-top: 3rem;
+    margin-bottom: 1rem;
   }
-  caption,
-  th,
-  td {
-    padding: 0.25em;
+}
+
+h3, h4 {
+  font-size: $size-2;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+}
+
+p {
+  margin-bottom: 1rem;
+
+  @media (min-width: $viewport-md) {
+    width: 75%;
+    margin-bottom: 2rem;
+  }
+}
+
+.lede {
+  @media (min-width: $viewport-md) {
+    width: 90%;
+    font-size: $size-5;
+    line-height: 1.6;
+  }
+}
+
+.updated {
+  color: $alert-color;
+}
+
+// Limit some styles to .body to avoid nav collision
+.body {
+  li {
+    margin-bottom: .5rem;
+
     @media (min-width: $viewport-md) {
-      padding: 0.45em;
+      margin-bottom: 1rem;
     }
-  }
-  caption {
-    font-size: $size-3;
-    font-weight: bold;
-  }
-  th {
-    font-weight: normal;
+
+    ul {
+      margin-left: 1rem;
+      margin-bottom: 1rem;
+    }
   }
 }

--- a/_src/_assets/css/_states.scss
+++ b/_src/_assets/css/_states.scss
@@ -1,6 +1,7 @@
 // Specificity hack is specific
 .us-totals {
-  max-width: 60em;
+  max-width: 60rem;
+
   table {
     margin-bottom: 4em;
   }
@@ -11,10 +12,11 @@
 }
 
 .states-list {
-  max-width: 60em;
+  max-width: 60rem;
+
   @media (min-width: $viewport-md) {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(26em, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
     grid-gap: $size-5;
   }
 
@@ -23,6 +25,7 @@
     margin-bottom: $size-5;
     max-width: 26em;
     width: inherit;
+
     @media (min-width: $viewport-md) {
       margin-bottom: $size-3;
     }
@@ -46,30 +49,6 @@
   }
   .state-name {
     margin: 0 0.75em 0 0;
-  }
-
-  .state-table {
-    width: 100%;
-
-    &,
-    th,
-    td {
-      border: 1px solid #AAA;
-    }
-    caption,
-    th,
-    td {
-      padding: 0.25em;
-      @media (min-width: $viewport-md) {
-        padding: 0.45em;
-      }
-    }
-    caption {
-      caption-side: bottom;
-      font-size: $size-1;
-      font-weight: normal;
-      text-align: right;
-    }
   }
 
   .state-notes {

--- a/_src/_assets/css/_tables.scss
+++ b/_src/_assets/css/_tables.scss
@@ -1,0 +1,41 @@
+table {
+  width: 100%;
+  font-size: $size-1;
+  border-collapse: collapse;
+
+  @media (min-width: $viewport-md) {
+  font-size: $size-2;
+  }
+}
+
+caption,
+th,
+td {
+  padding: 0.25em;
+
+  @media (min-width: $viewport-md) {
+  padding: 0.5em;
+  }
+}
+
+th,
+td {
+  text-align: right;
+  border: 1px solid #ddd;
+}
+
+thead th {
+  background-color: #eee;
+  border-bottom: 1px solid #999;
+}
+
+tbody tr:nth-child(even) {
+  background-color: #f5f5f5;
+}
+
+caption {
+  font-size: $size-1;
+  font-weight: normal;
+  text-align: right;
+  caption-side: bottom;
+}

--- a/_src/_assets/css/_usDaily.scss
+++ b/_src/_assets/css/_usDaily.scss
@@ -1,84 +1,12 @@
 // Specificity hack is specific
 .us-days {
-  max-width: 60em;
+  max-width: 60rem;
+
   table {
     margin-bottom: 4em;
   }
   caption {
     padding-left: 0;
     text-align: left;
-  }
-}
-
-.day-list {
-  max-width: 60em;
-  @media (min-width: $viewport-md) {
-    /* display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(26em, 1fr));
-    grid-gap: $size-5;
-    */
-  }
-
-  .day-item {
-    list-style: none;
-    margin-bottom: $size-5;
-    max-width: 26em;
-    width: inherit;
-    @media (min-width: $viewport-md) {
-      margin-bottom: $size-3;
-    }
-    @supports (display: grid) {
-      max-width: inherit;
-    }
-  }
-  .day-header {
-    display: flex;
-    margin-bottom: $size-1;
-  }
-  .day-link {
-    color: inherit;
-    &:hover,
-    &:focus {
-      text-decoration: none;
-    }
-    img {
-      vertical-align: bottom;
-    }
-  }
-  .day-name {
-    margin: 0 0.75em 0 0;
-  }
-
-  .day-table {
-    width: 100%;
-
-    &,
-    th,
-    td {
-      border: 1px solid #aaa;
-    }
-    caption,
-    th,
-    td {
-      padding: 0.25em;
-      @media (min-width: $viewport-md) {
-        padding: 0.45em;
-      }
-    }
-    caption {
-      caption-side: bottom;
-      font-size: $size-1;
-      font-weight: normal;
-      text-align: right;
-    }
-  }
-
-  .day-notes {
-    max-width: 26rem;
-    & > * {
-      color: $text-color-light;
-      font-size: $size-2;
-      width: inherit;
-    }
   }
 }

--- a/_src/_assets/css/_variables.scss
+++ b/_src/_assets/css/_variables.scss
@@ -6,7 +6,9 @@ $border-color: #f3f3f3;
 $text-color-dark: #333;
 $text-color-light: #666;
 
-$alert-color: #DA352B;
+$alert-color: #da352b;
+
+$link-color: #0074d9;
 
 $hed: -apple-system, system-ui, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
 $body: -apple-system, system-ui, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;

--- a/_src/_assets/css/all.scss
+++ b/_src/_assets/css/all.scss
@@ -1,5 +1,7 @@
 @import "_variables";
 @import "_globals";
+@import "_tables";
+@import "_button";
 @import "_layout";
 @import "_header";
 @import "_states";

--- a/_src/_templates/base.njk
+++ b/_src/_templates/base.njk
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="fonts">
+<html lang="en">
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -18,7 +18,7 @@
 		<link rel="apple-touch-icon-precomposed" sizes="144x144" href="/_assets/img/icon-144.png">
 		<link rel="apple-touch-icon-precomposed" sizes="120x120" href="/_assets/img/icon-120.png">
 		<link rel="apple-touch-icon-precomposed" sizes="114x114" href="/_assets/img/icon-114.png">
-		
+
 		<meta name="msapplication-TileImage" content="/_assets/img/icon-144.png">
 		<meta name="theme-color" content="#6d252e">
 		<link rel="icon" type="image/png" href="/_assets/img/icon-32.png" sizes="32x32">
@@ -34,7 +34,7 @@
 				"logo": "{{ data.url }}/_assets/img/card.gif",
 				"sameAs" : [
 					"https://twitter.com/wilto"
-				] 
+				]
 			}
 		</script>
 

--- a/_src/_templates/partials/header.njk
+++ b/_src/_templates/partials/header.njk
@@ -1,6 +1,14 @@
 <a href="#main" class="a11y-only focusable">Skip to main content</a>
 <header class="site-header">
 	<div class="container">
-		<a href="/">{{ data.title }}</a>
+		<a class="site-title" href="/">{{ data.title }}</a>
+
+		<nav>
+			<ul class="site-nav">
+				<li><a href="/">Home</a></li>
+				<li><a href="/us-daily">US Daily</a></li>
+				<li><a href="/data">States</a></li>
+			</ul>
+		</nav>
 	</div>
 </header>

--- a/_src/_templates/us-daily.njk
+++ b/_src/_templates/us-daily.njk
@@ -13,7 +13,7 @@ layout: base.njk
       </caption>
       <thead>
         <tr>
-          <th scope="col">Date</th>
+          <th scope="col" class="text-left">Date</th>
           <th scope="col">States Tracked</th>
           <th scope="col">Positive</th>
           <th scope="col">Negative</th>
@@ -27,7 +27,7 @@ layout: base.njk
         {% for day in sheets.usDaily %}
           <tr>
             {# [{"date":20200304,"states":14,"positive":118,"negative":748,"posNeg":866,"pending":103,"death":null,"total":969}, #}
-            <td>{{ day.date | readableYYYYMMDD }}</td>
+            <td class="text-left">{{ day.date | readableYYYYMMDD }}</td>
             <td>{{ day.states | thousands }}</td>
             <td>{{ day.positive | thousands }}</td>
             <td>{{ day.negative | thousands }}</td>

--- a/_src/index.md
+++ b/_src/index.md
@@ -4,7 +4,7 @@ summary: ''
 ---
 The COVID Tracking Project collects information from 50 US states, the District of Columbia, and 5 other U.S. territories to provide the most comprehensive testing data we can collect for the novel coronavirus, SARS-CoV-2. We attempt to include **positive and negative results**, **pending tests**, and **total people tested for** each state or district currently reporting that data.
 
-### [TAKE ME TO THE DATA](/data)
+<a class="btn" href="/data">View data</a>
 
 [Show me the raw data (spreadsheet)](https://docs.google.com/spreadsheets/u/2/d/e/2PACX-1vRwAqp96T9sYYq2-i7Tj0pvTf6XVHjDSMIKBdZHXiCGGdNC0ypEU9NbngS8mxea55JuCFuua1MUeOj5/pubhtml) or [hook me up with the API (JSON and CSV)](https://covidtracking.com/api/).
 
@@ -16,19 +16,19 @@ From here, you can [view the most recent data](https://docs.google.com/spreadshe
 
 ## In the Press
 
-[U.S. Lags in Coronavirus Testing After Slow Response to Outbreak](https://www.nytimes.com/interactive/2020/03/17/us/coronavirus-testing-data.html), The New York Times, March 17, 2020
+- [U.S. Lags in Coronavirus Testing After Slow Response to Outbreak](https://www.nytimes.com/interactive/2020/03/17/us/coronavirus-testing-data.html), The New York Times, March 17, 2020
 
-[The 4 Key Reasons the U.S. Is So Behind on Coronavirus Testing](https://www.theatlantic.com/health/archive/2020/03/why-coronavirus-testing-us-so-delayed/607954/), The Atlantic, March 13, 2020
+- [The 4 Key Reasons the U.S. Is So Behind on Coronavirus Testing](https://www.theatlantic.com/health/archive/2020/03/why-coronavirus-testing-us-so-delayed/607954/), The Atlantic, March 13, 2020
 
-[America Isn’t Testing for the Most Alarming Coronavirus Cases](https://www.theatlantic.com/science/archive/2020/03/who-gets-tested-coronavirus/607999/), The Atlantic, March 13, 2020
+- [America Isn’t Testing for the Most Alarming Coronavirus Cases](https://www.theatlantic.com/science/archive/2020/03/who-gets-tested-coronavirus/607999/), The Atlantic, March 13, 2020
 
-[How to Understand Your State’s Coronavirus Numbers](https://www.theatlantic.com/technology/archive/2020/03/how-understand-your-states-coronavirus-numbers/607921/), The Atlantic, March 12, 2020
+- [How to Understand Your State’s Coronavirus Numbers](https://www.theatlantic.com/technology/archive/2020/03/how-understand-your-states-coronavirus-numbers/607921/), The Atlantic, March 12, 2020
 
-[The Dangerous Delays in U.S. Coronavirus Testing Haven’t Stopped](https://www.theatlantic.com/health/archive/2020/03/coronavirus-testing-numbers/607714/), The Atlantic, March 9, 2020
+- [The Dangerous Delays in U.S. Coronavirus Testing Haven’t Stopped](https://www.theatlantic.com/health/archive/2020/03/coronavirus-testing-numbers/607714/), The Atlantic, March 9, 2020
 
-[Key Source of COVID-19 Testing & Infection Data](https://talkingpointsmemo.com/edblog/key-source-of-covid-19-testing-infection-data), TPM, March 7, 2020
+- [Key Source of COVID-19 Testing & Infection Data](https://talkingpointsmemo.com/edblog/key-source-of-covid-19-testing-infection-data), TPM, March 7, 2020
 
-[The Strongest Evidence Yet That America Is Botching Coronavirus Testing](https://www.theatlantic.com/health/archive/2020/03/how-many-americans-have-been-tested-coronavirus/607597/), The Atlantic, March 6, 2020
+- [The Strongest Evidence Yet That America Is Botching Coronavirus Testing](https://www.theatlantic.com/health/archive/2020/03/how-many-americans-have-been-tested-coronavirus/607597/), The Atlantic, March 6, 2020
 
 ## Best Practices for Data Release
 


### PR DESCRIPTION
After a [request from Julie](https://twitter.com/joulee/status/1239755367556337665?s=20) for some design/CSS feedback, I volunteered some time to check out the project and see where I could be of use. Holled at @ccheever as well to get a brief lowdown on things. This PR is very open to any and all feedback, or outright closure if y'all aren't into it :). Just holler with any questions or comments.

Below is a summary of changes and some screenshots. My changes largely focused on under the hood updates, optimizing CSS, removing duplicated code, some minor Markdown changes, and adding clear navigation. Hope it helps!

Anyway, here we go!

## Summary

- Updated links to have clear blue color throughout. As I understand it, the goal is to keep things black and white, but the links didn't seem that easily discoverable, even with the underline.

- Added basic navigation to the header. I know there are links in the footer, however, these are in the footer—quickly jumping on mobile and even desktop without scrolling to the bottom would be an improvement. Current page style would be nice, but I'm new to nunjucks. On narrow viewports, the nav wraps to a new line.

- Made table styles all global, reducing specificity and duplication. I didn't want to push the table styles too far without direction first, so the style changes were kept pretty minimal Striped rows were added for quicker scanning (used `even` for now to avoid extra coloring on the two-row state tables).

  Also made all tables `text-align: right` for the time being, and added a `.text-left` utility class, due to the tables exclusively housing numerical data. This makes all the data easier to read.

- Added explicit button styles for the homepage button, and shortened the button text. These could be easily dropped for simpler styling if that's desired.

- Un-nested nearly all `.body` styles for lower specificity. `.body` is left intact for some `font-size` changes and list styling, but the rest is top level now.

- Removed nearly all of the unused, duplicated `_states.scss` CSS from `_usDaily.scss`. Could maybe remove more.

- Added some new Sass files to help split things out. Let me know if this goes too far, happy to consolidate.

## Possible todos

- [ ] Update tables (or just US Daily table?) to be responsive, using some `overflow` and `white-space` to make them scroll horizontally maybe?
- [ ] Nav current page highlighting
- [ ] Adjust some page sizing/spacing to bring tables higher up on the page
- [ ] Further CSS refactoring

## Screenshots

![covid1](https://user-images.githubusercontent.com/98681/76825617-af021400-67d7-11ea-966d-e5210ff3a36b.png)

![covid2](https://user-images.githubusercontent.com/98681/76825612-add0e700-67d7-11ea-81bd-c6b75f52d25e.png)

![covid3](https://user-images.githubusercontent.com/98681/76825619-af9aaa80-67d7-11ea-82dc-bdcf1f87048d.png)

---

Thanks for being awesome and making useful, beautiful open source projects that help people! <3