### PR TITLE
Document required Node version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "covid-tracking-project",
   "version": "0.0.1",
+  "engines": {
+    "node": ">=10.13"
+  },
   "description": "Collects information from 50 US states, the District of Columbia, and 5 other US territories to provide the most comprehensive testing data we can collect for the novel coronavirus, SARS-CoV-2.",
   "author": "The COVID Tracking Project",
   "homepage": "https://covidtracking.com",


### PR DESCRIPTION
`gatsby develop` errors with any Node version earlier than 10.13, so I’ve added this
requirement to the package.json and set an .npmrc file to require it when `npm install`
is run.

My next step would be to define an `.nvmrc` to enable auto-switching to 10.13 but that’s
assuming:
- people use nvm
- we’re okay tracking the minimum node version in two places: `package.json` and `.nvmrc`

Let me know and I’ll update this PR.