### PR TITLE
fix(visualization): Changed tooltip style for map

### DIFF
--- a/src/pages/dashboard/charts/_Map.js
+++ b/src/pages/dashboard/charts/_Map.js
@@ -118,25 +118,27 @@ export default function Map({
             <BubbleLegend data={data} r={r} maxValue={maxValue} />
           ))}
       </div>
-      <svg width={width} height={height}>
-        {data && (
-          <>
-            {!useChoropleth && (
-              <Bubbles geoJson={data} getValue={getValue} r={r} />
-            )}
-            <States
-              geoJson={data}
-              useChoropleth={useChoropleth}
-              currentDate={currentDate}
-              currentField={currentField}
-              setHoveredState={setHoveredState}
-            />
-          </>
+      <div className="map-contents">
+        <svg width={width} height={height}>
+          {data && (
+            <>
+              {!useChoropleth && (
+                <Bubbles geoJson={data} getValue={getValue} r={r} />
+              )}
+              <States
+                geoJson={data}
+                useChoropleth={useChoropleth}
+                currentDate={currentDate}
+                currentField={currentField}
+                setHoveredState={setHoveredState}
+              />
+            </>
+          )}
+        </svg>
+        {hoveredState && (
+          <Tooltip hoveredState={hoveredState} getValue={getValue} />
         )}
-      </svg>
-      {hoveredState && (
-        <Tooltip hoveredState={hoveredState} getValue={getValue} />
-      )}
+      </div>
     </div>
   )
 }
@@ -166,9 +168,12 @@ const States = ({
       className="countries"
       fill={getColorFromFeature(d)}
       stroke="#ababab"
-      onMouseEnter={event => {
+      onMouseEnter={() => {
         setHoveredState({
-          coordinates: [event.clientX, event.clientY],
+          coordinates: [
+            d.properties.centroidCoordinates[0],
+            d.properties.centroidCoordinates[1],
+          ],
           state: d,
         })
       }}
@@ -269,33 +274,58 @@ const Tooltip = ({ hoveredState, currentDate, getValue }) => {
   return (
     <div id="map-tooltip" style={{ top: y, left: x }}>
       <table>
+        <caption>
+          {d.properties.NAME}
+          <br />
+          <span className="date">{formatDate(parseDate(currentDate))}</span>
+        </caption>
         <thead>
           <tr>
-            <td colSpan="3">
-              {d.properties.NAME}
-              <br />
-              <span className="date">{formatDate(parseDate(currentDate))}</span>
-            </td>
+            <th scope="col">Metric</th>
+            <th scope="col">Total</th>
+            <th scope="col">Per capita*</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td />
-            <td>Total</td>
-            <td>Per capita*</td>
-          </tr>
-          <tr>
-            <td>Tests</td>
+            <th scope="row">
+              <span
+                style={{
+                  display: 'inline',
+                  borderBottom: `2px solid ${colors.totalTestResults}`,
+                }}
+              >
+                Tests
+              </span>
+            </th>
             <td>{formatNumber(totalTestResults)}</td>
             <td>{formatNumber(totalTestResultsNorm)}</td>
           </tr>
           <tr>
-            <td>Positive tests</td>
+            <th scope="col">
+              <span
+                style={{
+                  display: 'inline',
+                  borderBottom: `2px solid ${colors.positive}`,
+                }}
+              >
+                Positive tests
+              </span>
+            </th>
             <td>{formatNumber(positive)}</td>
             <td>{formatNumber(positiveNorm)}</td>
           </tr>
           <tr>
-            <td>Deaths</td>
+            <th scope="col">
+              <span
+                style={{
+                  display: 'inline',
+                  borderBottom: `2px solid ${colors.death}`,
+                }}
+              >
+                Deaths
+              </span>
+            </th>
             <td>{formatNumber(death)}</td>
             <td>{formatNumber(deathNorm)}</td>
           </tr>

--- a/src/pages/dashboard/charts/map.scss
+++ b/src/pages/dashboard/charts/map.scss
@@ -1,47 +1,48 @@
+.map-contents {
+  position: relative;
+}
+
 #map-tooltip {
   background: white;
   pointer-events: none;
-  position: fixed;
-  width: 270px;
+  position: absolute;
+  border: 2px solid #000;
   table {
-    border: 1px solid #333;
+    table-layout: fixed;
+    width: 270px;
     border-collapse: collapse;
     margin: -1px;
   }
-  td {
-    border: 1px solid lightgray;
+  caption {
+    font-size: 16px;
+    padding: 6px 12px;
+    span.date {
+      font-size: 11px;
+      color: gray;
+      text-transform: uppercase;
+    }
+  }
+  td,
+  th {
+    border: 1px solid #000;
     border-collapse: collapse;
+    text-align: center;
+    background: none;
   }
-  thead {
-    td {
-      text-align: left;
-      color: #000;
-      font-weight: 600;
-      margin: 10px 10px;
-      font-size: 18px;
-      span.date {
-        font-size: 14px;
-        color: gray;
-        text-transform: uppercase;
-      }
+  td {
+    font-size: 12px;
+  }
+  th {
+    font-size: 11px;
+    font-weight: bold;
+    white-space: nowrap;
+    span {
+      font-size: 11px;
     }
   }
-
   tbody {
-    td {
-      text-align: center;
-      padding: 2px 4px;
-    }
-    tr:nth-child(1) {
-      background-color: #e8eff6;
-      font-weight: 600;
-    }
-    tr:nth-child(even) {
-      background-color: initial;
-    }
-    td:nth-child(1) {
-      background-color: #e8eff6;
-      font-weight: 600;
+    th {
+      font-size: 11px;
     }
   }
 }


### PR DESCRIPTION
Note that the positioning of the tooltip was also changed in this commit. Previously, the tooltip was `position: fixed`, which caused the tooltip to not scroll with the page. Switched it to absolute + added a new relative div to position it consistently across the choropleth and bubble maps.

fixes issue #353