### PR TITLE
markdownify state notes

### DIFF
--- a/_src/_templates/state.njk
+++ b/_src/_templates/state.njk
@@ -22,7 +22,10 @@ layout: base.njk
             </li>
         {% endif %}
     </ul>
-    <p>{{ state.notes }}</p>
+
+    {% if state.notes %}
+         <p>{{ state.notes | markdownify | safe }}</p>
+    {% endif %}
 
     <table class="state-table">
         <caption>


### PR DESCRIPTION
Currently the state notes are rendered as text, not as markdown:

![image](https://user-images.githubusercontent.com/18607205/77141952-3eabfa80-6a44-11ea-947d-c4d6a8ee0d23.png)

This PR should fix that.