### PR TITLE
[⚠️Do not merge⚠️] feat: Outcomes in state/US history

### DIFF
--- a/src/components/common/summary-table.js
+++ b/src/components/common/summary-table.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import Table from './table'
+import formatNumber from '../../utilities/format-number'
 import '../../scss/components/common/summary-table.scss'
-import thousands from '../../utilities/format-thousands'
 
 export default ({ data, lastUpdated }) => (
   <Table tableLabel={lastUpdated && `Last updated: ${lastUpdated} ET`}>
@@ -48,38 +48,18 @@ export default ({ data, lastUpdated }) => (
     </thead>
     <tbody>
       <tr>
-        <td>{data.positive ? thousands(data.positive) : 'N/A'}</td>
-        <td>{data.negative ? thousands(data.negative) : 'N/A'}</td>
-        <td>{data.pending ? thousands(data.pending) : 'N/A'}</td>
-        <td>
-          {data.hospitalizedCurrently
-            ? thousands(data.hospitalizedCurrently)
-            : 'N/A'}
-        </td>
-        <td>
-          {data.hospitalizedCumulative
-            ? thousands(data.hospitalizedCumulative)
-            : 'N/A'}
-        </td>
-        <td>{data.inIcuCurrently ? thousands(data.inIcuCurrently) : 'N/A'}</td>
-        <td>
-          {data.inIcuCumulative ? thousands(data.inIcuCumulative) : 'N/A'}
-        </td>
-        <td>
-          {data.onVentilatorCurrently
-            ? thousands(data.onVentilatorCurrently)
-            : 'N/A'}
-        </td>
-        <td>
-          {data.onVentilatorCumulative
-            ? thousands(data.onVentilatorCumulative)
-            : 'N/A'}
-        </td>
-        <td>{data.recovered ? thousands(data.recovered) : 'N/A'}</td>
-        <td>{data.death ? thousands(data.death) : 'N/A'}</td>
-        <td>
-          {data.totalTestResults ? thousands(data.totalTestResults) : 'N/A'}
-        </td>
+        <td>{formatNumber(data.positive)}</td>
+        <td>{formatNumber(data.negative)}</td>
+        <td>{formatNumber(data.pending)}</td>
+        <td>{formatNumber(data.hospitalizedCurrently)}</td>
+        <td>{formatNumber(data.hospitalizedCumulative)}</td>
+        <td>{formatNumber(data.inIcuCurrently)}</td>
+        <td>{formatNumber(data.inIcuCumulative)}</td>
+        <td>{formatNumber(data.onVentilatorCurrently)}</td>
+        <td>{formatNumber(data.onVentilatorCumulative)}</td>
+        <td>{formatNumber(data.recovered)}</td>
+        <td>{formatNumber(data.death)}</td>
+        <td>{formatNumber(data.totalTestResults)}</td>
       </tr>
     </tbody>
   </Table>

--- a/src/pages/data/us-daily.js
+++ b/src/pages/data/us-daily.js
@@ -2,9 +2,11 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import { DateTime } from 'luxon'
 import Layout from '../../components/layout'
+import DetailText from '../../components/common/detail-text'
+import formatNumber from '../../utilities/format-number'
 import { SyncInfobox } from '../../components/common/infobox'
 
-const ContentPage = ({ data }) => (
+const UsDailyPage = ({ data }) => (
   <Layout
     title="US Historical Data"
     navigation={data.allContentfulNavigationGroup.edges[0].node.pages}
@@ -12,30 +14,71 @@ const ContentPage = ({ data }) => (
     <div
       dangerouslySetInnerHTML={{
         __html:
-          data.allContentfulSnippet.edges[0].node
+          data.usDailyPreamble.edges[0].node
             .childContentfulSnippetContentTextNode.childMarkdownRemark.html,
       }}
     />
 
     <SyncInfobox />
 
+    <DetailText>
+      <span
+        dangerouslySetInnerHTML={{
+          __html:
+            data.dataSummaryFootnote.nodes[0].content.childMarkdownRemark.html,
+        }}
+      />
+    </DetailText>
+
     <div className="us-days">
       <div className="table-scroll">
         <table className="day-table">
           <caption>US Daily Cumulative Totals - 4 pm ET</caption>
+          <col />
+          <col />
+          <colgroup span="3" />
+          <colgroup span="2" />
+          <colgroup span="2" />
+          <colgroup span="2" />
+          <col />
+          <col />
+          <col />
+          <col />
           <thead>
             <tr>
-              <th scope="col" className="text-left">
-                Date
+              <td />
+              <td />
+              <th scope="colgroup" colSpan="3">
+                Tests
               </th>
-              <th scope="col">States Tracked</th>
+              <th scope="colgroup" colSpan="2">
+                Hospitalized
+              </th>
+              <th scope="colgroup" colSpan="2">
+                In ICU
+              </th>
+              <th scope="colgroup" colSpan="2">
+                On Ventilator
+              </th>
+              <td colSpan="3"> </td>
+            </tr>
+            <tr>
+              <th scope="col">Date</th>
+              <th scope="col">States</th>
               <th scope="col">Positive</th>
               <th scope="col">Negative</th>
-              <th scope="col">Pos + Neg</th>
               <th scope="col">Pending</th>
-              <th scope="col">Hospitalized</th>
+              <th scope="col">Currently</th>
+              <th scope="col">Cumulative</th>
+              <th scope="col">Currently</th>
+              <th scope="col">Cumulative</th>
+              <th scope="col">Currently</th>
+              <th scope="col">Cumulative</th>
+              <th scope="col">Recovered</th>
               <th scope="col">Deaths</th>
-              <th scope="col">Total Tests</th>
+              <th scope="col">
+                Total test results <span>(Positive + Negative)</span>
+              </th>
             </tr>
           </thead>
           <tbody>
@@ -48,17 +91,18 @@ const ContentPage = ({ data }) => (
                   ).toFormat('dd LLL yyyy ccc')}
                 </td>
                 <td>{node.states}</td>
-                <td>{node.positive.toLocaleString()}</td>
-                <td>{node.negative.toLocaleString()}</td>
-                <td>{(node.positive + node.negative).toLocaleString()}</td>
-                <td>{node.pending.toLocaleString()}</td>
-                <td>
-                  {node.hospitalized
-                    ? node.hospitalized.toLocaleString()
-                    : 'N/A'}
-                </td>
-                <td>{node.death ? node.death.toLocaleString() : 'N/A'}</td>
-                <td>{node.totalTestResults.toLocaleString()}</td>
+                <td>{formatNumber(node.positive)}</td>
+                <td>{formatNumber(node.negative)}</td>
+                <td>{formatNumber(node.pending)}</td>
+                <td>{formatNumber(node.hospitalizedCurrently)}</td>
+                <td>{formatNumber(node.hospitalizedCumulative)}</td>
+                <td>{formatNumber(node.inIcuCurrently)}</td>
+                <td>{formatNumber(node.inIcuCumulative)}</td>
+                <td>{formatNumber(node.onVentilatorCurrently)}</td>
+                <td>{formatNumber(node.onVentilatorCumulative)}</td>
+                <td>{formatNumber(node.recovered)}</td>
+                <td>{formatNumber(node.death)}</td>
+                <td>{formatNumber(node.totalTestResults)}</td>
               </tr>
             ))}
           </tbody>
@@ -68,11 +112,26 @@ const ContentPage = ({ data }) => (
   </Layout>
 )
 
-export default ContentPage
+export default UsDailyPage
 
 export const query = graphql`
   query {
-    allContentfulSnippet(filter: { slug: { eq: "us-daily" } }) {
+    dataSummaryFootnote: allContentfulSnippet(
+      filter: { name: { eq: "Data summary footnote" } }
+    ) {
+      nodes {
+        id
+        name
+        content {
+          childMarkdownRemark {
+            html
+          }
+        }
+      }
+    }
+    usDailyPreamble: allContentfulSnippet(
+      filter: { slug: { eq: "us-daily" } }
+    ) {
       edges {
         node {
           childContentfulSnippetContentTextNode {
@@ -86,14 +145,20 @@ export const query = graphql`
     allCovidUsDaily(sort: { order: DESC, fields: date }) {
       edges {
         node {
-          totalTestResults
+          date
           states
           positive
-          pending
           negative
-          hospitalized
+          pending
+          hospitalizedCurrently
+          hospitalizedCumulative
+          inIcuCurrently
+          inIcuCumulative
+          recovered
+          onVentilatorCurrently
+          onVentilatorCumulative
           death
-          date
+          totalTestResults
         }
       }
     }

--- a/src/scss/templates/state.scss
+++ b/src/scss/templates/state.scss
@@ -7,12 +7,14 @@
   ul {
     color: green;
     list-style: none;
-    display: inline list-item;
+    display: inline;
   }
 
   li {
     display: inline;
-    padding: 0.8em;
     padding-right: 0;
+    &::after {
+      content: ' ';
+    }
   }
 }

