### PR TITLE
Updated colors for links & buttons (per #63); active page indicator

### DIFF
--- a/_src/_assets/css/_button.scss
+++ b/_src/_assets/css/_button.scss
@@ -9,19 +9,18 @@
   vertical-align: middle;
   cursor: pointer;
   user-select: none;
-  background-color: $link-color;
-  border: 1px solid $link-color;
+  background-color: $color-btn;
   border-radius: .5em;
 
   &:hover,
   &:focus {
     color: #fff;
-    border-color: darken($link-color, 5%);
+    background-color: $color-btn--active;
   }
 
   &:active {
     color: #fff;
-    background-color: darken($link-color, 5%);
-    border-color: darken($link-color, 5%);
+    background-color: darken($color-btn, 5%);
+    border-color: darken($color-btn, 5%);
   }
 }

--- a/_src/_assets/css/_globals.scss
+++ b/_src/_assets/css/_globals.scss
@@ -57,11 +57,12 @@ body {
 }
 
 a {
-  color: $link-color;
+  color: $color-link;
 
   &:hover,
   &:focus {
-    color: darken($link-color, 10%);
+    color: $color-link--active;
+    text-decoration: none;
   }
 }
 

--- a/_src/_assets/css/_globals.scss
+++ b/_src/_assets/css/_globals.scss
@@ -36,6 +36,7 @@ img, svg {
   position: static;
   width: auto;
 }
+.hidden,
 [aria-hidden="true"] {
   display: none;
 }

--- a/_src/_assets/css/_header.scss
+++ b/_src/_assets/css/_header.scss
@@ -24,7 +24,6 @@
   margin-bottom: 1rem;
   font-size: $size-3;
   font-weight: 700;
-  color: #000;
   text-decoration: none;
   transition: opacity 0.3s;
 
@@ -37,6 +36,10 @@
   &:focus {
     opacity: 0.5;
   }
+  &.active {
+    color: inherit;
+    text-decoration: none;
+  }
 }
 
 .site-nav {
@@ -48,13 +51,13 @@
   }
 
   a {
-    padding-top: .5em;
-    padding-bottom: .5em;
     font-weight: 700;
+    padding-bottom: .5em;
+    padding-top: .5em;
+    text-decoration: none;
 
-    &:hover,
-    &:focus {
-      opacity: .5;
+    &.active {
+      color: inherit;
     }
   }
 }

--- a/_src/_assets/css/_variables.scss
+++ b/_src/_assets/css/_variables.scss
@@ -8,7 +8,15 @@ $text-color-light: #666;
 
 $alert-color: #da352b;
 
-$link-color: #0074d9;
+$color-link: #546D8E;
+$color-link--active: #4A5F85;
+
+$color-btn: #4A5F85;
+$color-btn--active: #3D4F70;
+
+// links and headers: #607A9C
+// hover links: #4A5F85
+// hover headers: #7391B0
 
 $hed: -apple-system, system-ui, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;
 $body: -apple-system, system-ui, BlinkMacSystemFont, Roboto, Helvetica, Arial, sans-serif;

--- a/_src/_templates/base.njk
+++ b/_src/_templates/base.njk
@@ -75,6 +75,11 @@
 
 		{% include "partials/footer.njk" %}
 
+    <!-- Current page, as referenced by `aria-describedby` -->
+    <div id="wayfinding" class="hidden">
+      <span id="current-page">Current page</span>
+    </div>
+
 		<script>
 			if( 'serviceWorker' in navigator && window.location.hostname !== "localhost" ) {
 				navigator.serviceWorker.register('sw.js');

--- a/_src/_templates/partials/footer.njk
+++ b/_src/_templates/partials/footer.njk
@@ -3,7 +3,7 @@
     <ul class="pages">
 	  {%- for post in collections.posts -%}
 	  	{% if post.data.nav %}
-	  	<li{% if page.url == post.url %} class="active"{% endif %}><a href="{{ post.url | url }}">{{ post.data.nav }}</a></li>
+	  	<li{% if page.url == post.url %} aria-describedby="current-page" class="active"{% endif %}><a{% if page.url == post.url %} aria-current="page"{% endif %} href="{{ post.url | url }}">{{ post.data.nav }}</a></li>
 	  	{% endif %}
 	  {%- endfor -%}
 	  </ul>

--- a/_src/_templates/partials/header.njk
+++ b/_src/_templates/partials/header.njk
@@ -1,13 +1,13 @@
 <a href="#main" class="a11y-only focusable">Skip to main content</a>
 <header class="site-header">
 	<div class="container">
-		<a class="site-title" href="/">{{ data.title }}</a>
+		<a class="site-title{% if page.url == "/" %} active{% endif %}" href="/">{{ data.title }}</a>
 
 		<nav>
 			<ul class="site-nav">
-				<li><a href="/">Home</a></li>
-				<li><a href="/us-daily">US Daily</a></li>
-				<li><a href="/data">States</a></li>
+				<li><a{% if page.url == "/" %} class="active"{% endif %} href="/">Home</a></li>
+				<li><a{% if page.url == "/us-daily/" %} class="active"{% endif %} href="/us-daily">US Daily</a></li>
+				<li><a{% if page.url == "/data/" %} class="active"{% endif %} href="/data">States</a></li>
 			</ul>
 		</nav>
 	</div>

--- a/_src/_templates/partials/header.njk
+++ b/_src/_templates/partials/header.njk
@@ -5,9 +5,15 @@
 
 		<nav>
 			<ul class="site-nav">
-				<li><a{% if page.url == "/" %} class="active"{% endif %} href="/">Home</a></li>
-				<li><a{% if page.url == "/us-daily/" %} class="active"{% endif %} href="/us-daily">US Daily</a></li>
-				<li><a{% if page.url == "/data/" %} class="active"{% endif %} href="/data">States</a></li>
+				<li{% if page.url == "/" %} aria-describedby="current-page"{% endif %}>
+          <a{% if page.url == "/" %} aria-current="page" class="active"{% endif %} href="/">Home</a>
+        </li>
+				<li{% if page.url == "/us-daily/" %} aria-describedby="current-page"{% endif %}>
+          <a{% if page.url == "/us-daily/" %} aria-current="page" class="active"{% endif %} href="/us-daily">US Daily</a>
+        </li>
+				<li{% if page.url == "/data/" %} aria-describedby="current-page"{% endif %}>
+          <a{% if page.url == "/data/" %} aria-current="page" class="active"{% endif %} href="/data">States</a>
+        </li>
 			</ul>
 		</nav>
 	</div>


### PR DESCRIPTION
Here’re a few small design updates to address items in #63:

- Updated colors, per Júlia’s spec. (Note: I _very slightly_ adjusted a few to make sure they pass WCAG contrast thresholds. Would love to hear how folks like them!)
- Removed the underlines on the links in the primary navigation.
- Also added an `active page` state, to match the work @Wilto did in the footer.

Opening this for review/discussion!