### PR TITLE
fix(design): align infobox sync icon with infobox header

### DIFF
--- a/src/scss/components/common/infobox.scss
+++ b/src/scss/components/common/infobox.scss
@@ -20,6 +20,7 @@
 
   .info-header {
     font-weight: bold;
+    line-height: 1em;
   }
 
   .info-content {


### PR DESCRIPTION
original:
![image](https://user-images.githubusercontent.com/18607205/78195636-6be1ab00-743d-11ea-8005-10807a5d9c54.png)


new:
![image](https://user-images.githubusercontent.com/18607205/78195624-62584300-743d-11ea-923e-e818947f8c48.png)
