### PR TITLE
Add lighthouse audit to PRs

### DIFF
--- a/.github/budget.json
+++ b/.github/budget.json
@@ -4,7 +4,7 @@
     "resourceSizes": [
       {
         "resourceType": "total",
-        "budget": 200
+        "budget": 1000
       }
     ]
   }

--- a/.github/budget.json
+++ b/.github/budget.json
@@ -1,0 +1,11 @@
+[
+  {
+    "path": "/*",
+    "resourceSizes": [
+      {
+        "resourceType": "total",
+        "budget": 200
+      }
+    ]
+  }
+]

--- a/.github/lighthouserc.json
+++ b/.github/lighthouserc.json
@@ -1,0 +1,9 @@
+{
+  "ci": {
+    "assert": {
+      "assertions": {
+        "first-contentful-paint": ["error", { "minScore": 0.6 }]
+      }
+    }
+  }
+}

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,25 @@
+name: Lighthouse audit
+on: pull_request
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Wait for deploy preview to finish'
+        uses: 'WyriHaximus/github-action-wait-for-status@master'
+        with:
+          ignoreActions: 'Lighthouse audit'
+          checkInterval: 20
+        env:
+          GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
+      - uses: actions/checkout@v1
+      - name: Audit URLs using Lighthouse
+        uses: treosh/lighthouse-ci-action@v2
+        with:
+          urls: |
+            https://deploy-preview-${{ github.event.number }}--upbeat-lovelace-3e9fff.netlify.com/
+            https://deploy-preview-${{ github.event.number }}--upbeat-lovelace-3e9fff.netlify.com/data
+          uploadArtifacts: true
+          temporaryPublicStorage: true
+          budgetPath: ./.github/budget.json
+          configPath: ./.github/lighthouserc.json

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -19,6 +19,8 @@ jobs:
           urls: |
             https://deploy-preview-${{ github.event.number }}--upbeat-lovelace-3e9fff.netlify.com/
             https://deploy-preview-${{ github.event.number }}--upbeat-lovelace-3e9fff.netlify.com/data
+            https://deploy-preview-${{ github.event.number }}--upbeat-lovelace-3e9fff.netlify.com/data/state/washington
+            https://deploy-preview-${{ github.event.number }}--upbeat-lovelace-3e9fff.netlify.com/us-daily
           uploadArtifacts: true
           temporaryPublicStorage: true
           budgetPath: ./.github/budget.json


### PR DESCRIPTION
Adds an action to do a Lighthouse audit using [treosh/lighthouse-ci-action](treosh/lighthouse-ci-action). This PR also includes a `budget.json` file to define [page size budgets](https://web.dev/use-lighthouse-for-performance-budgets/). 

I'm including this so we can start getting baseline performance audits. We can refine budgets and pass/fail assertions like first paint for critical paths in the future.