### PR TITLE
Use GraphQL query for small multiples charts

### DIFF
--- a/src/pages/dashboard/_SmallMultiplesContainer.js
+++ b/src/pages/dashboard/_SmallMultiplesContainer.js
@@ -1,4 +1,6 @@
 import { max } from 'd3-array'
+import { nest } from 'd3-collection'
+import { graphql, useStaticQuery } from 'gatsby'
 import React, { useMemo } from 'react'
 
 import AreaChart from './charts/_AreaChart'
@@ -59,12 +61,56 @@ const stayAtHomeOrders = {
   WI: 20200325,
 }
 
-const SmallMultiplesAreaCharts = ({ data }) => {
+function groupAndSortStateDaily(query) {
+  const data = query.allCovidStateDaily.edges.map(edge => {
+    const { node } = edge
+    return node
+  })
+  const grouped = nest()
+    .key(d => d.state)
+    .sortValues((a, b) => {
+      const aDate = parseDate(a.date)
+      const bDate = parseDate(b.date)
+
+      if (aDate > bDate) return -1
+      if (bDate > aDate) return 1
+      return 0
+    })
+    .entries(data)
+
+  return grouped.sort((a, b) => {
+    const lastA = a.values[0]
+    const lastB = b.values[0]
+
+    const lastATotal = calculateTotal(lastA)
+    const lastBTotal = calculateTotal(lastB)
+    return lastBTotal - lastATotal
+  })
+}
+
+const SmallMultiplesContainer = () => {
+  const query = useStaticQuery(graphql`
+    {
+      allCovidStateDaily {
+        edges {
+          node {
+            date
+            state
+            positive
+            negative
+          }
+        }
+      }
+    }
+  `)
+
+  const data = groupAndSortStateDaily(query)
   const secondMaxTotal = useMemo(() => {
     if (!data[1] && !data[0]) return
     // eslint-disable-next-line consistent-return
     return max(data[1].values, d => calculateTotal(d))
   }, [data.length])
+
   return (
     <div>
       <p>
@@ -172,4 +218,4 @@ const SmallMultiplesAreaCharts = ({ data }) => {
   )
 }
 
-export default SmallMultiplesAreaCharts
+export default SmallMultiplesContainer

--- a/src/pages/dashboard/index.js
+++ b/src/pages/dashboard/index.js
@@ -1,50 +1,17 @@
-import { nest } from 'd3-collection'
-import { json } from 'd3-fetch'
-
-import React, { useState, useEffect } from 'react'
+import React from 'react'
 import Layout from '../../components/layout'
-import SmallMultiplesAreaCharts from './_SmallMultiplesAreaCharts'
 import MapContainer from './_MapContainer'
-
+import SmallMultiplesContainer from './_SmallMultiplesContainer'
 import UsAreaChartContainer from './_UsAreaChartContainer'
-import { calculateTotal } from './_util'
 
 import './dashboard.scss'
 
-function groupAndSortStateDaily(data) {
-  const grouped = nest()
-    .key(d => d.state)
-    .entries(data)
-
-  return grouped.sort((a, b) => {
-    const lastA = a.values[0]
-    const lastB = b.values[0]
-
-    const lastATotal = calculateTotal(lastA)
-    const lastBTotal = calculateTotal(lastB)
-    return lastBTotal - lastATotal
-  })
-}
-
 const DashboardPage = () => {
-  const [stateDaily, setStateDaily] = useState([])
-
-  useEffect(() => {
-    async function fetchData() {
-      const stateDailyReq = await json(
-        'https://covidtracking.com/api/v1/states/daily.json',
-      )
-
-      setStateDaily(groupAndSortStateDaily(stateDailyReq))
-    }
-    fetchData()
-  }, [])
-
   return (
     <Layout title="Visual Dashboard">
       <UsAreaChartContainer />
       <MapContainer />
-      <SmallMultiplesAreaCharts data={stateDaily} />
+      <SmallMultiplesContainer />
     </Layout>
   )
 }


### PR DESCRIPTION
Uses the pattern established in #432 to query the data from the GraphQL API for the small multiples charts, instead of fetching data client side.