### PR TITLE
fix(code): Don't use Etags from screenshots

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -1,6 +1,7 @@
 const { createFilePath } = require(`gatsby-source-filesystem`)
 const path = require('path')
 const slugify = require('slugify')
+const objectHash = require('object-hash')
 
 exports.onCreateNode = ({ node, getNode, createNodeId, actions }) => {
   const { createNodeField, createNode } = actions
@@ -15,12 +16,12 @@ exports.onCreateNode = ({ node, getNode, createNodeId, actions }) => {
       }
       node[key].forEach(screenshot => {
         const node = {
-          id: createNodeId(`covidScreenshot >>> ${screenshot.ETag}`),
+          id: createNodeId(`covidScreenshot >>> ${screenshot.url}`),
           children: [],
           parent: null,
           internal: {
             type: `covidScreenshot`,
-            contentDigest: screenshot.ETag,
+            contentDigest: objectHash(screenshot),
           },
         }
         createNode({ ...node, ...screenshot })

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "luxon": "^1.22.0",
     "marked": "^0.8.2",
     "node-sass": "^4.13.1",
+    "object-hash": "^2.0.3",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/src/templates/state.js
+++ b/src/templates/state.js
@@ -45,7 +45,7 @@ const Screenshots = ({ date, screenshots }) => {
   return (
     <ul>
       {dateScreenshots.map(screenshot => (
-        <li key={`screenshot-${screenshot.ETag}`}>
+        <li key={screenshot.url}>
           <a href={screenshot.url} target="_blank" rel="noopener noreferrer">
             {screenshot.dateChecked && (
               <>
@@ -166,7 +166,6 @@ export const query = graphql`
           url
           state
           dateChecked
-          ETag
         }
       }
     }


### PR DESCRIPTION
Use an objecthash for the screenshot GraphQL hash, instead of the ETag from the API.