### PR TITLE
Include current page title in <title> when available

### DIFF
--- a/_src/_templates/base.njk
+++ b/_src/_templates/base.njk
@@ -7,7 +7,11 @@
 		<meta property="og:site_name" content="{{ data.title }}">
 		<link rel="canonical" href="{{ data.url }}">
 
-		<title>{{ data.title }}</title>
+		{% if title %}
+			<title>{{ data.title }} - {{ title }}</title>
+		{% else %}
+		  <title>{{ data.title }}</title>
+		{% endif %}
 		<meta name="description" content="{{ data.description }}">
 
 		<meta name="application-name" content="{{ data.title }}">


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/65950/77205982-60e95b00-6acc-11ea-8f91-6834c3ddcfa1.png)

After:
![image](https://user-images.githubusercontent.com/65950/77205935-4dd68b00-6acc-11ea-95c0-79bb8d4501f8.png)

Importantly doesn't mess with the homepage or any page that doesn't have a `title` in its front-matter:
![image](https://user-images.githubusercontent.com/65950/77206096-942bea00-6acc-11ea-84aa-f83794fe533f.png)

Fixes #86