### PR TITLE
Add component for press links

### DIFF
--- a/src/components/common/press.js
+++ b/src/components/common/press.js
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Link } from 'gatsby'
+
+export default ({ press }) => (
+  <ul>
+    {press.map(({ node }) => (
+      <li key={`press-${node.id}`}>
+        <Link to={node.url}>{node.title}</Link>, {node.publication}, {node.publishDate}
+      </li>
+    ))}
+  </ul>
+)

--- a/src/components/common/press.js
+++ b/src/components/common/press.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link } from 'gatsby'
 
-export default ({ press }) => (
+export const PressList = ({ press }) => (
   <ul>
     {press.map(({ node }) => (
       <li key={`press-${node.id}`}>

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -4,7 +4,6 @@ import Layout from '../../components/layout'
 import BuildTime from '../../components/common/build-time'
 import slug from '../../utilities/slug'
 import SummaryTable from '../../components/common/summary-table'
-import PressList from '../../components/common/press'
 
 const StateList = ({ states }) => (
   <ul>
@@ -26,8 +25,6 @@ export default ({ data }) => (
     />
     <BuildTime />
     <SummaryTable data={data.allCovidUs.edges[0].node} />
-    <h2>In The Press</h2>
-    <PressList press={data.allCovidPress.edges} />
     <h2>States</h2>
     <StateList states={data.allCovidStateInfo.edges} />
   </Layout>
@@ -65,17 +62,6 @@ export const query = graphql`
         node {
           name
           state
-        }
-      }
-    }
-    allCovidPress(filter: {addToCovidTrackingProjectWebsite: {eq: true}}) {
-      edges {
-        node {
-          title
-          url
-          publishDate(formatString: "DD MMMM YYYY")
-          id
-          publication
         }
       }
     }

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -4,6 +4,7 @@ import Layout from '../../components/layout'
 import BuildTime from '../../components/common/build-time'
 import slug from '../../utilities/slug'
 import SummaryTable from '../../components/common/summary-table'
+import PressList from '../../components/common/press'
 
 const StateList = ({ states }) => (
   <ul>
@@ -25,6 +26,8 @@ export default ({ data }) => (
     />
     <BuildTime />
     <SummaryTable data={data.allCovidUs.edges[0].node} />
+    <h2>In The Press</h2>
+    <PressList press={data.allCovidPress.edges} />
     <h2>States</h2>
     <StateList states={data.allCovidStateInfo.edges} />
   </Layout>
@@ -62,6 +65,17 @@ export const query = graphql`
         node {
           name
           state
+        }
+      }
+    }
+    allCovidPress(filter: {addToCovidTrackingProjectWebsite: {eq: true}}) {
+      edges {
+        node {
+          title
+          url
+          publishDate(formatString: "DD MMMM YYYY")
+          id
+          publication
         }
       }
     }

--- a/src/stories/12-Press-links.stories.js
+++ b/src/stories/12-Press-links.stories.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import { PressList } from '../components/common/press'
+
+export default {
+  title: 'Press Links',
+}
+
+export const regular = () => <PressList press={dummyData.allCovidPress.edges}/>
+
+const dummyData = {
+  "allCovidPress": {
+    "edges": [
+      {
+        "node": {
+          "title": "Coronavirus update: 392,870 cases globally, 17,159 deaths, Italy shows glimmer of hope and NYC remains U.S. epicenter",
+          "url": "https://www.marketwatch.com/story/coronavirus-update-392870-cases-globally-17159-deaths-italy-shows-glimmer-of-hope-and-nyc-remains-us-epicenter-2020-03-24?siteid=yhoof2&yptr=yahoo",
+          "publishDate": "24 March 2020",
+          "id": "e0b4614e-ad97-5d0f-9cde-582b88c815ff",
+          "publication": "MarketWatch"
+        }
+      },
+      {
+        "node": {
+          "title": "Comparing COVID-19 in Minnesota and its neighbors in Upper Midwest",
+          "url": "https://www.mprnews.org/story/2020/03/17/comparing-covid19-in-minnesota-and-its-neighbors-in-upper-midwest",
+          "publishDate": "23 March 2020",
+          "id": "72d7dbae-24b3-5253-8a3e-9bbbe54d23f7",
+          "publication": "Minnesota Public Radio"
+        }
+      },
+      {
+        "node": {
+          "title": "Coronavirus cases top 300,000 worldwide as US becomes one of worst hit countries",
+          "url": "https://www.cnbc.com/2020/03/21/coronavirus-cases-top-300000-worldwide-as-us-becomes-one-of-worst-hit.html",
+          "publishDate": "21 March 2020",
+          "id": "a5ecabb4-c79a-58d3-b85e-e54035471d25",
+          "publication": "CNBC"
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add component for press links

*Note that this isn't rendered anywhere yet. This can be put wherever the design people want it to end up.*

GraphQL Query:

```graphql
    allCovidPress(filter: {addToCovidTrackingProjectWebsite: {eq: true}}) {
      edges {
        node {
          title
          url
          publishDate(formatString: "DD MMMM YYYY")
          id
          publication
        }
      }
    }
```