### PR TITLE
test(api): Add jest tests for API quality

### DIFF
--- a/build/datasources/stateNames.js
+++ b/build/datasources/stateNames.js
@@ -73,4 +73,5 @@ module.exports = {
   nameByCode: _.propertyOf(states),
   fipsByCode: _.propertyOf(fips),
   codeByName: _.propertyOf({ ...stateNames, ..._.invert(states) }),
+  allStates: states,
 }

--- a/src/__tests__/API-CHECKING.md
+++ b/src/__tests__/API-CHECKING.md
@@ -1,0 +1,19 @@
+# API Testing
+
+In the `build-test.js` script there are a number of API tests. Most are basic right now and there are plans to expand them. If you have difficulty getting these tests to pass see troubleshooting below.
+
+## Build Process
+
+During the build process -- see package.json `build` step -- the files used to build the API are downloaded and processed before being copied over to the API directory (`./public/api/v1/`). This fetching and processing step is done before tests are run -- see `build:test`. 
+
+## Troubleshooting 
+
+Since many will not have the required permissions to pull down the required files during `build:fetch`, the local API tests will fail. If the tests fail, try the following commands in your shell:
+
+```bash session
+> cd {COVID_TRACKING_ROOT}
+> mkdir -p ./public/api/v1/states
+> curl https://covidtracking.com/api/v1/states/daily.json -o ./public/api/v1/states/daily.json
+```
+
+Ensure that there is a `daily.json` file inside the path `./public/api/v1/states/`.

--- a/src/__tests__/build-test.js
+++ b/src/__tests__/build-test.js
@@ -21,19 +21,20 @@ describe('Website build', () => {
     expect(exists).toBe(true)
   })
 
-  it('has a /public/API/states endpoint with over 1400 items in array', () => {
-    const exists = fs.readFileSync('./public/api/states/daily', 'utf8')
-    expect(JSON.parse(exists).length).toBeGreaterThan(1484)
+  it('has a /public/API/states endpoint with over 1764 items in array', () => {
+    const exists = fs.readFileSync('./public/api/v1/states/daily.json', 'utf8')
+    expect(JSON.parse(exists).length).toBeGreaterThan(1764)
   })
 
-  it('has a /public/API/us endpoint with over 28 items in array', () => {
-    const exists = fs.readFileSync('./public/api/us/daily', 'utf8')
-    expect(JSON.parse(exists).length).toBeGreaterThan(28)
+  it('has a /public/API/us endpoint with over 33 items in array', () => {
+    const exists = fs.readFileSync('./public/api/v1/us/daily.json', 'utf8')
+    console.log(JSON.parse(exists).length)
+    expect(JSON.parse(exists).length).toBeGreaterThan(33)
   })
 
   it('should contain over 50 reports for the most recent date', () => {
     const statesDaily = JSON.parse(
-      fs.readFileSync('./public/api/states/daily', 'utf8'),
+      fs.readFileSync('./public/api/v1/states/daily.json', 'utf8'),
     )
     const mostRecent = getMostRecent(
       getSortedDatesUnique(statesDaily.map(state => state.dateChecked)),
@@ -46,7 +47,7 @@ describe('Website build', () => {
 
   it('contains only reports from states that are a subset of states in stateNames.js', () => {
     const statesDaily = JSON.parse(
-      fs.readFileSync('./public/api/states/daily', 'utf8'),
+      fs.readFileSync('./public/api/v1/states/daily.json', 'utf8'),
     )
     const mostRecent = getMostRecent(
       getSortedDatesUnique(statesDaily.map(state => state.dateChecked)),

--- a/src/__tests__/build-test.js
+++ b/src/__tests__/build-test.js
@@ -1,5 +1,10 @@
 const fs = require('fs-extra')
 
+const stateNames = require('../../build/datasources/stateNames.js')
+
+const getSortedDatesUnique = dates => [...new Set(dates)].sort()
+const getMostRecent = arr => arr[arr.length - 1]
+
 describe('Website build', () => {
   it('has a homepage', () => {
     const exists = fs.pathExistsSync('./public/index.html')
@@ -14,5 +19,44 @@ describe('Website build', () => {
   it('has an API page', () => {
     const exists = fs.pathExistsSync('./public/api/index.html')
     expect(exists).toBe(true)
+  })
+
+  it('has a /public/API/states endpoint with over 1400 items in array', () => {
+    const exists = fs.readFileSync('./public/api/states/daily', 'utf8')
+    expect(JSON.parse(exists).length).toBeGreaterThan(1484)
+  })
+
+  it('has a /public/API/us endpoint with over 28 items in array', () => {
+    const exists = fs.readFileSync('./public/api/us/daily', 'utf8')
+    expect(JSON.parse(exists).length).toBeGreaterThan(28)
+  })
+
+  it('should contain over 50 reports for the most recent date', () => {
+    const statesDaily = JSON.parse(
+      fs.readFileSync('./public/api/states/daily', 'utf8'),
+    )
+    const mostRecent = getMostRecent(
+      getSortedDatesUnique(statesDaily.map(state => state.dateChecked)),
+    )
+    const allLatestReports = statesDaily.filter(
+      state => state.dateChecked === mostRecent,
+    )
+    expect(allLatestReports.length).toBeGreaterThan(50)
+  })
+
+  it('contains only reports from states that are a subset of states in stateNames.js', () => {
+    const statesDaily = JSON.parse(
+      fs.readFileSync('./public/api/states/daily', 'utf8'),
+    )
+    const mostRecent = getMostRecent(
+      getSortedDatesUnique(statesDaily.map(state => state.dateChecked)),
+    )
+    const allLatestReports = statesDaily.filter(
+      state => state.dateChecked === mostRecent,
+    )
+    const arr = [...new Set(allLatestReports.map(item => item.state))]
+    expect(Object.keys(stateNames.allStates)).toEqual(
+      expect.arrayContaining(arr),
+    )
   })
 })

--- a/src/__tests__/build-test.js
+++ b/src/__tests__/build-test.js
@@ -28,7 +28,6 @@ describe('Website build', () => {
 
   it('has a /public/API/us endpoint with over 33 items in array', () => {
     const exists = fs.readFileSync('./public/api/v1/us/daily.json', 'utf8')
-    console.log(JSON.parse(exists).length)
     expect(JSON.parse(exists).length).toBeGreaterThan(33)
   })
 


### PR DESCRIPTION
Fixes #381 

This is a first stab at adding some testing around [API quality as referenced here](https://github.com/COVID19Tracking/website/issues/266#issuecomment-607249211). These first four tests add some basic data quality checks ensuring:

1.) Length of items in daily (us & states) array.
2.) Latest daily state data has at least 50 items.
3.) Latest daily states is subset of states (`./build/datasources/stateNames.js`)

While these are by no means comprehensive, it is a step forward. There are a couple of caveats:

1.) Since pulling the data from the spreadsheet during build time requires Google API keys, only privileged users with credentials will have the ability to reliably run these tests. Others, will have to manually pull from the site to the `./public/api` directory. I have created a bash script for that not included in this PR. We could also just mock it so that at least it would not fail for other users.
2.) Static thresholds will become stale. This could possible be overcome with utilizing Jest snapshots or some other method.