### PR TITLE
fix(prettier-config): enable building on windows

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,4 +3,5 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'all',
   semi: false,
+  endOfLine: 'auto',
 }


### PR DESCRIPTION
without this fix: ` error  Delete '␍'  prettier/prettier` for every newline of every file on windows:
![image](https://user-images.githubusercontent.com/16123225/78323388-86dc1a00-7526-11ea-8760-bafd004d7328.png)
https://stackoverflow.com/questions/53516594/why-do-i-keep-getting-delete-cr-prettier-prettier