### PR TITLE
fix: Force install build packages (temp fix)

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
   publish = "public"
-  command = "npm run build"
+  command = "cd build; npm install; cd ..; npm run build"

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook",
-    "fetch-data": "cd build && npm run build",
-    "postinstall": "cd build && npm install"
+    "fetch-data": "cd build && npm run build"
   }
 }


### PR DESCRIPTION
For some reason netlify is not caching `/build/node_modules` correctly - so we are making them install every time until we get this fixed.