### PR TITLE
Remove US total outcomes data

### DIFF
--- a/src/components/common/summary-table.js
+++ b/src/components/common/summary-table.js
@@ -3,7 +3,7 @@ import Table from './table'
 import '../../scss/components/common/summary-table.scss'
 import thousands from '../../utilities/format-thousands'
 
-export default ({ data, lastUpdated }) => (
+export default ({ data, lastUpdated, showOutcomes = true }) => (
   <Table tableLabel={lastUpdated && `Last updated: ${lastUpdated} ET`}>
     <colgroup span="3" />
     <colgroup span="2" />
@@ -18,28 +18,38 @@ export default ({ data, lastUpdated }) => (
         <th scope="colgroup" colSpan="3">
           Tests
         </th>
-        <th scope="colgroup" colSpan="2">
-          Hospitalized
-        </th>
-        <th scope="colgroup" colSpan="2">
-          In ICU
-        </th>
-        <th scope="colgroup" colSpan="2">
-          On Ventilator
-        </th>
-        <td colSpan="3"> </td>
+        {showOutcomes ? (
+          <>
+            <th scope="colgroup" colSpan="2">
+              Hospitalized
+            </th>
+            <th scope="colgroup" colSpan="2">
+              In ICU
+            </th>
+            <th scope="colgroup" colSpan="2">
+              On Ventilator
+            </th>
+            <td colSpan="3"> </td> {/* 3 includes recovered */}
+          </>
+        ) : (
+          <td colSpan="2"> </td>
+        )}
       </tr>
       <tr>
         <th scope="col">Positive</th>
         <th scope="col">Negative</th>
         <th scope="col">Pending</th>
-        <th scope="col">Currently</th>
-        <th scope="col">Cumulative</th>
-        <th scope="col">Currently</th>
-        <th scope="col">Cumulative</th>
-        <th scope="col">Currently</th>
-        <th scope="col">Cumulative</th>
-        <th scope="col">Recovered</th>
+        {showOutcomes && (
+          <>
+            <th scope="col">Currently</th>
+            <th scope="col">Cumulative</th>
+            <th scope="col">Currently</th>
+            <th scope="col">Cumulative</th>
+            <th scope="col">Currently</th>
+            <th scope="col">Cumulative</th>
+            <th scope="col">Recovered</th>
+          </>
+        )}
         <th scope="col">Deaths</th>
         <th scope="col">
           Total test results <span>(Positive + Negative)</span>
@@ -51,31 +61,37 @@ export default ({ data, lastUpdated }) => (
         <td>{data.positive ? thousands(data.positive) : 'N/A'}</td>
         <td>{data.negative ? thousands(data.negative) : 'N/A'}</td>
         <td>{data.pending ? thousands(data.pending) : 'N/A'}</td>
-        <td>
-          {data.hospitalizedCurrently
-            ? thousands(data.hospitalizedCurrently)
-            : 'N/A'}
-        </td>
-        <td>
-          {data.hospitalizedCumulative
-            ? thousands(data.hospitalizedCumulative)
-            : 'N/A'}
-        </td>
-        <td>{data.inIcuCurrently ? thousands(data.inIcuCurrently) : 'N/A'}</td>
-        <td>
-          {data.inIcuCumulative ? thousands(data.inIcuCumulative) : 'N/A'}
-        </td>
-        <td>
-          {data.onVentilatorCurrently
-            ? thousands(data.onVentilatorCurrently)
-            : 'N/A'}
-        </td>
-        <td>
-          {data.onVentilatorCumulative
-            ? thousands(data.onVentilatorCumulative)
-            : 'N/A'}
-        </td>
-        <td>{data.recovered ? thousands(data.recovered) : 'N/A'}</td>
+        {showOutcomes && (
+          <>
+            <td>
+              {data.hospitalizedCurrently
+                ? thousands(data.hospitalizedCurrently)
+                : 'N/A'}
+            </td>
+            <td>
+              {data.hospitalizedCumulative
+                ? thousands(data.hospitalizedCumulative)
+                : 'N/A'}
+            </td>
+            <td>
+              {data.inIcuCurrently ? thousands(data.inIcuCurrently) : 'N/A'}
+            </td>
+            <td>
+              {data.inIcuCumulative ? thousands(data.inIcuCumulative) : 'N/A'}
+            </td>
+            <td>
+              {data.onVentilatorCurrently
+                ? thousands(data.onVentilatorCurrently)
+                : 'N/A'}
+            </td>
+            <td>
+              {data.onVentilatorCumulative
+                ? thousands(data.onVentilatorCumulative)
+                : 'N/A'}
+            </td>
+            <td>{data.recovered ? thousands(data.recovered) : 'N/A'}</td>
+          </>
+        )}
         <td>{data.death ? thousands(data.death) : 'N/A'}</td>
         <td>
           {data.totalTestResults ? thousands(data.totalTestResults) : 'N/A'}

--- a/src/components/common/summary-table.js
+++ b/src/components/common/summary-table.js
@@ -6,11 +6,14 @@ import thousands from '../../utilities/format-thousands'
 export default ({ data, lastUpdated, showOutcomes = true }) => (
   <Table tableLabel={lastUpdated && `Last updated: ${lastUpdated} ET`}>
     <colgroup span="3" />
-    <colgroup span="2" />
-    <colgroup span="2" />
-    <colgroup span="2" />
-    <col />
-    <col />
+    {showOutcomes && (
+      <>
+        <colgroup span="2" />
+        <colgroup span="2" />
+        <colgroup span="2" />
+        <col />
+      </>
+    )}
     <col />
     <col />
     <thead>

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -19,7 +19,7 @@ export default ({ data }) => (
       }}
     />
     <SyncInfobox />
-    <SummaryTable data={data.allCovidUs.edges[0].node} />
+    <SummaryTable data={data.allCovidUs.edges[0].node} showOutcomes={false} />
     <DetailText>
       <span
         dangerouslySetInnerHTML={{

--- a/src/pages/data/us-daily.js
+++ b/src/pages/data/us-daily.js
@@ -33,7 +33,6 @@ const ContentPage = ({ data }) => (
               <th scope="col">Negative</th>
               <th scope="col">Pos + Neg</th>
               <th scope="col">Pending</th>
-              <th scope="col">Hospitalized</th>
               <th scope="col">Deaths</th>
               <th scope="col">Total Tests</th>
             </tr>
@@ -52,11 +51,6 @@ const ContentPage = ({ data }) => (
                 <td>{node.negative.toLocaleString()}</td>
                 <td>{(node.positive + node.negative).toLocaleString()}</td>
                 <td>{node.pending.toLocaleString()}</td>
-                <td>
-                  {node.hospitalized
-                    ? node.hospitalized.toLocaleString()
-                    : 'N/A'}
-                </td>
                 <td>{node.death ? node.death.toLocaleString() : 'N/A'}</td>
                 <td>{node.totalTestResults.toLocaleString()}</td>
               </tr>


### PR DESCRIPTION
Alexis put this out to the website team earlier today:
> Because some states report current and some states report cumulative hospitalization/ICU numbers, we a fundamental mismatch in what these data represent. We can't just push currents across into cumulatives to get a cumulative number [...] The only real answer, I think, is to not provide a national summary of outcomes data.

This PR **does** remove the outcomes data from the US summary table
This PR **does not** remove the outcomes data from individual states (it is retained on both the data index, under each state and on the individual state pages)

[Relevant Slack thread](https://covid-tracking.slack.com/archives/CUYAS1M25/p1586199198317900)

We'll need to update the contentful snippet (`dataSummaryFootnote`) for this update as well
----