### PR TITLE
State jump selector fix

### DIFF
--- a/src/components/pages/data/state-data.js
+++ b/src/components/pages/data/state-data.js
@@ -47,7 +47,7 @@ const State = ({ state }) => (
         }}
       />
     )}
-    <a className="top-link" href="#states-top" title="top">
+    <a className="top-link" href="#reach-skip-nav" title="top">
       ↑ (return to top)
     </a>
   </>

--- a/src/components/pages/data/state-list.js
+++ b/src/components/pages/data/state-list.js
@@ -16,12 +16,7 @@ export default ({ states, stateData }) => {
   return (
     <Flex flexWrap="wrap" m="0 -10px">
       {stateList.map(state => (
-        <Box
-          width={1}
-          mb={['1rem', '1.5rem']}
-          p="0 10px"
-          className="data-state"
-        >
+        <Box width={1} mb={['1rem', '50px']} p="0 10px" className="data-state">
           <State state={state} stateData={state.stateData} />
         </Box>
       ))}

--- a/src/scss/components/pages/data/state-data.scss
+++ b/src/scss/components/pages/data/state-data.scss
@@ -10,8 +10,8 @@
   h3 {
     margin-bottom: 0.5rem;
     @media (min-width: $viewport-md) {
-      margin-top: -70px;
-      padding-top: 70px;
+      margin-top: -50px;
+      padding-top: 50px;
       display: inline-block;
     }
   }


### PR DESCRIPTION
Fixes:

- The jump to top links were pointing to a non-existant anchor
- The crazy margin/padding trick to keep states visible with a fixed header was covering up the back to top link.