### PR TITLE
re-order state-notes

### DIFF
--- a/_src/_templates/states.njk
+++ b/_src/_templates/states.njk
@@ -125,14 +125,14 @@ layout: base.njk
 
     <div class="state-notes">
       <p>
-        <a href="/data/state/{{ state.name | slug }}#history">
-          Historical data for {{ state.name }}.
+        <a href="{{ state.covid19Site }}">
+          Best current data source for {{ state.name }}.
         </a>
       </p>
 
       <p>
-        <a href="{{ state.covid19Site }}">
-          Best current data source for {{ state.name }}.
+        <a href="/data/state/{{ state.name | slug }}#history">
+          Historical data for {{ state.name }}.
         </a>
       </p>
 


### PR DESCRIPTION
history is lower down now, top to bottom: current data source, history, data quality