### PR TITLE
converted US Area chart to use Gatsby data

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9320,7 +9320,8 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "optional": true
         },
         "slice-ansi": {
           "version": "3.0.0",
@@ -13916,7 +13917,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -13937,12 +13939,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -13957,17 +13961,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -14084,7 +14091,8 @@
         "inherits": {
           "version": "2.0.4",
           "resolved": false,
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -14096,6 +14104,7 @@
           "version": "1.0.0",
           "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -14110,6 +14119,7 @@
           "version": "3.0.4",
           "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -14117,12 +14127,14 @@
         "minimist": {
           "version": "1.2.5",
           "resolved": false,
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "resolved": false,
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -14141,6 +14153,7 @@
           "version": "0.5.3",
           "resolved": false,
           "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -14202,7 +14215,8 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
+          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+          "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -14230,7 +14244,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -14242,6 +14257,7 @@
           "version": "1.4.0",
           "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -14319,7 +14335,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": false,
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -14355,6 +14372,7 @@
           "version": "1.0.2",
           "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -14374,6 +14392,7 @@
           "version": "3.0.1",
           "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -14417,12 +14436,14 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "optional": true
         },
         "yallist": {
           "version": "3.1.1",
           "resolved": false,
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "optional": true
         }
       }
     },
@@ -17672,12 +17693,14 @@
         "ansi-regex": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "optional": true
         },
         "ansi-styles": {
           "version": "4.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
           "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "optional": true,
           "requires": {
             "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
@@ -17718,6 +17741,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "optional": true,
           "requires": {
             "color-name": "~1.1.4"
           }
@@ -17725,7 +17749,8 @@
         "color-name": {
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "optional": true
         },
         "emoji-regex": {
           "version": "8.0.0",
@@ -17742,7 +17767,8 @@
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "optional": true
         },
         "mimic-fn": {
           "version": "2.1.0",
@@ -17795,6 +17821,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "optional": true,
           "requires": {
             "ansi-regex": "^5.0.0"
           }

--- a/src/pages/dashboard/_MapContainer.js
+++ b/src/pages/dashboard/_MapContainer.js
@@ -131,10 +131,7 @@ const MapContainer = () => {
       name: 'Deaths',
     },
   ]
-  const togglePlaying = event => {
-    console.log('togglePlaying: ', event)
-    setPlaying(p => !p)
-  }
+  const togglePlaying = () => setPlaying(p => !p)
 
   const toggleMapStyle = () => setUseChoropleth(u => !u)
 

--- a/src/pages/dashboard/_SmallMultiplesAreaCharts.js
+++ b/src/pages/dashboard/_SmallMultiplesAreaCharts.js
@@ -1,7 +1,7 @@
 import { max } from 'd3-array'
 import React, { useMemo } from 'react'
 
-import AreaChart from './_AreaChart'
+import AreaChart from './charts/_AreaChart'
 
 import {
   calculateTotal,

--- a/src/pages/dashboard/_UsAreaChartContainer.js
+++ b/src/pages/dashboard/_UsAreaChartContainer.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import { StaticQuery, graphql } from 'gatsby'
+import AreaChart from './charts/_AreaChart'
+import { parseDate } from './_util'
+
+export default function UsAreaChartContainer() {
+  const transformData = data => {
+    const transformedData = data.allCovidUsDaily.edges
+      .map(({ node }) => [
+        {
+          date: parseDate(node.date),
+          label: 'Total',
+          value: node.totalTestResults,
+        },
+        { date: parseDate(node.date), label: 'Positive', value: node.positive },
+      ])
+      .flat()
+    return transformedData
+  }
+  const query = graphql`
+    {
+      allCovidUsDaily {
+        edges {
+          node {
+            totalTestResults
+            positive
+            date
+          }
+        }
+      }
+    }
+  `
+  return (
+    <StaticQuery
+      query={query}
+      render={data => (
+        <AreaChart
+          data={transformData(data)}
+          fill={d => {
+            if (d === 'Total') return '#585BC1'
+            return '#FFA270'
+          }}
+          height={400}
+          labelOrder={['Total', 'Positive']}
+          marginBottom={40}
+          marginLeft={80}
+          marginRight={10}
+          marginTop={10}
+          xTicks={2}
+          width={400}
+        />
+      )}
+    />
+  )
+}

--- a/src/pages/dashboard/_UsAreaChartContainer.js
+++ b/src/pages/dashboard/_UsAreaChartContainer.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { StaticQuery, graphql } from 'gatsby'
+import { graphql, useStaticQuery } from 'gatsby'
 import AreaChart from './charts/_AreaChart'
 import { parseDate } from './_util'
 
@@ -17,7 +17,7 @@ export default function UsAreaChartContainer() {
       .flat()
     return transformedData
   }
-  const query = graphql`
+  const data = useStaticQuery(graphql`
     {
       allCovidUsDaily {
         edges {
@@ -29,27 +29,22 @@ export default function UsAreaChartContainer() {
         }
       }
     }
-  `
+  `)
   return (
-    <StaticQuery
-      query={query}
-      render={data => (
-        <AreaChart
-          data={transformData(data)}
-          fill={d => {
-            if (d === 'Total') return '#585BC1'
-            return '#FFA270'
-          }}
-          height={400}
-          labelOrder={['Total', 'Positive']}
-          marginBottom={40}
-          marginLeft={80}
-          marginRight={10}
-          marginTop={10}
-          xTicks={2}
-          width={400}
-        />
-      )}
+    <AreaChart
+      data={transformData(data)}
+      fill={d => {
+        if (d === 'Total') return '#585BC1'
+        return '#FFA270'
+      }}
+      height={400}
+      labelOrder={['Total', 'Positive']}
+      marginBottom={40}
+      marginLeft={80}
+      marginRight={10}
+      marginTop={10}
+      xTicks={2}
+      width={400}
     />
   )
 }

--- a/src/pages/dashboard/charts/_AreaChart.js
+++ b/src/pages/dashboard/charts/_AreaChart.js
@@ -6,7 +6,7 @@ import { scaleLinear, scaleTime } from 'd3-scale'
 import { area } from 'd3-shape'
 import React from 'react'
 
-import { formatDate, formatNumber } from './_util'
+import { formatDate, formatNumber } from '../_util'
 
 export default function AreaChart({
   data,

--- a/src/pages/dashboard/index.js
+++ b/src/pages/dashboard/index.js
@@ -3,11 +3,11 @@ import { json } from 'd3-fetch'
 
 import React, { useState, useEffect } from 'react'
 import Layout from '../../components/layout'
-import AreaChart from './_AreaChart'
 import SmallMultiplesAreaCharts from './_SmallMultiplesAreaCharts'
 import MapContainer from './_MapContainer'
 
-import { calculateTotal, parseDate } from './_util'
+import UsAreaChartContainer from './_UsAreaChartContainer'
+import { calculateTotal } from './_util'
 
 import './dashboard.scss'
 
@@ -26,44 +26,15 @@ function groupAndSortStateDaily(data) {
   })
 }
 
-function transformUsDaily(data) {
-  return data
-    .map(d => {
-      const date = parseDate(d.date)
-      return [
-        {
-          date,
-          label: 'Total',
-          value: calculateTotal(d),
-        },
-        {
-          date,
-          label: 'Positive',
-          value: d.positive,
-        },
-      ]
-    })
-    .flat()
-}
-
 const DashboardPage = () => {
-  const [usDaily, setUsDaily] = useState([])
   const [stateDaily, setStateDaily] = useState([])
 
   useEffect(() => {
     async function fetchData() {
-      const usDailyReq = await json('https://covidtracking.com/api/us/daily')
       const stateDailyReq = await json(
         'https://covidtracking.com/api/v1/states/daily.json',
       )
-      const sortedUsDaily = usDailyReq.sort(function sortByDate(a, b) {
-        const aDate = parseDate(a.date)
-        const bDate = parseDate(b.date)
 
-        return aDate - bDate
-      })
-
-      setUsDaily(transformUsDaily(sortedUsDaily))
       setStateDaily(groupAndSortStateDaily(stateDailyReq))
     }
     fetchData()
@@ -71,21 +42,7 @@ const DashboardPage = () => {
 
   return (
     <Layout title="Visual Dashboard">
-      <AreaChart
-        data={usDaily}
-        fill={d => {
-          if (d === 'Total') return '#585BC1'
-          return '#FFA270'
-        }}
-        height={400}
-        labelOrder={['Total', 'Positive']}
-        marginBottom={40}
-        marginLeft={80}
-        marginRight={10}
-        marginTop={10}
-        xTicks={2}
-        width={400}
-      />
+      <UsAreaChartContainer />
       <MapContainer />
       <SmallMultiplesAreaCharts data={stateDaily} />
     </Layout>


### PR DESCRIPTION
first PR converting a chart to using Gatsby data instead of fetching from API.
You can see how much faster the top chart loads than everything below.

For using graphql queries within a component (instead of a page) you must use a `<StaticQuery>` component.  More info can be found [here](https://www.gatsbyjs.org/docs/static-query/).

@kevee would like you to take a look and make sure we've got your vote of confidence before converting the rest of the dashboard using this pattern.