### PR TITLE
Add “Projects Built with Our Data” section

### DIFF
--- a/_src/software.md
+++ b/_src/software.md
@@ -48,3 +48,7 @@ The COVID Tracking Project is based on a group developer effort, with code hoste
 ## Satellite Projects
 
 * [R package that wraps the COVID Tracking Project API](https://github.com/aedobbyn/covid19us) from [Amanda Dobbyn](https://github.com/aedobbyn)
+
+## Projects Built with Our Data
+
+* [The COVID-19 Testing Gap](https://testing.predictcovid.com) by [Lachlan Campbell](https://lachlanjc.me).


### PR DESCRIPTION
Hey friends! I’m not sure this is the right place on the website, so please let me know if you’d like it elsewhere, but I think it’d be great to have a list of other sites/projects that use data from here. I’ve added mine to start:

https://testing.predictcovid.com/

Thanks for all your hard work <3