### PR TITLE
Simplify development setup and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 Clone this sucker, run `npm install`, and you’re in business.
 
-Before you start developing, you may need to run `npm run prod` one time and then `Ctrl+C` to kill it once the output stops. This will generate some static assets that the project needs. You probably only need to do this once when you first clone the repo.
+`npm run dev` will compile assets locally, spin up a local instance of the site,
+open itself in your browser, and watch for any changes to reload your browser automatically.
 
-`npm run dev` will spin up a local instance of the site. That usually runs at [https://localhost:8080](https://localhost:8080), unless you already have asomething running on that port—it’ll give you a URL in your terminal.
+## Development
 
-When you push a change, the CI will get kicked off at https://app.netlify.com/sites/upbeat-lovelace-3e9fff/deploys
+When you push a change to GitHub or open a Pull Request, the CI will get kicked off at https://app.netlify.com/sites/upbeat-lovelace-3e9fff/deploys
 
 ## Formatting
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ open itself in your browser, and watch for any changes to reload your browser au
 
 ## Development
 
-When you push a change to GitHub or open a Pull Request, the CI will get kicked off at https://app.netlify.com/sites/upbeat-lovelace-3e9fff/deploys
+When you make a change in the CMS, push a change to GitHub or merge a Pull Request, the CI will get kicked off at https://app.netlify.com/sites/upbeat-lovelace-3e9fff/deploys
 
 ## Formatting
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "",
   "scripts": {
-    "dev": "grunt watch & eleventy --serve",
+    "dev": "grunt & grunt watch & eleventy --serve",
     "prod": "grunt & eleventy"
   },
   "repository": {


### PR DESCRIPTION
grunt can be run before grunt watch to compile assets once before watching
so there's no need for control+c shenanigans I believe.

I also simplified the instructions considering how simple the setup process
is, although it does assume you have npm and node installed.