### PR TITLE
List tweaks! (closes #82)

### DIFF
--- a/_src/_assets/css/_globals.scss
+++ b/_src/_assets/css/_globals.scss
@@ -9,7 +9,7 @@
 }
 
 body, h1, h2, h3, h4,
-ol, ul {
+ol[class], ul[class] {
   margin: 0;
   padding: 0;
 }

--- a/_src/_assets/css/_layout.scss
+++ b/_src/_assets/css/_layout.scss
@@ -67,8 +67,11 @@ p {
     margin-bottom: .5rem;
 
     ul {
-      margin-left: 1rem;
       margin-bottom: 1rem;
+    }
+    // This is a _very_ hack-y fix for a spacing issue on the software page. (Each top-level title is getting wrapped in a paragraph.)
+    & > p:first-child + ul {
+      margin-top: -1em;
     }
   }
 }

--- a/_src/_assets/css/_layout.scss
+++ b/_src/_assets/css/_layout.scss
@@ -66,10 +66,6 @@ p {
   li {
     margin-bottom: .5rem;
 
-    @media (min-width: $viewport-md) {
-      margin-bottom: 1rem;
-    }
-
     ul {
       margin-left: 1rem;
       margin-bottom: 1rem;


### PR DESCRIPTION
Per #82, here are a couple small adjustments to our lists!

- We were removing the default margins on all lists, numbered (`ol`) and bulleted (`ul`). Now, we’re _only_ removing margins on lists that have classes attached to them. (https://github.com/COVID19Tracking/website/commit/a8b801341415fcdc7fc96c6fb4251f3519299917#diff-e0f67e5f919e01d7ea1925d34ba25159R12) That should re-outdent the bullets, per the request!
- I’ve tightened up the bottom margin on `li` elements.