### PR TITLE
Add "Last Checked" Time to Tables (close #74)

### DIFF
--- a/_src/_templates/state.njk
+++ b/_src/_templates/state.njk
@@ -30,7 +30,8 @@ layout: base.njk
 
     <table class="state-table">
         <caption>
-            <span class="a11y-only">{{ state.name }} data</span> Last updated: {{ state.lastUpdateEt }} ET &bull;
+            <span class="a11y-only">{{ state.name }} data</span>
+            <span>Last updated: {{ state.lastUpdateEt }} ET</span> &bull;
             <span title="The last time we reviewed the state data source and updated our data">Last checked: {{ state.checkTimeEt }} ET</span>
         </caption>
         <thead>

--- a/_src/_templates/state.njk
+++ b/_src/_templates/state.njk
@@ -27,9 +27,12 @@ layout: base.njk
          <p>{{ state.notes | markdownify | safe }}</p>
     {% endif %}
 
+
     <table class="state-table">
         <caption>
-            <span class="a11y-only">{{ state.name }} data</span> Last updated: {{ state.lastUpdateEt }} ET</caption>
+            <span class="a11y-only">{{ state.name }} data</span> Last updated: {{ state.lastUpdateEt }} ET &bull;
+            <span title="The last time we reviewed the state data source and updated our data">Last checked: {{ state.checkTimeEt }} ET</span>
+        </caption>
         <thead>
             <tr>
                 <th scope="col">Positive</th>

--- a/_src/_templates/state.njk
+++ b/_src/_templates/state.njk
@@ -31,7 +31,7 @@ layout: base.njk
     <table class="state-table">
         <caption>
             <span class="a11y-only">{{ state.name }} data</span>
-            <span>Last updated: {{ state.lastUpdateEt }} ET</span> &bull;
+            <span title="The time the data was last updated by the state.">Last updated: {{ state.lastUpdateEt }} ET</span> &bull;
             <span title="The last time we reviewed the state data source and updated our data">Last checked: {{ state.checkTimeEt }} ET</span>
         </caption>
         <thead>

--- a/_src/_templates/states.njk
+++ b/_src/_templates/states.njk
@@ -45,7 +45,10 @@ layout: base.njk
       </div>
       <table class="state-table">
         <caption>
-          <span class="a11y-only">{{ state.name }} data</span> Last updated: {{ state.lastUpdateEt }} ET</caption>
+            <span class="a11y-only">{{ state.name }} data</span>
+            <span title="The time the data was last updated by the state.">Last updated: {{ state.lastUpdateEt }} ET</span> &bull;
+            <span title="The last time we reviewed the state data source and updated our data">Last checked: {{ state.checkTimeEt }} ET</span>
+        </caption>
         <thead>
           <tr>
             <th scope="col">Positive</th>


### PR DESCRIPTION
This adds the last checked time adjacent to the last updated time in table captions.

This also closes #74 

See below for the updated appearance:
![image](https://user-images.githubusercontent.com/18607205/77205883-65594800-6abb-11ea-866e-dde1d61063c9.png)
![image](https://user-images.githubusercontent.com/18607205/77205896-6d18ec80-6abb-11ea-8555-04b7005ec843.png)
