### PR TITLE
Added disclosure component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1701,6 +1701,26 @@
         "tslib": "^1.10.0"
       }
     },
+    "@reach/auto-id": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.9.0.tgz",
+      "integrity": "sha512-9/aXl+dT0pOenvpkB2kkmQnpMDlmSk8ZkBYmYFzFz3eA4PZFNuXcHVzQevFRhc0HVlskPjxwPNf92EkI9rdFOw==",
+      "requires": {
+        "@reach/utils": "^0.9.0",
+        "tslib": "^1.10.0"
+      }
+    },
+    "@reach/disclosure": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@reach/disclosure/-/disclosure-0.9.1.tgz",
+      "integrity": "sha512-Sb0Ces8mt9aStoZ1PstYio4xnDRYrpmWrlKgppV0EFIVB8CU8UvX4HzvWgqagq9NgOUoEmr7w9CuLpCxYuHS5w==",
+      "requires": {
+        "@reach/auto-id": "^0.9.0",
+        "@reach/utils": "^0.9.0",
+        "tslib": "^1.10.0",
+        "warning": "^4.0.3"
+      }
+    },
     "@reach/router": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.3.tgz",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@mdx-js/mdx": "^1.5.7",
     "@mdx-js/react": "^1.5.7",
     "@reach/alert": "^0.9.1",
+    "@reach/disclosure": "^0.9.1",
     "@reach/skip-nav": "^0.9.0",
     "@reach/visually-hidden": "^0.9.0",
     "@storybook/addon-info": "^5.3.17",

--- a/src/components/common/disclosure.js
+++ b/src/components/common/disclosure.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import {
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel,
+} from '@reach/disclosure'
+import '../../scss/components/common/disclosure.scss'
+
+export default ({ title, children }) => (
+  <Disclosure>
+    <DisclosureButton className="disclosure-button">
+      <span className="disclosure-button-toggle"></span>
+      {title}
+    </DisclosureButton>
+    <DisclosurePanel>{children}</DisclosurePanel>
+  </Disclosure>
+)

--- a/src/scss/components/common/disclosure.scss
+++ b/src/scss/components/common/disclosure.scss
@@ -1,0 +1,29 @@
+.disclosure-button {
+  border: none;
+  background: transparent;
+  padding: 0;
+  font-size: 1.2rem;
+  font-weight: bold;
+  width: 100%;
+  display: block;
+  text-align: left;
+  cursor: pointer;
+
+  .disclosure-button-toggle {
+    display: inline-block;
+    margin-right: 0.3rem;
+    font-size: 0.8rem;
+  }
+
+  &[aria-expanded='false'] {
+    .disclosure-button-toggle::after {
+      content: '▶';
+    }
+  }
+
+  &[aria-expanded='true'] {
+    .disclosure-button-toggle::after {
+      content: '▼';
+    }
+  }
+}

--- a/src/stories/12-Disclosure.stories.js
+++ b/src/stories/12-Disclosure.stories.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import Disclosure from '../components/common/disclosure'
+
+export default {
+  title: 'Disclosure',
+}
+
+export const disclosure = () => (
+  <Disclosure title="Why are we doing this?">
+    <p>
+      Testing is a crucial part of any public health response, and sharing test
+      data is essential to understanding this outbreak. The CDC is currently not
+      publishing complete testing data, so we’re doing our best to collect it
+      from each state and provide it to the public. The information is patchy
+      and inconsistent, so we’re being transparent about what we find and how we
+      handle it—the spreadsheet includes our live comments about changing data
+      and how we’re working with incomplete information.
+    </p>
+    <p>
+      From here, you can also{' '}
+      <a href="/about-tracker/">learn about our methodology</a>,{' '}
+      <a href="/about-team/">see who makes this</a>, and{' '}
+      <a href="/notes/">
+        find out what information states provide and how we handle it
+      </a>
+      .
+    </p>
+  </Disclosure>
+)
+
+disclosure.story = {
+  parameters: {
+    info: {
+      text:
+        'Used to visually hide elements on a page and give users the option to expand content.',
+    },
+  },
+}


### PR DESCRIPTION
Added a 'disclosure' component using [ReachUI](https://reacttraining.com/reach-ui/disclosure). This is useful for hiding elements like glossaries, etc. that we don't want default-expanded.

Preview: https://5e7e043142dad500085645dc--goofy-tesla-43452a.netlify.com/__storybook/?path=/story/disclosure--disclosure