### PR TITLE
fix: Error out on any build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "prettier": "^1.19.1"
   },
   "scripts": {
-    "build": "npm run fetch-data; gatsby build; cp -R build/data/* public/api/; npm run build-test",
+    "build": "npm run fetch-data && gatsby build && cp -R build/data/* public/api/ && npm run build-test",
     "develop": "gatsby develop",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "start": "npm run develop",


### PR DESCRIPTION
Chain build commands with `&&` to throw an error on any command.