### PR TITLE
chore: Turn off dev warning for deploy #244

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -7,7 +7,7 @@ module.exports = {
     shortname: 'ctracker',
     production:
       typeof process.env.BRANCH !== 'undefined' &&
-      process.env.BRANCH === 'master',
+      (process.env.BRANCH === 'master' || process.env.BRANCH === 'gatsbyjs'),
     buildDate: DateTime.fromObject({ zone: 'America/New_York' }).toFormat(
       "M/dd HH:mm 'ET'",
     ),


### PR DESCRIPTION
Made the development warning not show for `gatsbyjs` branch