--- a/src/templates/state.js
+++ b/src/templates/state.js
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon'
 import marked from 'marked'
 import Layout from '../components/layout'
 import formatDate from '../utilities/format-date'
-import thousands from '../utilities/format-thousands'
+import formatNumber from '../utilities/format-number'
 import { UnstyledList } from '../components/common/lists'
 import StateGrade from '../components/common/state-grade'
 import SummaryTable from '../components/common/summary-table'
@@ -64,16 +64,51 @@ const Screenshots = ({ date, screenshots }) => {
 
 const StateHistory = ({ history, screenshots }) => (
   <Table className="state-historical">
+    <col />
+    <col />
+    <colgroup span="3" />
+    <colgroup span="2" />
+    <colgroup span="2" />
+    <colgroup span="2" />
+    <col />
+    <col />
+    <col />
+    <col />
     <thead>
       <tr>
+        <td />
+        <td />
+        <th scope="colgroup" colSpan="3">
+          Tests
+        </th>
+        <th scope="colgroup" colSpan="2">
+          Hospitalized
+        </th>
+        <th scope="colgroup" colSpan="2">
+          In ICU
+        </th>
+        <th scope="colgroup" colSpan="2">
+          On Ventilator
+        </th>
+        <td colSpan="3"> </td>
+      </tr>
+      <tr>
         <th scope="col">Date</th>
-        <th scope="col">Screenshot</th>
+        <th scope="col">Screenshots</th>
         <th scope="col">Positive</th>
         <th scope="col">Negative</th>
         <th scope="col">Pending</th>
-        <th scope="col">Hospitalized</th>
+        <th scope="col">Currently</th>
+        <th scope="col">Cumulative</th>
+        <th scope="col">Currently</th>
+        <th scope="col">Cumulative</th>
+        <th scope="col">Currently</th>
+        <th scope="col">Cumulative</th>
+        <th scope="col">Recovered</th>
         <th scope="col">Deaths</th>
-        <th scope="col">Total</th>
+        <th scope="col">
+          Total test results <span>(Positive + Negative)</span>
+        </th>
       </tr>
     </thead>
     <tbody>
@@ -83,12 +118,18 @@ const StateHistory = ({ history, screenshots }) => (
           <td>
             <Screenshots date={node.dateChecked} screenshots={screenshots} />
           </td>
-          <td>{thousands(node.positive)}</td>
-          <td>{thousands(node.negative)}</td>
-          <td>{thousands(node.pending)}</td>
-          <td>{thousands(node.hospitalized)}</td>
-          <td>{thousands(node.death)}</td>
-          <td>{thousands(node.totalTestResults)}</td>
+          <td>{formatNumber(node.positive)}</td>
+          <td>{formatNumber(node.negative)}</td>
+          <td>{formatNumber(node.pending)}</td>
+          <td>{formatNumber(node.hospitalizedCurrently)}</td>
+          <td>{formatNumber(node.hospitalizedCumulative)}</td>
+          <td>{formatNumber(node.inIcuCurrently)}</td>
+          <td>{formatNumber(node.inIcuCumulative)}</td>
+          <td>{formatNumber(node.onVentilatorCurrently)}</td>
+          <td>{formatNumber(node.onVentilatorCumulative)}</td>
+          <td>{formatNumber(node.recovered)}</td>
+          <td>{formatNumber(node.death)}</td>
+          <td>{formatNumber(node.totalTestResults)}</td>
         </tr>
       ))}
     </tbody>
