### PR TITLE
chore(git): Lighthouse only on master branch

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,5 +1,5 @@
 name: Lighthouse audit
-#on: pull_request
+on: pull_request.master
 
 jobs:
   audit:


### PR DESCRIPTION
Only run the lighthouse github action in the 'master' branch PR deploys