### PR TITLE
shrink table width

### DIFF
--- a/_src/about-tracker.md
+++ b/_src/about-tracker.md
@@ -32,12 +32,33 @@ A number score is tallied based on 4 simple components:
 
 The total score for each state corresponds to a letter grade:
 
-| Score | Grade |
-|-------|-------|
-| 4     | A     |
-| 3     | B     |
-| 2     | C     |
-| 1     | D     |
+
+<table style="width: 200px;">
+  <thead>
+    <tr>
+      <th>Score</th>
+      <th>Grade</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>4</td>
+      <td>A</td>
+    </tr>
+    <tr>
+      <td>3</td>
+      <td>B</td>
+    </tr>
+    <tr>
+      <td>2</td>
+      <td>C</td>
+    </tr>
+    <tr>
+      <td>1</td>
+      <td>D</td>
+    </tr>
+  </tbody>
+</table>
 
 If you are calculating positive rates, it should only be with states that have an A grade. And be careful going back in time because almost all the states have changed their level of reporting at different times.
 


### PR DESCRIPTION
I don't think there is a way to do this in MD, so I ended up using HTML here, with inline styles (not great, I know).

See #94 -- this table currently takes up a lot of space.

Here's the updated version:

![image](https://user-images.githubusercontent.com/18607205/77243170-b7d65980-6bcc-11ea-9a30-1b5468998978.png)

I won't merge this yet since I want someone else to be on board with this implementation of an HTML table in the middle of this Markdown file. If anyone has a cleaner way to achieve this, I am all ears.
