### PR TITLE
fix: Remove duplicate screenshots from state page

### DIFF
--- a/src/data/navigation/header.yml
+++ b/src/data/navigation/header.yml
@@ -4,9 +4,9 @@ items:
     link: /data
   - title: About the Data
     link: /about-data
-  - title: How You Can Help
-    link: /help
+  - title: About the Project
+    link: /about-project
   - title: Data API
     link: /api
-  - title: FAQs for Newsrooms
-    link: /project/faq
+  - title: How You Can Help
+    link: /help

--- a/src/templates/state.js
+++ b/src/templates/state.js
@@ -160,7 +160,7 @@ export const query = graphql`
       }
     }
     allCovidScreenshot(
-      filter: { state: { eq: $state } }
+      filter: { state: { eq: $state }, secondary: { eq: false } }
       sort: { fields: dateChecked, order: DESC }
     ) {
       edges {


### PR DESCRIPTION
Filtered out "secondary" screenshots from the state page.