### PR TITLE
feature(dashboard): added expand/collapse to horizontal bar chart; removed legends from death charts

### DIFF
--- a/_src/_assets/css/_charts.scss
+++ b/_src/_assets/css/_charts.scss
@@ -288,10 +288,10 @@ ul.chart-legend {
   cursor: pointer;
   p {
     color: #000000;
-    font-size: 12pt;
-    margin-top: 0.2rem;
+    font-size: 10pt;
+    top: -0.2rem;
     margin-bottom: 0.2rem;
-    text-align: right;
+    text-align: left;
     width: 86%;
   }
 }

--- a/_src/_assets/css/_charts.scss
+++ b/_src/_assets/css/_charts.scss
@@ -283,3 +283,15 @@ ul.chart-legend {
     }
   }
 }
+
+.chart-expand-note {
+  cursor: pointer;
+  p {
+    color: #000000;
+    font-size: 12pt;
+    margin-top: 0.2rem;
+    margin-bottom: 0.2rem;
+    text-align: right;
+    width: 86%;
+  }
+}

--- a/_src/_assets/js/dashboard-charts.js
+++ b/_src/_assets/js/dashboard-charts.js
@@ -320,6 +320,11 @@ d => d.negativeIncrease + d.positiveIncrease,
     const hed = chartContainer
       .append('h3')
       .classed('chart-hed', true)
+    // adding expand div container following same pattern as source 
+    const expand = chartContainer
+      .append('div')
+      .classed('chart-expand-note', true)
+
     const chart = chartContainer
       .append('div')
       .classed('chart', true)
@@ -330,7 +335,11 @@ d => d.negativeIncrease + d.positiveIncrease,
     const barChart = britecharts.bar()
     const width =
       chartContainer.node().clientWidth * 0.9
-
+    const isExpanded = () => expand.classed('expanded-true')
+    const getHeight = () => isExpanded() ? 1000 : 400
+    const formatExpandedChartData = () => isExpanded() ? transformedData : transformedData.slice(-10)
+    const getExpandText = () => isExpanded() ? 'Collapse' : 'Expand' 
+    
     barChart
       .margin({
         left: 140,
@@ -340,15 +349,31 @@ d => d.negativeIncrease + d.positiveIncrease,
       })
       .isHorizontal(true)
       .colorSchema([totalColor])
-      .height(1000)
+      .height(getHeight())
       .width(width)
       .xAxisLabel('Deaths')
 
+    const expandContainer = expand
+      .on('click', function() {
+        if(isExpanded()) {
+          expand.classed('expanded-true', false)
+          barChart.height(getHeight())
+          chart.datum(formatExpandedChartData()).call(barChart)
+          expand.html(`<p>${getExpandText()}</p>`)
+        } else {
+          expand.classed('expanded-true', true)
+          barChart.height(getHeight())
+          chart.datum(formatExpandedChartData()).call(barChart)
+          expand.html(`<p>${getExpandText()}</p>`)
+        }
+      })          
+
     hed.text('Total deaths by State')
