### PR TITLE
feat: Use snippet for 404 page

### DIFF
--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -1,10 +1,33 @@
 import React from 'react'
+import { graphql } from 'gatsby'
 import Layout from '../components/layout'
 
-const NotFoundPage = () => (
+const NotFoundPage = ({ data }) => (
   <Layout title="Page not found">
-    <p>Page not found</p>
+    <div
+      dangerouslySetInnerHTML={{
+        __html:
+          data.allContentfulSnippet.edges[0].node
+            .childContentfulSnippetContentTextNode.childMarkdownRemark.html,
+      }}
+    />
   </Layout>
 )
 
 export default NotFoundPage
+
+export const query = graphql`
+  query {
+    allContentfulSnippet(filter: { slug: { eq: "page-not-found" } }) {
+      edges {
+        node {
+          childContentfulSnippetContentTextNode {
+            childMarkdownRemark {
+              html
+            }
+          }
+        }
+      }
+    }
+  }
+`


### PR DESCRIPTION
Fixes #312 

Uses content from a snippet in Contentful so content editors can manage the text of the Page-not-found page. 

[Preview here](https://deploy-preview-405--upbeat-lovelace-3e9fff.netlify.com/lkjsdf)

I added the following to the snippet:

> Looks like we couldn't find that page. Here's a few helpful places to find what you're looking for:
> 
> - [State-by-state Data](/data) - A list of COVID data by state
> - [US Daily totals](/data/us-daily) - A list of US COVID totals by day
> - [FAQ](/about-data/faq) - FAQ about our data and process
> - [Data API](/api) - Our data API for developers
> 
> Think you found a bug with the website? [Reach out on GitHub](https://github.com/COVID19Tracking/website)