### PR TITLE
fix(api): Add info by state files.

### DIFF
--- a/build/datasources/index.js
+++ b/build/datasources/index.js
@@ -1,5 +1,6 @@
-const { cdcTests, counties, press, statesInfo } = require('./sheets')
+const { cdcTests, counties, press } = require('./sheets')
 const statesDaily = require('./statesDaily')
+const statesInfo = require('./statesInfo')
 const usCurrent = require('./usCurrent')
 const usDaily = require('./usDaily')
 const { grade, states } = require('./states')

--- a/build/datasources/sheets.js
+++ b/build/datasources/sheets.js
@@ -3,7 +3,6 @@ const {
   addDailyDateChecked,
   addFips,
   addHash,
-  addName,
   compatibility,
 } = require('./utils')
 
@@ -52,14 +51,6 @@ function fixDaily(items) {
     _.orderBy(['date'], ['desc']),
   )(items)
 }
-const fixStatesInfo = _.map(_.flow(addFips, addName))
-
-const statesInfo = {
-  ...sheets,
-  fixItems: fixStatesInfo,
-  sheetName: 'States',
-  path: 'states/info',
-}
 
 const cdcTests = {
   ...sheets,
@@ -89,5 +80,4 @@ module.exports = {
   fixDaily,
   press,
   sheets,
-  statesInfo,
 }

--- a/build/datasources/statesInfo.js
+++ b/build/datasources/statesInfo.js
@@ -1,0 +1,24 @@
+const _ = require('lodash/fp')
+const { addFips, addName } = require('./utils')
+const { sheets } = require('./sheets')
+
+const fixStatesInfo = _.map(_.flow(addFips, addName))
+
+const statePages = _.flatMap(value => [
+  {
+    path: `states/${value.state}/info`,
+    value,
+  },
+])
+
+function createPages(value) {
+  return [{ path: 'states/info', value }, ...statePages(value)]
+}
+
+module.exports = {
+  ...sheets,
+  fixItems: fixStatesInfo,
+  sheetName: 'States',
+  path: 'states/info',
+  createPages,
+}


### PR DESCRIPTION
Another common request is getting info for a single state. This creates files `/v1/api/states/{state}/info.{ext}`