### PR TITLE
change state-nav bar to a hoverable dropdown menu at fixed position

### DIFF
--- a/_src/_assets/css/_states.scss
+++ b/_src/_assets/css/_states.scss
@@ -17,9 +17,8 @@
 }
 
 .states-nav {
-  max-width: 6vw;
   padding-left: 5px;
-  position: absolute;
+  position: fixed;
   right: 1vw;
   top: 150px;
 
@@ -38,11 +37,12 @@
   ul {
     margin-top: 0.5em;
     padding-left: 0;
+    display: none;
+    flex-direction: row;
+    flex-wrap: wrap;
 
     @media (max-width: $viewport-md) {
       display: flex;
-      flex-direction: row;
-      flex-wrap: wrap;
     }
 
     li {
@@ -51,13 +51,21 @@
       padding: 1px;
       margin: 1px;
       text-align: center;
-
-      @media (max-width: $viewport-md) {
-        display: inline-block;
-        margin: 4px 14px;
-        flex-grow: 1;
-      }
+      display: inline-block;
+      margin: 4px 14px;
+      flex-grow: 1;
     }
+  }
+}
+
+.states-nav:hover {
+  h4 {
+    display: none;
+  }
+
+  ul {
+    display: flex;
+    width: 400px;
   }
 }
 

--- a/_src/_templates/states.njk
+++ b/_src/_templates/states.njk
@@ -58,7 +58,7 @@ layout: base.njk
   </div>
 
   <nav id="states-nav" class="states-nav">
-    <h4>Jump to:</h4>
+    <h4>Jump to State</h4>
     <ul>
       {% for state in sheets.states | sort(false, false, 'state') %}
       <li><a href="#{{ state.state }}">{{ state.state | slug }}</a></li>


### PR DESCRIPTION
Problem: Currently on the state data page, the state navigation bar will be out of view for most states. To choose another state, the user needs to go back to top,  then scroll through the state navigation list to find the target state.

Changes made in this pull request: 
1. States is shown in a grid (as the mobile version) to avoid the scroll, and it is hidden.
1. "jump to" label will be positioned as "fixed".
2. When the mouse hovers on the label, the state grid will appear.
3. the label text changed to "jump to state" because "jump to" feels incomplete without the state names following it.

Remaining issues: the "jump to" label is in the middle of page, does not fit well with other contents. Ideally, the label should be able "scroll-then-fix": scroll to the top first, then become fixed. But this requires extra JS code.