-    chart.datum(transformedData).call(barChart)
+    expand.html(`<p>${getExpandText()}</p>`)
+    chart.datum(formatExpandedChartData()).call(barChart)
     source.html(`
-<p><a href="https://covidtracking.com/api/states">Get this data from our API</a></p>
-`)
+      <p><a href="https://covidtracking.com/api/states">Get this data from our API</a></p>
+    `)
   }
 
   function alterBriteChartStyles() {

--- a/_src/_assets/js/dashboard-charts.js
+++ b/_src/_assets/js/dashboard-charts.js
@@ -320,7 +320,6 @@ d => d.negativeIncrease + d.positiveIncrease,
     const hed = chartContainer
       .append('h3')
       .classed('chart-hed', true)
-    // adding expand div container following same pattern as source 
     const expand = chartContainer
       .append('div')
       .classed('chart-expand-note', true)

--- a/_src/_assets/js/dashboard-charts.js
+++ b/_src/_assets/js/dashboard-charts.js
@@ -268,9 +268,6 @@ d => d.negativeIncrease + d.positiveIncrease,
     const hed = chartContainer
       .append('h2')
       .classed('chart-hed', true)
-    const legend = chartContainer
-      .append('div')
-      .classed('chart-legend', true)
     const chart = chartContainer
       .append('div')
       .classed('chart', true)
@@ -279,7 +276,6 @@ d => d.negativeIncrease + d.positiveIncrease,
       .append('div')
       .classed('chart-api-note', true)
     const barChart = britecharts.bar()
-    const legendChart = britecharts.legend()
 
     const width =
       chartContainer.node().clientWidth * 0.9
@@ -295,23 +291,6 @@ d => d.negativeIncrease + d.positiveIncrease,
       .height(350)
       .width(width)
       .xAxisLabel('Date')
-
-    legendChart
-      .colorSchema([totalColor])
-      .height(50)
-      .isHorizontal(true)
-      .margin({
-        left: 0,
-      })
-
-    legend
-      .datum([
-        {
-          id: 1,
-          name: 'Deaths',
-        },
-      ])
-      .call(legendChart)
 
     hed.text(
       'Total cumulative deaths by day in the US',
@@ -341,9 +320,6 @@ d => d.negativeIncrease + d.positiveIncrease,
     const hed = chartContainer
       .append('h3')
       .classed('chart-hed', true)
-    const legend = chartContainer
-      .append('div')
-      .classed('chart-legend', true)
     const chart = chartContainer
       .append('div')
       .classed('chart', true)
@@ -352,7 +328,6 @@ d => d.negativeIncrease + d.positiveIncrease,
       .append('div')
       .classed('chart-api-note', true)
     const barChart = britecharts.bar()
-    const legendChart = britecharts.legend()
     const width =
       chartContainer.node().clientWidth * 0.9
 
@@ -369,24 +344,8 @@ d => d.negativeIncrease + d.positiveIncrease,
       .width(width)
       .xAxisLabel('Deaths')
 
-    legendChart
-      .colorSchema([totalColor])
-      .height(50)
-      .isHorizontal(true)
-      .margin({
-        left: 0,
-      })
-
     hed.text('Total deaths by State')
     chart.datum(transformedData).call(barChart)
-    legend
-      .datum([
-        {
-          id: 1,
-          name: 'Deaths',
-        },
-      ])
-      .call(legendChart)
     source.html(`
 <p><a href="https://covidtracking.com/api/states">Get this data from our API</a></p>
 `)

--- a/_src/_assets/js/dashboard-charts.js
+++ b/_src/_assets/js/dashboard-charts.js
@@ -320,14 +320,13 @@ d => d.negativeIncrease + d.positiveIncrease,
     const hed = chartContainer
       .append('h3')
       .classed('chart-hed', true)
-    const expand = chartContainer
-      .append('div')
-      .classed('chart-expand-note', true)
-
     const chart = chartContainer
       .append('div')
       .classed('chart', true)
       .classed('no-y-axis-domain', true)
+    const expand = chartContainer
+      .append('div')
+      .classed('chart-expand-note', true)
     const source = chartContainer
       .append('div')
       .classed('chart-api-note', true)

--- a/_src/dashboard.md
+++ b/_src/dashboard.md
@@ -68,7 +68,7 @@ nav: Dashboard
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
       </p>
     </div>
-    <div class="graphic" id="chart-states-current-death-total"></div>    
+    <div class="graphic" id="chart-states-current-death-total"></div>
   </div>  
   <div id="chart-state-small-multiples">
     <p>By comparing the positive tests to the total tests in each state, we can get a sense of how widespread a state’s testing regime might be (though always remember to consider population densities vary wildly across the country) and if the number of positive tests is tracking roughly against the total number of tests. If it is, then we might consider that the state isn’t necessarily just getting new infections every day but that they’re also giving more tests.</p>

--- a/_src/dashboard.md
+++ b/_src/dashboard.md
@@ -64,9 +64,6 @@ nav: Dashboard
   <div class="side-by-side">
     <div class="graphic-text">
        <p>Though this is a national crisis, each state is reporting data differently. We are tracking numbers from each state, though the quality and frequency of reports varies significantly.</p>
-      <p>
-        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-      </p>
     </div>
     <div class="graphic" id="chart-states-current-death-total"></div>
   </div>  


### PR DESCRIPTION
1. Removed legends from the two following bar charts:
- TOTAL CUMULATIVE DEATHS BY DAY IN THE US
- TOTAL DEATHS BY STATE
2. Added logic to expand and collapse bar charts 

![Screen Shot 2020-03-29 at 2 56 20 PM](https://user-images.githubusercontent.com/5491857/77862006-8d3c6000-71cd-11ea-8033-d6790008acf5.png)
![Screen Shot 2020-03-29 at 2 56 40 PM](https://user-images.githubusercontent.com/5491857/77862005-8b729c80-71cd-11ea-9ca9-e5d180971189.png)

