### PR TITLE
fix: Use github secret for webhook, 1 per hour

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,5 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Trigger Netlify build hook
+      env:
+        NETLIFY_BUILD_HOOK: ${{ secrets.NETLIFY_BUILD_HOOK }}
       run: |
-        curl -X POST -d {} ${{ secrets.NETLIFY_BUILD_HOOK }}
+        curl -X POST -d {} $NETLIFY_BUILD_HOOK

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
-name: Update site
+name: Hourly site build
 
-# Run action three times per hour.
+# Build site once an hour
 on:
   schedule:
-    - cron: "15 * * * *"
+    - cron: "10 * * * *"
 jobs:
   trigger:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,11 +3,11 @@ name: Update site
 # Run action three times per hour.
 on:
   schedule:
-    - cron: "19,39,59 * * * *"
+    - cron: "15 * * * *"
 jobs:
   trigger:
     runs-on: ubuntu-latest
     steps:
     - name: Trigger Netlify build hook
       run: |
-        curl -X POST -d {} https://api.netlify.com/build_hooks/5e6bf671fb5f313507961732
+        curl -X POST -d {} ${{ secrets.NETLIFY_BUILD_HOOK }}


### PR DESCRIPTION
This PR changes our Github Action to use a new Github Secret, `NETLIFY_BUILD_HOOK`

This will help prevent forks from also building the website. Fixes #324 