### PR TITLE
Differentiate Last updated from Last refreshed

### DIFF
--- a/_src/_templates/states.njk
+++ b/_src/_templates/states.njk
@@ -3,7 +3,7 @@ layout: base.njk
 ---
 
 {{ layoutContent | safe }}
-<p class="updated">Last updated: {{ sheets.updated }}</p>
+<p class="updated">Last refreshed: {{ sheets.updated }}</p>
 
 <div class="us-totals">
   <table>

--- a/_src/_templates/states.njk
+++ b/_src/_templates/states.njk
@@ -3,7 +3,7 @@ layout: base.njk
 ---
 
 {{ layoutContent | safe }}
-<p class="updated">Last refreshed: {{ sheets.updated }}</p>
+<p class="updated">Last synced with our spreadsheet: {{ sheets.updated }}</p>
 
 <div class="us-totals">
   <table>

--- a/_src/_templates/us-daily.njk
+++ b/_src/_templates/us-daily.njk
@@ -3,7 +3,7 @@ layout: base.njk
 ---
 
 {{ layoutContent | safe }}
-<p class="updated">Last refreshed: {{ sheets.updated }}</p>
+<p class="updated">Last synced with our spreadsheet: {{ sheets.updated }}</p>
 
 <div class="us-days">
   <ul class="day-list">

--- a/_src/_templates/us-daily.njk
+++ b/_src/_templates/us-daily.njk
@@ -3,7 +3,7 @@ layout: base.njk
 ---
 
 {{ layoutContent | safe }}
-<p class="updated">Last updated: {{ sheets.updated }}</p>
+<p class="updated">Last refreshed: {{ sheets.updated }}</p>
 
 <div class="us-days">
   <ul class="day-list">


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/65950/77143799-99e8e780-6a5a-11ea-9f57-f407a0e6c1e5.png)


We don't actually "update" any data when we refresh/pull from the API. Which means
the timestamp listed falsly suggest we update the data show on the States and
US Daily pages when `sheets.updated` changes.

I think "refresh" avoids that potentially confusing term but it does leave
some ambiguity which I think could either be solved with copy on the page or
using an info tooltip for people who care what "Last refreshed" means exactly.

By contrast, the `Last updated` we show for each state *is in fact* when that state last updated their data according to timestamps we report back. So I think it's important to distinguish these two uses of the term. 

![image](https://user-images.githubusercontent.com/65950/77143867-c7359580-6a5a-11ea-9f54-7686f04d6da1.png)
