### PR TITLE
Move React components to separate files

### DIFF
--- a/src/components/pages/data/state-data.js
+++ b/src/components/pages/data/state-data.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import marked from 'marked'
 import { Link } from 'gatsby'
-import slug from '../../utilities/slug'
-import { UnstyledList } from './lists'
-import StateGrade from './state-grade'
-import SummaryTable from './summary-table'
-import '../../scss/components/common/state-data.scss'
+import slug from '../../../utilities/slug'
+import { UnstyledList } from '../../common/lists'
+import StateGrade from '../../common/state-grade'
+import SummaryTable from '../../common/summary-table'
+import '../../../scss/components/pages/data/state-data.scss'
 
 const State = ({ state }) => (
   <>

--- a/src/components/pages/data/state-list.js
+++ b/src/components/pages/data/state-list.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Flex, Box } from '../../common/flexbox'
+import State from './state-data'
+
+export default ({ states, stateData }) => {
+  const stateList = []
+  states.forEach(({ node }) => {
+    const state = node
+    stateData.forEach(data => {
+      if (data.node.state === state.state) {
+        state.stateData = data.node
+      }
+    })
+    stateList.push(state)
+  })
+  return (
+    <Flex flexWrap="wrap" m="0 -10px">
+      {stateList.map(state => (
+        <Box
+          width={1}
+          mb={['1rem', '1.5rem']}
+          p="0 10px"
+          className="data-state"
+        >
+          <State state={state} stateData={state.stateData} />
+        </Box>
+      ))}
+    </Flex>
+  )
+}

--- a/src/components/pages/data/state-nav.js
+++ b/src/components/pages/data/state-nav.js
@@ -1,0 +1,16 @@
+import React from 'react'
+import { Link } from 'gatsby'
+import { Box } from '../../common/flexbox'
+
+export default ({ stateList }) => (
+  <Box width={[1, 1, 1, 1 / 2]} className="state-nav" m="0 auto 1rem">
+    <h3>Jump to a state:</h3>
+    <ul>
+      {stateList.map(state => (
+        <li key={state.node.state}>
+          <Link to={`/data#state-${state.node.state}`}>{state.node.state}</Link>
+        </li>
+      ))}
+    </ul>
+  </Box>
+)

