### PR TITLE
Fix(design): fix table border size mismatch.

### DIFF
--- a/_src/_assets/css/_tables.scss
+++ b/_src/_assets/css/_tables.scss
@@ -41,7 +41,7 @@ tbody tr:nth-child(even) {
   display: flex;
   flex-wrap: wrap;
   flex-direction: column;
-
+  border: 1px solid #ddd;
   @media (min-width: $viewport-md) {
     flex-direction: row;
   }
@@ -51,20 +51,10 @@ tbody tr:nth-child(even) {
   display: flex;
   flex-direction: column;
   flex-grow: 1;
-}
-
-.state-first-row .state-flex-header {
-  border-top: 1px solid #ddd;
-
   @media (min-width: $viewport-md) {
-    border-top: 0.5px solid #ddd;
+    border: 1.0px solid #ddd;
   }
-}
 
-.state-first-row {
-  @media (min-width: $viewport-md) {
-    border-left: 0.5px solid #ddd;
-  }
 }
 
 .state-flex-header,
@@ -72,31 +62,16 @@ tbody tr:nth-child(even) {
   text-align: center;
   font-size: 16px;
   padding: 0.5em;
-  border-left: 1px solid #ddd;
-  border-right: 1px solid #ddd;
-
-  @media (min-width: $viewport-md) {
-    border: 0.5px solid #ddd;
-  }
 }
 
 .state-flex-data {
-  border-bottom: 1px solid #ddd;
   flex-grow: 1;
-
-  @media (min-width: $viewport-md) {
-    border-bottom: 0.5px solid #ddd;
-  }
 }
 
 .state-flex-header {
   font-weight: bold;
   background-color: #eee;
   border-bottom: 1px solid #999;
-
-  @media (min-width: $viewport-md) {
-    border-bottom: 0.5px solid #999;
-  }
 }
 
 .state-table-caption {


### PR DESCRIPTION
Fixes https://github.com/COVID19Tracking/website/issues/109 ("Double border on tables"). Updated to apply borders to `.state-flex-container` rather than adding up individual borders on cells.

**Before (zoomed in)**
<img width="575" alt="Before - zoomed" src="https://user-images.githubusercontent.com/1669271/78091488-d46b5200-7381-11ea-98db-a99e7847a714.png">

**After (zoomed in)**
<img width="580" alt="After - zoomed" src="https://user-images.githubusercontent.com/1669271/78091497-d9300600-7381-11ea-8eb7-377c1b442be3.png">


**Before (full size)**
<img width="1272" alt="Before - full size" src="https://user-images.githubusercontent.com/1669271/78091639-4fcd0380-7382-11ea-8413-e2d8b7ac8ef2.png">

**After (full size)**
<img width="1273" alt="After - full size" src="https://user-images.githubusercontent.com/1669271/78091646-5491b780-7382-11ea-80bf-474684c77e0f.png">

**Before (mobile size)**
<img width="671" alt="Before - mobile view" src="https://user-images.githubusercontent.com/1669271/78091649-59566b80-7382-11ea-8763-699a76c84502.png">

**After (mobile size)**
<img width="669" alt="After - mobile view" src="https://user-images.githubusercontent.com/1669271/78091654-5d828900-7382-11ea-97e7-2f077acbb47d.png">

