### PR TITLE
Minor accessibility tweaks

### DIFF
--- a/_src/_templates/state.njk
+++ b/_src/_templates/state.njk
@@ -8,7 +8,7 @@ layout: base.njk
     <ul class="state-links">
         {% if state.twitter %}
             <li>
-                <a href="https://twitter.com/{{ state.twitter }}">Twitter</a>
+                <a href="https://twitter.com/{{ state.twitter }}">{{ state.stateName }} on Twitter</a>
             </li>
         {% endif %}
         {% if state.covid19Site %}

--- a/_src/_templates/us-daily.njk
+++ b/_src/_templates/us-daily.njk
@@ -6,37 +6,36 @@ layout: base.njk
 <p class="updated">Last updated: {{ sheets.updated }}</p>
 
 <div class="us-days">
-  <ul class="day-list">
-    <table class="day-table">
-      <caption>
-        US Daily Cumulative Totals - 4 pm ET
-      </caption>
-      <thead>
+  <table class="day-table">
+    <caption>
+      US Daily Cumulative Totals - 4 pm ET
+    </caption>
+    <thead>
+      <tr>
+        <th scope="col" class="text-left">Date</th>
+        <th scope="col">States Tracked</th>
+        <th scope="col">Positive</th>
+        <th scope="col">Negative</th>
+        <th scope="col">Pos + Neg</th>
+        <th scope="col">Pending</th>
+        <th scope="col">Deaths</th>
+        <th scope="col">Total Tests</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for day in sheets.usDaily %}
         <tr>
-          <th scope="col" class="text-left">Date</th>
-          <th scope="col">States Tracked</th>
-          <th scope="col">Positive</th>
-          <th scope="col">Negative</th>
-          <th scope="col">Pos + Neg</th>
-          <th scope="col">Pending</th>
-          <th scope="col">Deaths</th>
-          <th scope="col">Total Tests</th>
+          {# [{"date":20200304,"states":14,"positive":118,"negative":748,"posNeg":866,"pending":103,"death":null,"total":969}, #}
+          <td class="text-left">{{ day.date | readableYYYYMMDD }}</td>
+          <td>{{ day.states | thousands }}</td>
+          <td>{{ day.positive | thousands }}</td>
+          <td>{{ day.negative | thousands }}</td>
+          <td>{{ day.posNeg | thousands }}</td>
+          <td>{{ day.pending | thousands }}</td>
+          <td>{{ day.death | thousands }}</td>
+          <td>{{ day.total | thousands }}</td>
         </tr>
-      </thead>
-      <tbody>
-        {% for day in sheets.usDaily %}
-          <tr>
-            {# [{"date":20200304,"states":14,"positive":118,"negative":748,"posNeg":866,"pending":103,"death":null,"total":969}, #}
-            <td class="text-left">{{ day.date | readableYYYYMMDD }}</td>
-            <td>{{ day.states | thousands }}</td>
-            <td>{{ day.positive | thousands }}</td>
-            <td>{{ day.negative | thousands }}</td>
-            <td>{{ day.posNeg | thousands }}</td>
-            <td>{{ day.pending | thousands }}</td>
-            <td>{{ day.death | thousands }}</td>
-            <td>{{ day.total | thousands }}</td>
-          </tr>
-        {% endfor %}
-      </tbody>
-    </table>
-  </div>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/_src/data.md
+++ b/_src/data.md
@@ -4,4 +4,4 @@ nav: Most Recent Data
 layout: states.njk
 summary: ''
 ---
-Our most up-to-date data and annotations. [](https://docs.google.com/spreadsheets/u/2/d/e/2PACX-1vRwAqp96T9sYYq2-i7Tj0pvTf6XVHjDSMIKBdZHXiCGGdNC0ypEU9NbngS8mxea55JuCFuua1MUeOj5/pubhtml)We also have [cumulative daily totals for the US](/us-daily/) on this site. Get the entire dataset as a [spreadsheet](https://docs.google.com/spreadsheets/u/2/d/e/2PACX-1vRwAqp96T9sYYq2-i7Tj0pvTf6XVHjDSMIKBdZHXiCGGdNC0ypEU9NbngS8mxea55JuCFuua1MUeOj5/pubhtml) or via [API (JSON and CSV)](/api/), [learn how this project works](/about-tracker/), or [dig into detailed documentation on the data itself](/newsroom-expert-faq/).
+Our most up-to-date data and annotations. We also have [cumulative daily totals for the US](/us-daily/) on this site. Get the entire dataset as a [spreadsheet](https://docs.google.com/spreadsheets/u/2/d/e/2PACX-1vRwAqp96T9sYYq2-i7Tj0pvTf6XVHjDSMIKBdZHXiCGGdNC0ypEU9NbngS8mxea55JuCFuua1MUeOj5/pubhtml) or via [API (JSON and CSV)](/api/), [learn how this project works](/about-tracker/), or [dig into detailed documentation on the data itself](/newsroom-expert-faq/).


### PR DESCRIPTION
This PR fixes some minor issues when I did an accessibility audit:

- [x] Remove [empty UL](https://github.com/COVID19Tracking/website/blob/master/_src/_templates/us-daily.njk#L9) around US daily table
- [x] Remove empty link after first sentence on the [Data page](https://github.com/COVID19Tracking/website/blob/master/_src/data.md).
- [x] Individual state page links to Twitter should read "[state name] on Twitter"

Also, this came up, but I think is fixed on #73 
- [ ] The Data page has 50 links that all say "Best current data source", which is confusing in a link selection rotor. Add "in [state name]" to the link. If we want to not have a long link name, you can wrap "in [state name]" in an off-screen readable element, or use `aria-label`
