### PR TITLE
fix: Container padding between xl and lg viewport

### DIFF
--- a/src/scss/components/common/container.scss
+++ b/src/scss/components/common/container.scss
@@ -1,7 +1,7 @@
 @import '../../breakpoints.scss';
 
 .container {
-  max-width: 1140px;
+  max-width: 1000px;
   margin-right: 1.5rem;
   margin-left: 1.5rem;
   @media (min-width: $viewport-md) {
@@ -11,6 +11,9 @@
   @media (min-width: $viewport-lg) {
     margin-left: auto;
     margin-right: auto;
+  }
+  @media (min-width: $viewport-xl) {
+    max-width: 1140px;
   }
   &.container-narrow {
     max-width: 900px;


### PR DESCRIPTION
Fixes #320 

Because we had a hard-width of 1140px on the container, which is larger than our lg viewport, there was a gutter missing.

This makes 1140 the width beyond the XL viewport, and 1000 the max-width for all others.