### PR TITLE
Flex press logos (closes #155)

### DIFF
--- a/_src/_assets/css/_pressLogos.scss
+++ b/_src/_assets/css/_pressLogos.scss
@@ -1,11 +1,13 @@
 .press-logos-container p {
   align-items: center;
   display: flex;
+  margin: 0;
+  flex-wrap: wrap;
 
   img {
     background-color: white;
     filter: grayscale(1);
-    margin-right: 1.3rem;
+    margin: 1rem 1.3rem 1rem 0;
     width: 100px;
   }
 

--- a/_src/_assets/css/_pressLogos.scss
+++ b/_src/_assets/css/_pressLogos.scss
@@ -9,15 +9,15 @@
     width: 100px;
   }
 
-  img[alt*="Vox"] {
+  img[alt="Vox logo"] {
     width: 50px;
   }
 
-  img[alt*="New York Times"] {
+  img[alt="New York Times logo"] {
     width: 135px;
   }
 
-  img[alt*="Talking Points"] {
+  img[alt="Talking Points Memo logo"] {
     width: 85px;
   }
 


### PR DESCRIPTION
Press logos now wrap on mobile, instead of extending in the x direction out of the viewport.

![image](https://user-images.githubusercontent.com/18607205/77447017-ced7a000-6db4-11ea-873b-50ec379c3812.png)

This closes 1/5th of #101 