### PR TITLE
Fix for header button text bug; focus styles

### DIFF
--- a/src/components/pages/homepage/visualizations.js
+++ b/src/components/pages/homepage/visualizations.js
@@ -9,7 +9,7 @@ import wsjGraph from '../../../images/homepage-visualizations/wsj.png'
 const Visualizations = () => (
   <div className="homepage-visualizations-wrapper">
     <Container>
-      <h2>From visualization gallery</h2>
+      <h2>From the visualization gallery</h2>
       <Flex flexWrap="wrap" className="homepage-visualizations">
         <Visualization
           image={nytGraph}

--- a/src/scss/components/header.scss
+++ b/src/scss/components/header.scss
@@ -106,7 +106,8 @@
             line-height: 16px;
           }
         }
-        a:hover {
+        a:hover,
+        a:focus {
           color: $color-secondary-lightest;
         }
         a[aria-current] {

--- a/src/scss/components/hero.scss
+++ b/src/scss/components/hero.scss
@@ -43,7 +43,8 @@
       color: white;
       font-weight: bold;
 
-      &:hover {
+      &:hover,
+      &:focus {
         color: $color-secondary-lightest;
       }
     }

--- a/src/scss/components/hero.scss
+++ b/src/scss/components/hero.scss
@@ -56,8 +56,10 @@
       text-align: center;
       color: $color-secondary-darkest;
       &:hover,
+      &:focus,
       &:active {
         background: $color-secondary-lightest;
+        color: $color-secondary-darkest;
       }
       @media only screen and (max-width: $viewport-sm) {
         width: 100%;

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -30,8 +30,13 @@ a {
   &:active {
     color: $color-link--active;
   }
-  &:hover {
+  &:hover,
+  &:focus {
     color: $color-link--hover;
+    text-decoration: none;
+  }
+  &:focus {
+    outline: 2px dotted;
   }
 }
 


### PR DESCRIPTION
Added in a fix for the button hover styles bug that @jasonsantamaria flagged in https://github.com/COVID19Tracking/website/issues/276#issuecomment-606982973; also added a focus style for each `:hover` rule in our css, and introduced [a base `:focus` style for keyboard users](https://github.com/COVID19Tracking/website/pull/307/commits/8e9c4f484f54daeff34b9e41666d439f9f760977#diff-086adca9968d5685b874aa4d44a3c61cR38-R40).

(Also fixed a smol copy tweak on the homepage: https://github.com/COVID19Tracking/website/pull/307/commits/eccc3029fd0c15e60370ac21ad36d470d8ebc054)