### PR TITLE
Fix active tab state when URL has trailing slash

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,6 +33,7 @@ module.exports = {
     `gatsby-plugin-sass`,
     `gatsby-transformer-yaml`,
     'gatsby-plugin-eslint',
+    `gatsby-plugin-remove-trailing-slashes`,
     {
       resolve: 'gatsby-source-covid-tracking-api',
       options: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15137,6 +15137,14 @@
         "@babel/runtime": "^7.8.7"
       }
     },
+    "gatsby-plugin-remove-trailing-slashes": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-remove-trailing-slashes/-/gatsby-plugin-remove-trailing-slashes-2.2.1.tgz",
+      "integrity": "sha512-V/pLK1VkmqePlrPkEagsY4LSGVVG73+quiYOoNOWGzPi4FFSUu3GSiA8is4hiejB5fOs81TDhjYfvIIPbv5Q7w==",
+      "requires": {
+        "@babel/runtime": "^7.8.7"
+      }
+    },
     "gatsby-plugin-sass": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sass/-/gatsby-plugin-sass-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "gatsby-plugin-offline": "^3.0.41",
     "gatsby-plugin-page-creator": "^2.2.1",
     "gatsby-plugin-react-helmet": "^3.1.24",
+    "gatsby-plugin-remove-trailing-slashes": "^2.2.1",
     "gatsby-plugin-sass": "^2.2.0",
     "gatsby-plugin-sharp": "^2.4.13",
     "gatsby-plugin-typography": "^2.4.1",


### PR DESCRIPTION
When navigating using the site tabs/UI, the URLs do not have trailing slashes, which ensures the Gatsby `Link` components render with correct aria-current attributes and selected states. The current page's tab is highlighted.

However, if you directly navigate with a trailing slash, such as:

[https://covidtracking.com/data/](https://covidtracking.com/data/)

The `Link` matching logic fails. Adding the [gatsby-plugin-remove-trailing-slashes](https://www.gatsbyjs.org/packages/gatsby-plugin-remove-trailing-slashes/) plugin fixes the issue, but only works in production mode.

To test locally, run `gatsby build` and serve the /public directory using local static file server.