### PR TITLE
[add] added horizontal bar charts for deaths by state

### DIFF
--- a/_src/_assets/js/dashboard-charts.js
+++ b/_src/_assets/js/dashboard-charts.js
@@ -345,22 +345,24 @@
   }
 
   function alterBriteChartStyles() {
-    const ids = ['#chart-daily-positive-total', '#chart-daily-death-total']
+    const ids = ['#chart-daily-positive-total', '#chart-daily-death-total', '#chart-states-current-death-total']
 
     ids.forEach(function(id) {
       const container = d3.select(id)
 
       // set up grid lines
-      const tickSelector = id + ' .y-axis-group .tick'
-      const chart = container.select('.chart-group')
-      d3.selectAll(tickSelector).each(function(d) {
-        const tick = d3.select(this)
-        const line = tick.select('line')
-
-        line.attr('x1', container.node().clientWidth * 0.78)
-      })
-
-      chart.raise()
+      if(id === '#chart-daily-positive-total' || id === '#chart-daily-death-total') {
+        const tickSelector = id + ' .y-axis-group .tick'
+        const chart = container.select('.chart-group')
+        d3.selectAll(tickSelector).each(function(d) {
+          const tick = d3.select(this)
+          const line = tick.select('line')
+  
+          line.attr('x1', container.node().clientWidth * 0.78)
+        })
+  
+        chart.raise()
+      }
 
       // change circle legend indicators to squares
 

--- a/_src/dashboard.md
+++ b/_src/dashboard.md
@@ -46,6 +46,14 @@ nav: Dashboard
       <p>Though this is a national crisis each state is reporting data differently. We are tracking numbers from each state, though the quality and frequency of reports varies significantly.</p>
     </div>
   </div>
+  <div class="side-by-side">
+    <div class="graphic-text">
+      <p>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      </p>
+    </div>
+    <div class="graphic" id="chart-states-current-death-total"></div>    
+  </div>  
   <div id="chart-state-small-multiples">
     <h3 class="chart-hed">Cumulative tests per state</h3>
     <p>By comparing the positive tests to the total tests in each state, we can get a sense of how widespread a state’s testing regime might be (though always remember to consider population densities vary wildly across the country) and if the number of positive tests is tracking roughly against the total number of tests. If it is, then we might consider that the state isn’t necessarily just getting new infections every day but that they’re also giving more tests.</p>


### PR DESCRIPTION
This adds horizontal bar charts for deaths by states
- sorted descending
- no horizontal lines

Open questions
- currently using dummy placeholder text, need summary
- How should I handle "null" deaths? In this PR I filtered them out and did not note this anywhere on the UI