### PR TITLE
Report positive test rate for states

### DIFF
--- a/_src/_assets/css/_states.scss
+++ b/_src/_assets/css/_states.scss
@@ -129,3 +129,12 @@
     margin-left: 5px;
   }
 }
+
+.statistics {
+  color: rgba(0,0,0,0.64)
+}
+
+.statistic {
+  float: right;
+  font-size: smaller;
+}

--- a/_src/_templates/states.njk
+++ b/_src/_templates/states.njk
@@ -115,6 +115,14 @@ layout: base.njk
         <div class="state-flex-data">
           {% if state.total %}{{ state.total | thousands }}{% else %}N/A{% endif %}
         </div>
+        {% if state.total %}
+        <div class="state-flex-data statistics">
+          <div class="statistic">
+            <strong>Positive Test Rate</strong>:
+            {{ state.positive }}/{{ state.positive+state.negative }} = {{ ((state.positive / (state.positive+state.negative))*100) | round(1) }}%
+          </div>
+        </div>
+        {% endif %}
       </div>
     </div>
     <div class="state-table-caption">


### PR DESCRIPTION
I was interested to see how testing outcomes differ by states and created this PR.

Attached is screenshot on the output:

![positive-test-rate](https://user-images.githubusercontent.com/50580/77286642-4c0df280-6c99-11ea-8af9-f32e8e3b2650.png)
