### PR TITLE
Re-add press links. Spreadsheet no longer has bad links.

### DIFF
--- a/_src/_templates/index.njk
+++ b/_src/_templates/index.njk
@@ -8,12 +8,13 @@ layout: base.njk
 
 <div class="press-logos-container">
     <p>
-        <img alt="The Atlantic logo" src="/_assets/img/press-logos/the-atlantic.png">
-        <img alt="Politico logo" src="/_assets/img/press-logos/politico.jpg">
-        <img alt="Vox logo" src="/_assets/img/press-logos/vox.png">
-        <img alt="New York Times logo" src="/_assets/img/press-logos/nyt.png">
-        <img alt="Talking Points Memo logo" src="/_assets/img/press-logos/tpm.png">
-        <img alt="Minnesota Public Radio logo" src="/_assets/img/press-logos/mpr.jpg">
+        <img alt="The Atlantic logo" src="/_assets/img/press-logos/the-atlantic.svg">
+        <img alt="Politico logo" src="/_assets/img/press-logos/politico.svg">
+        <img alt="Vox logo" src="/_assets/img/press-logos/vox.svg">
+        <img alt="New York Times logo" src="/_assets/img/press-logos/nyt.svg">
+        <img alt="Talking Points Memo logo" src="/_assets/img/press-logos/tpm.svg">
+        <img alt="Minnesota Public Radio News logo" src="/_assets/img/press-logos/mprnews.svg">
+        <img alt="The Washington Post logo" src="/_assets/img/press-logos/wapo.svg">
     </p>
 </div>
 

--- a/_src/index.md
+++ b/_src/index.md
@@ -1,5 +1,6 @@
 ---
 title: Homepage
+layout: index.njk
 summary: ''
 ---
 The COVID Tracking Project collects information from 50 US states, the District of Columbia, and 5 other US territories to provide the most comprehensive testing data we can collect for the novel coronavirus, SARS-CoV-2. We attempt to include **positive and negative results**, **pending tests**, and **total people tested for** each state or district currently reporting that data.
@@ -17,29 +18,3 @@ From here, you can also [learn about our methodology](/about-tracker/), [see who
 ## Best Practices for Data Release
 
 [State Testing Data Release - Best Practices](https://docs.google.com/document/d/1OyN6_1UeDePwPwKi6UKZB8GwNC7-kSf1-BO2af8kqVA/edit)—Our recommendations on what data state public health authorities should be releasing, and how.
-
-## In the Press
-
-<div class="press-logos-container">
-
-![The Atlantic logo](/_assets/img/press-logos/the-atlantic.svg)
-![Politico logo](/_assets/img/press-logos/politico.svg)
-![Vox logo](/_assets/img/press-logos/vox.svg)
-![New York Times logo](/_assets/img/press-logos/nyt.svg)
-![Talking Points Memo logo](/_assets/img/press-logos/tpm.svg)
-![Minnesota Public Radio News logo](/_assets/img/press-logos/mprnews.svg)
-![The Washington Post logo](/_assets/img/press-logos/wapo.svg)
-
-</div>
-
-* [Huge testing discrepancies among states muddles the meaning of results](https://www.washingtonpost.com/health/2020/03/23/huge-testing-discrepancies-among-states-muddles-meaning-results), The Washington Post, March 23rd, 2020
-* [U.S. Lags in Coronavirus Testing After Slow Response to Outbreak](https://www.nytimes.com/interactive/2020/03/17/us/coronavirus-testing-data.html), The New York Times, March 17, 2020
-* [Comparing COVID-19 in Minnesota and its neighbors in Upper Midwest](https://www.mprnews.org/story/2020/03/17/comparing-covid19-in-minnesota-and-its-neighbors-in-upper-midwest), Minnesota Public Radio, March 17, 2020
-* [Live tracker: How many coronavirus cases have been reported in each U.S. state?](https://www.politico.com/interactives/2020/coronavirus-testing-by-state-chart-of-new-cases/), Politico, March 16, 2020
-* [The Trump administration’s botched coronavirus response, explained](https://www.vox.com/policy-and-politics/2020/3/14/21177509/coronavirus-trump-covid-19-pandemic-response), Vox, March 14, 2020
-* [The 4 Key Reasons the U.S. Is So Behind on Coronavirus Testing](https://www.theatlantic.com/health/archive/2020/03/why-coronavirus-testing-us-so-delayed/607954/), The Atlantic, March 13, 2020
-* [America Isn’t Testing for the Most Alarming Coronavirus Cases](https://www.theatlantic.com/science/archive/2020/03/who-gets-tested-coronavirus/607999/), The Atlantic, March 13, 2020
-* [How to Understand Your State’s Coronavirus Numbers](https://www.theatlantic.com/technology/archive/2020/03/how-understand-your-states-coronavirus-numbers/607921/), The Atlantic, March 12, 2020
-* [The Dangerous Delays in U.S. Coronavirus Testing Haven’t Stopped](https://www.theatlantic.com/health/archive/2020/03/coronavirus-testing-numbers/607714/), The Atlantic, March 9, 2020
-* [Key Source of COVID-19 Testing & Infection Data](https://talkingpointsmemo.com/edblog/key-source-of-covid-19-testing-infection-data), TPM, March 7, 2020
-* [The Strongest Evidence Yet That America Is Botching Coronavirus Testing](https://www.theatlantic.com/health/archive/2020/03/how-many-americans-have-been-tested-coronavirus/607597/), The Atlantic, March 6, 2020


### PR DESCRIPTION
This reverts commit aa5ae1fd195fdb13426b9989fc9f6f0d89233022.

This re-adds the add-press-links PR, now that the spreadsheet has been cleaned up.