--- a/src/components/pages/state/screenshots.js
+++ b/src/components/pages/state/screenshots.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import { DateTime } from 'luxon'
+
+export default ({ date, screenshots }) => {
+  const dateScreenshots = []
+  const currentDate = DateTime.fromISO(date)
+  screenshots.forEach(({ node }) => {
+    if (DateTime.fromISO(node.dateChecked).hasSame(currentDate, 'day')) {
+      dateScreenshots.push(node)
+    }
+  })
+  if (dateScreenshots.length === 0) {
+    return null
+  }
+  return (
+    <ul>
+      {dateScreenshots.map(screenshot => (
+        <li key={screenshot.url}>
+          <a href={screenshot.url} target="_blank" rel="noopener noreferrer">
+            {screenshot.dateChecked && (
+              <>
+                {DateTime.fromISO(screenshot.dateChecked)
+                  .toFormat('h:mm a')
+                  .toLowerCase()}
+              </>
+            )}
+          </a>
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/components/pages/state/state-history.js
+++ b/src/components/pages/state/state-history.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import Screenshots from './screenshots'
+import Table from '../../common/table'
+import formatDate from '../../../utilities/format-date'
+import thousands from '../../../utilities/format-thousands'
+
+export default ({ history, screenshots }) => (
+  <Table className="state-historical">
+    <thead>
+      <tr>
+        <th scope="col">Date</th>
+        <th scope="col">Screenshot</th>
+        <th scope="col">Positive</th>
+        <th scope="col">Negative</th>
+        <th scope="col">Pending</th>
+        <th scope="col">Hospitalized</th>
+        <th scope="col">Deaths</th>
+        <th scope="col">Total</th>
+      </tr>
+    </thead>
+    <tbody>
+      {history.map(({ node }) => (
+        <tr key={`history-${node.dateChecked}`}>
+          <td>{formatDate(node.dateChecked)}</td>
+          <td>
+            <Screenshots date={node.dateChecked} screenshots={screenshots} />
+          </td>
+          <td>{thousands(node.positive)}</td>
+          <td>{thousands(node.negative)}</td>
+          <td>{thousands(node.pending)}</td>
+          <td>{thousands(node.hospitalized)}</td>
+          <td>{thousands(node.death)}</td>
+          <td>{thousands(node.totalTestResults)}</td>
+        </tr>
+      ))}
+    </tbody>
+  </Table>
+)

--- a/src/components/pages/state/state-links.js
+++ b/src/components/pages/state/state-links.js
@@ -1,0 +1,22 @@
+import React from 'react'
+import { UnstyledList } from '../../common/lists'
+
+export default ({ name, twitter, covid19Site, dataSource }) => (
+  <UnstyledList>
+    {twitter && (
+      <li>
+        <a href={`https://twitter.com/${twitter}`}>{name} on Twitter</a>
+      </li>
+    )}
+    {covid19Site && (
+      <li>
+        <a href={covid19Site}>Best current data source</a>
+      </li>
+    )}
+    {dataSource && (
+      <li>
+        <a href={dataSource}>Data source</a>
+      </li>
+    )}
+  </UnstyledList>
+)

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import { graphql, Link } from 'gatsby'
 import { Flex, Box } from '../../components/common/flexbox'
-import State from '../../components/common/state-data'
+import State from '../../components/pages/data/state-data'
 import Layout from '../../components/layout'
 import { SyncInfobox } from '../../components/common/infobox'
 import DetailText from '../../components/common/detail-text'

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -1,39 +1,12 @@
 import React from 'react'
 import { graphql, Link } from 'gatsby'
-import { Flex, Box } from '../../components/common/flexbox'
-import State from '../../components/pages/data/state-data'
+import { Box } from '../../components/common/flexbox'
+import StateList from '../../components/pages/data/state-list'
 import Layout from '../../components/layout'
 import { SyncInfobox } from '../../components/common/infobox'
 import DetailText from '../../components/common/detail-text'
 import SummaryTable from '../../components/common/summary-table'
 import '../../scss/pages/data.scss'
-
-const StateList = ({ states, stateData }) => {
-  const stateList = []
-  states.forEach(({ node }) => {
-    const state = node
-    stateData.forEach(data => {
-      if (data.node.state === state.state) {
-        state.stateData = data.node
-      }
-    })
-    stateList.push(state)
-  })
-  return (
-    <Flex flexWrap="wrap" m="0 -10px">
-      {stateList.map(state => (
-        <Box
-          width={1}
-          mb={['1rem', '1.5rem']}
-          p="0 10px"
-          className="data-state"
-        >
-          <State state={state} stateData={state.stateData} />
-        </Box>
-      ))}
-    </Flex>
-  )
-}
 
 const StatesNav = ({ stateList }) => (
   <Box width={[1, 1, 1, 1 / 2]} className="state-nav" m="0 auto 1rem">

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -8,7 +8,6 @@ import SummaryTable from '../../components/common/summary-table'
 import { SyncInfobox } from '../../components/common/infobox'
 import '../../scss/pages/data.scss'
 
-// The top-level content of this page is from 'src/content/snippets/data.md'
 export default ({ data }) => (
   <Layout
     title="Most recent data"

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -1,25 +1,12 @@
 import React from 'react'
-import { graphql, Link } from 'gatsby'
-import { Box } from '../../components/common/flexbox'
-import StateList from '../../components/pages/data/state-list'
-import Layout from '../../components/layout'
-import { SyncInfobox } from '../../components/common/infobox'
+import { graphql } from 'gatsby'
 import DetailText from '../../components/common/detail-text'
+import Layout from '../../components/layout'
+import StateList from '../../components/pages/data/state-list'
+import StateNav from '../../components/pages/data/state-nav'
 import SummaryTable from '../../components/common/summary-table'
+import { SyncInfobox } from '../../components/common/infobox'
 import '../../scss/pages/data.scss'
-
-const StatesNav = ({ stateList }) => (
-  <Box width={[1, 1, 1, 1 / 2]} className="state-nav" m="0 auto 1rem">
-    <h3>Jump to a state:</h3>
-    <ul>
-      {stateList.map(state => (
-        <li key={state.node.state}>
-          <Link to={`/data#state-${state.node.state}`}>{state.node.state}</Link>
-        </li>
-      ))}
-    </ul>
-  </Box>
-)
 
 // The top-level content of this page is from 'src/content/snippets/data.md'
 export default ({ data }) => (
@@ -43,7 +30,7 @@ export default ({ data }) => (
       />
     </DetailText>
     <h2 id="states-top">States</h2>
-    <StatesNav stateList={data.allCovidState.edges} />
+    <StateNav stateList={data.allCovidState.edges} />
     <StateList
       states={data.allCovidStateInfo.edges}
       stateData={data.allCovidState.edges}

--- a/src/scss/components/pages/data/state-data.scss
+++ b/src/scss/components/pages/data/state-data.scss
@@ -1,4 +1,4 @@
-@import '../../breakpoints.scss';
+@import '../../../breakpoints.scss';
 
 .state-header {
   display: flex;

--- a/src/templates/state.js
+++ b/src/templates/state.js
@@ -1,46 +1,16 @@
 import React from 'react'
 import { graphql } from 'gatsby'
-import { DateTime } from 'luxon'
 import marked from 'marked'
 import Layout from '../components/layout'
 import formatDate from '../utilities/format-date'
 import thousands from '../utilities/format-thousands'
+import Screenshots from '../components/pages/state/screenshots'
 import StateGrade from '../components/common/state-grade'
 import StateLinks from '../components/pages/state/state-links'
 import SummaryTable from '../components/common/summary-table'
 import { SyncInfobox } from '../components/common/infobox'
 import Table from '../components/common/table'
 import '../scss/templates/state.scss'
-
-const Screenshots = ({ date, screenshots }) => {
-  const dateScreenshots = []
-  const currentDate = DateTime.fromISO(date)
-  screenshots.forEach(({ node }) => {
-    if (DateTime.fromISO(node.dateChecked).hasSame(currentDate, 'day')) {
-      dateScreenshots.push(node)
-    }
-  })
-  if (dateScreenshots.length === 0) {
-    return null
-  }
-  return (
-    <ul>
-      {dateScreenshots.map(screenshot => (
-        <li key={screenshot.url}>
-          <a href={screenshot.url} target="_blank" rel="noopener noreferrer">
-            {screenshot.dateChecked && (
-              <>
-                {DateTime.fromISO(screenshot.dateChecked)
-                  .toFormat('h:mm a')
-                  .toLowerCase()}
-              </>
-            )}
-          </a>
-        </li>
-      ))}
-    </ul>
-  )
-}
 
 const StateHistory = ({ history, screenshots }) => (
   <Table className="state-historical">

--- a/src/templates/state.js
+++ b/src/templates/state.js
@@ -2,48 +2,12 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import marked from 'marked'
 import Layout from '../components/layout'
-import formatDate from '../utilities/format-date'
-import thousands from '../utilities/format-thousands'
-import Screenshots from '../components/pages/state/screenshots'
 import StateGrade from '../components/common/state-grade'
+import StateHistory from '../components/pages/state/state-history'
 import StateLinks from '../components/pages/state/state-links'
 import SummaryTable from '../components/common/summary-table'
 import { SyncInfobox } from '../components/common/infobox'
-import Table from '../components/common/table'
 import '../scss/templates/state.scss'
-
-const StateHistory = ({ history, screenshots }) => (
-  <Table className="state-historical">
-    <thead>
-      <tr>
-        <th scope="col">Date</th>
-        <th scope="col">Screenshot</th>
-        <th scope="col">Positive</th>
-        <th scope="col">Negative</th>
-        <th scope="col">Pending</th>
-        <th scope="col">Hospitalized</th>
-        <th scope="col">Deaths</th>
-        <th scope="col">Total</th>
-      </tr>
-    </thead>
-    <tbody>
-      {history.map(({ node }) => (
-        <tr key={`history-${node.dateChecked}`}>
-          <td>{formatDate(node.dateChecked)}</td>
-          <td>
-            <Screenshots date={node.dateChecked} screenshots={screenshots} />
-          </td>
-          <td>{thousands(node.positive)}</td>
-          <td>{thousands(node.negative)}</td>
-          <td>{thousands(node.pending)}</td>
-          <td>{thousands(node.hospitalized)}</td>
-          <td>{thousands(node.death)}</td>
-          <td>{thousands(node.totalTestResults)}</td>
-        </tr>
-      ))}
-    </tbody>
-  </Table>
-)
 
 const StatePage = ({ pageContext, data }) => {
   const state = pageContext

--- a/src/templates/state.js
+++ b/src/templates/state.js
@@ -5,32 +5,12 @@ import marked from 'marked'
 import Layout from '../components/layout'
 import formatDate from '../utilities/format-date'
 import thousands from '../utilities/format-thousands'
-import { UnstyledList } from '../components/common/lists'
 import StateGrade from '../components/common/state-grade'
+import StateLinks from '../components/pages/state/state-links'
 import SummaryTable from '../components/common/summary-table'
 import { SyncInfobox } from '../components/common/infobox'
 import Table from '../components/common/table'
 import '../scss/templates/state.scss'
-
-const StateLinks = ({ name, twitter, covid19Site, dataSource }) => (
-  <UnstyledList>
-    {twitter && (
-      <li>
-        <a href={`https://twitter.com/${twitter}`}>{name} on Twitter</a>
-      </li>
-    )}
-    {covid19Site && (
-      <li>
-        <a href={covid19Site}>Best current data source</a>
-      </li>
-    )}
-    {dataSource && (
-      <li>
-        <a href={dataSource}>Data source</a>
-      </li>
-    )}
-  </UnstyledList>
-)
 
 const Screenshots = ({ date, screenshots }) => {
   const dateScreenshots = []


### PR DESCRIPTION
Two files:

* `src/pages/data/index.js`
* `src/templates/state.js`

had many React components in them. This PR breaks the components in each original file into separate files located in the `src/components/pages/` directory.

This should increase the readability and accessibility of the codebase.

This will likely cause some merging issues as other PRs crop up -- merging sooner would hopefully mitigate those.