@@ -150,13 +191,19 @@ export const query = graphql`
     ) {
       edges {
         node {
-          totalTestResults
-          positive
-          pending
-          negative
-          hospitalized
-          death
           dateChecked
+          positive
+          negative
+          pending
+          hospitalizedCurrently
+          hospitalizedCumulative
+          inIcuCurrently
+          inIcuCumulative
+          recovered
+          onVentilatorCurrently
+          onVentilatorCumulative
+          death
+          totalTestResults
         }
       }
     }

--- a/src/utilities/format-number.js
+++ b/src/utilities/format-number.js
@@ -1,0 +1,6 @@
+export default number => {
+  if (typeof number === 'undefined' || (!number && number !== 0)) {
+    return 'N/A'
+  }
+  return number.toLocaleString()
+}

--- a/src/utilities/format-thousands.js
+++ b/src/utilities/format-thousands.js
@@ -1,2 +1,0 @@
-export default number =>
-  number ? number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',') : number


### PR DESCRIPTION
Fixes #403

Adds outcome data to state and US tables.

Note that we are getting very squished, especially with screenshots in the state tables. We should fix this long-term with a revisit to history tables and separate pages per day per state, or add features to expand tables. The scope of this PR is to just get the data out for now.


- [x] data-layer-changes notified
- [ ] Workstream leads notified after discussion
- [ ] Data team member reviewed & approved