### PR TITLE
Adding in a .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# For more information: http://editorconfig.org
+
+# This is the top-most .editorconfig file; do not search in parent directories.
+root = true
+
+# All files.
+[*]
+charset = utf-8
+end_of_line = LF
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true


### PR DESCRIPTION
If we’re going to start taking in more external contributions (à la https://github.com/COVID19Tracking/website/pull/43), it’d be great to have an [.editorconfig](https://editorconfig.org/) that documents a few of our expectations around (just e.g.) whitespace.

…so that’s what this PR is offering hi

This is definitely a draft, so comments/feedback are welcome. And this can definitely evolve! Treating this as a starting point more than anything.