### PR TITLE
Updated color set, closes #440

### DIFF
--- a/src/scss/colors.scss
+++ b/src/scss/colors.scss
@@ -1,8 +1,58 @@
 $text: #000;
 
-$color-link: #575aad;
-$color-link--active: #8b8dc7;
-$color-link--hover: #8B8DC7;
+/*
+
+Brand colors
+
+*/
+// Plum
+$color-plum-1: #111354;
+$color-plum-2: #31347A;
+$color-plum-3: #575AAD;
+$color-plum-4: #6164BA;
+$color-plum-5: #8B8DC7;
+$color-plum-6: #B6B7DB;
+$color-plum-7: #D1D1E8;
+$color-plum-8: #F2F2FF;
+
+// Honey
+$color-honey-1: #6E2F1F;
+$color-honey-2: #924F34;
+$color-honey-3: #C66B3E;
+$color-honey-4: #E2894E;
+$color-honey-5: #FFAD4A;
+$color-honey-6: #F6CE7A;
+$color-honey-7: #FBE8A9;
+$color-honey-8: #FCF9EB;
+
+// Blueberry
+$color-blueberry-1: #012656;
+$color-blueberry-2: #004399;
+$color-blueberry-3: #0091EA;
+$color-blueberry-4: #8CC7F4;
+$color-blueberry-5: #E2F1FC;
+
+// Slate
+$color-slate-1: #313638;
+$color-slate-2: #3D4245;
+$color-slate-3: #4C5559;
+$color-slate-4: #5B666B;
+$color-slate-5: #6F7E85;
+$color-slate-6: #849096;
+$color-slate-7: #95A0A6;
+$color-slate-8: #B2BBBF;
+$color-slate-9: #D0D7DB;
+$color-slate-10: #EDF1F2;
+
+
+/*
+
+Color primitives
+
+*/
+$color-link: $color-plum-3;
+$color-link--active: $color-plum-5;
+$color-link--hover: $color-plum-5;
 
 $color-infobox-question-light: #fef9cd;
 $color-infobox-question-dark: #5e4f24;
@@ -13,54 +63,39 @@ $color-infobox-sync-dark: #264a8c;
 $color-infobox-alert-light: #fedcd2;
 $color-infobox-alert-dark: #802509;
 
-//Referred to as "plumb"
-$color-main-darkest: #111354;
-$color-main-dark: #31347a;
-$color-main-mid: #575aad;
-$color-main-light: #8b8dc7;
-$color-main-lightest: #d1d1e8;
-
-//Referred to as "blueberry"
-$color-secondary-darkest: #012656;
-$color-secondary-dark: #004399;
-$color-secondary-mid: #0091ea;
-$color-secondary-light: #8cc7f4;
-$color-secondary-lightest: #e2f1fc;
-
-//Referred to as "slate"
-$color-grey-1: #313638;
-$color-grey-2: #3d4245;
-$color-grey-3: #4c5559;
-$color-grey-4: #5b666b;
-$color-grey-5: #6f7e85;
-$color-grey-6: #849096;
-$color-grey-7: #95a0a6;
-$color-grey-8: #b2bbbf;
-$color-grey-9: #d0d7db;
-$color-grey-10: #edf1f2;
-
 :export {
   text: $text;
   link: $color-link;
   linkActive: $color-link--active;
-  mainDarkest: $color-main-darkest;
-  mainDark: $color-main-dark;
-  mainMid: $color-main-mid;
-  mainLight: $color-main-light;
-  mainLightest: $color-main-lightest;
-  secondaryDarkest: $color-secondary-darkest;
-  secondaryDark: $color-secondary-dark;
-  secondaryMid: $color-secondary-mid;
-  secondaryLight: $color-secondary-light;
-  secondaryLightest: $color-secondary-lightest;
-  grey1: $color-grey-1;
-  grey2: $color-grey-2;
-  grey3: $color-grey-3;
-  grey4: $color-grey-4;
-  grey5: $color-grey-5;
-  grey6: $color-grey-6;
-  grey7: $color-grey-7;
-  grey8: $color-grey-8;
-  grey9: $color-grey-9;
-  grey10: $color-grey-10;
+  colorPlum01: $color-plum-1;
+  colorPlum02: $color-plum-2;
+  colorPlum03: $color-plum-3;
+  colorPlum04: $color-plum-4;
+  colorPlum05: $color-plum-5;
+  colorPlum06: $color-plum-6;
+  colorPlum07: $color-plum-7;
+  colorPlum08: $color-plum-8;
+  colorHoney01: $color-honey-1;
+  colorHoney02: $color-honey-2;
+  colorHoney03: $color-honey-3;
+  colorHoney04: $color-honey-4;
+  colorHoney05: $color-honey-5;
+  colorHoney06: $color-honey-6;
+  colorHoney07: $color-honey-7;
+  colorHoney08: $color-honey-8;
+  colorBlueberry01: $color-blueberry-1;
+  colorBlueberry02: $color-blueberry-2;
+  colorBlueberry03: $color-blueberry-3;
+  colorBlueberry04: $color-blueberry-4;
+  colorBlueberry05: $color-blueberry-5;
+  colorSlate01: $color-slate-1;
+  colorSlate02: $color-slate-2;
+  colorSlate03: $color-slate-3;
+  colorSlate04: $color-slate-4;
+  colorSlate05: $color-slate-5;
+  colorSlate06: $color-slate-6;
+  colorSlate07: $color-slate-7;
+  colorSlate08: $color-slate-8;
+  colorSlate09: $color-slate-9;
+  colorSlate10: $color-slate-10;
 }

--- a/src/scss/components/common/detail-text.scss
+++ b/src/scss/components/common/detail-text.scss
@@ -3,7 +3,7 @@
 .detail-text {
   font-size: 0.8rem;
   margin-bottom: 0.3rem;
-  color: $color-grey-3;
+  color: $color-slate-3;
 }
 
 .dot-separator {

--- a/src/scss/components/footer.scss
+++ b/src/scss/components/footer.scss
@@ -42,7 +42,7 @@ footer {
 
         &:hover,
         &:focus {
-          color: $color-main-lightest;
+          color: $color-plum-7;
         }
         &.footer-return-top {
           font-weight: bold;

--- a/src/scss/components/header.scss
+++ b/src/scss/components/header.scss
@@ -108,11 +108,11 @@
         }
         a:hover,
         a:focus {
-          color: $color-secondary-lightest;
+          color: $color-blueberry-5;
         }
         a:hover,
         a[aria-current] {
-          border-bottom: 3px solid $color-secondary-light;
+          border-bottom: 3px solid $color-blueberry-4;
           padding-bottom: 2px;
         }
         a[aria-current] {
@@ -192,7 +192,7 @@
         list-style-type: none;
         margin: 0;
         text-align: left;
-        background: $color-main-lightest;
+        background: $color-plum-7;
         border-top-right-radius: 5px;
         border-top-left-radius: 5px;
 
@@ -212,7 +212,7 @@
         }
 
         a {
-          color: $color-main-mid;
+          color: $color-plum-3;
           display: block;
           padding: 0.4rem 0.6rem;
           font-size: 0.72rem;

--- a/src/scss/components/hero.scss
+++ b/src/scss/components/hero.scss
@@ -45,22 +45,22 @@
 
       &:hover,
       &:focus {
-        color: $color-secondary-lightest;
+        color: $color-blueberry-5;
       }
     }
 
     .button {
-      background: $color-secondary-light;
+      background: $color-blueberry-4;
       text-decoration: none;
       padding: 1rem 0;
       width: 25%;
       text-align: center;
-      color: $color-secondary-darkest;
+      color: $color-blueberry-1;
       &:hover,
       &:focus,
       &:active {
-        background: $color-secondary-lightest;
-        color: $color-secondary-darkest;
+        background: $color-blueberry-5;
+        color: $color-blueberry-1;
       }
       @media only screen and (max-width: $viewport-sm) {
         width: 100%;

--- a/src/scss/components/pages/homepage/press-logos.scss
+++ b/src/scss/components/pages/homepage/press-logos.scss
@@ -4,7 +4,7 @@
   margin: 1.5rem 0;
   padding: 2rem 0;
   h2 {
-    color: $color-grey-3;
+    color: $color-slate-3;
     font-size: 1rem;
     text-align: center;
     font-variant: all-small-caps;

--- a/src/scss/pages/data.scss
+++ b/src/scss/pages/data.scss
@@ -12,7 +12,7 @@
 }
 
 .top-link {
-  color: $color-grey-4;
+  color: $color-slate-4;
   margin-top: 1.8rem;
   display: inline-block;
 }
@@ -41,7 +41,7 @@ li {
     margin: 0;
   }
   .inner-data-states-header {
-    border-bottom: 2px solid $color-grey-6;
+    border-bottom: 2px solid $color-slate-6;
     width: 100%;
   }
 }
@@ -61,7 +61,7 @@ li {
   }
   input {
     padding: 0.3rem;
-    border: 1px solid $color-grey-4;
+    border: 1px solid $color-slate-4;
   }
 }
 

--- a/src/scss/pages/homepage.scss
+++ b/src/scss/pages/homepage.scss
@@ -14,10 +14,10 @@
 }
 
 .homepage-visualizations-wrapper {
-  background: $color-grey-10;
+  background: $color-slate-10;
   padding: 2rem 0;
-  border-top: 1px solid $color-grey-8;
-  border-bottom: 1px solid $color-grey-8;
+  border-top: 1px solid $color-slate-8;
+  border-bottom: 1px solid $color-slate-8;
 }
 
 .homepage-visualizations {
@@ -48,7 +48,7 @@
 
   .homepage-get-involved-icon {
     flex: 0 0 30px;
-    color: $color-main-dark;
+    color: $color-plum-2;
     font-size: 1.3rem;
   }
   a {

--- a/src/stories/2-components/03-Colors.stories.js
+++ b/src/stories/2-components/03-Colors.stories.js
@@ -93,69 +93,100 @@ export const textColors = () => (
   </>
 )
 
-export const mainColors = () => (
+export const colorsPlum = () => (
   <ColorSwatch
     colors={[
-      colors.mainDarkest,
-      colors.mainDark,
-      colors.mainMid,
-      colors.mainLight,
-      colors.mainLightest,
+      colors.colorPlum01,
+      colors.colorPlum02,
+      colors.colorPlum03,
+      colors.colorPlum04,
+      colors.colorPlum05,
+      colors.colorPlum06,
+      colors.colorPlum07,
+      colors.colorPlum08,
     ]}
     names={[
-      '$color-main-darkest',
-      '$color-main-dark',
-      '$color-main-mid',
-      '$color-main-light',
-      '$color-main-lightest',
+      '$color-plum-1',
+      '$color-plum-2',
+      '$color-plum-3',
+      '$color-plum-4',
+      '$color-plum-5',
+      '$color-plum-6',
+      '$color-plum-7',
+      '$color-plum-8',
     ]}
   />
 )
 
-export const secondaryColors = () => (
+export const colorsHoney = () => (
   <ColorSwatch
     colors={[
-      colors.secondaryDarkest,
-      colors.secondaryDark,
-      colors.secondaryMid,
-      colors.secondaryLight,
-      colors.secondaryLightest,
+      colors.colorHoney01,
+      colors.colorHoney02,
+      colors.colorHoney03,
+      colors.colorHoney04,
+      colors.colorHoney05,
+      colors.colorHoney06,
+      colors.colorHoney07,
+      colors.colorHoney08,
     ]}
     names={[
-      '$color-secondary-darkest',
-      '$color-secondary-dark',
-      '$color-secondary-mid',
-      '$color-secondary-light',
-      '$color-secondary-lightest',
+      '$color-honey-1',
+      '$color-honey-2',
+      '$color-honey-3',
+      '$color-honey-4',
+      '$color-honey-5',
+      '$color-honey-6',
+      '$color-honey-7',
+      '$color-honey-8',
     ]}
   />
 )
 
-export const greys = () => (
+export const colorsBlueberry = () => (
   <ColorSwatch
     colors={[
-      colors.grey1,
-      colors.grey2,
-      colors.grey3,
-      colors.grey4,
-      colors.grey5,
-      colors.grey6,
-      colors.grey7,
-      colors.grey8,
-      colors.grey9,
-      colors.grey10,
+      colors.colorBlueberry01,
+      colors.colorBlueberry02,
+      colors.colorBlueberry03,
+      colors.colorBlueberry04,
+      colors.colorBlueberry05,
     ]}
     names={[
-      '$color-grey-1',
-      '$color-grey-2',
-      '$color-grey-3',
-      '$color-grey-4',
-      '$color-grey-5',
-      '$color-grey-6',
-      '$color-grey-7',
-      '$color-grey-8',
-      '$color-grey-9',
-      '$color-grey-10',
+      '$color-blueberry-1',
+      '$color-blueberry-2',
+      '$color-blueberry-3',
+      '$color-blueberry-4',
+      '$color-blueberry-5',
+    ]}
+  />
+)
+
+export const colorsSlate = () => (
+  <ColorSwatch
+    colors={[
+      colors.colorSlate01,
+      colors.colorSlate02,
+      colors.colorSlate03,
+      colors.colorSlate04,
+      colors.colorSlate05,
+      colors.colorSlate06,
+      colors.colorSlate07,
+      colors.colorSlate08,
+      colors.colorSlate09,
+      colors.colorSlate10,
+    ]}
+    names={[
+      '$color-slate-1',
+      '$color-slate-2',
+      '$color-slate-3',
+      '$color-slate-4',
+      '$color-slate-5',
+      '$color-slate-6',
+      '$color-slate-7',
+      '$color-slate-8',
+      '$color-slate-9',
+      '$color-slate-10',
     ]}
   />
 )


### PR DESCRIPTION
This PR now includes [our updated (and _lovely_) color set](https://github.com/COVID19Tracking/website/issues/440#issue-596634505)! Specifically:

- In https://github.com/COVID19Tracking/website/compare/beep/440-colors?expand=1#diff-29f0bd10a1e22baf2f9585a9ae897e4fR3-R45 I’m proposing we adopt a `$color-[name]-[number]` naming convention, where the `[name]`s are borrowed from the actual color names in the palette. (So `$color-plum-3` instead of `$color-main-mid`, and `$color-slate-4` instead of `$color-grey-4`.)
- The exported color variables in https://github.com/COVID19Tracking/website/compare/beep/440-colors?expand=1#diff-29f0bd10a1e22baf2f9585a9ae897e4fR70-R100 follow a similar convention, but camelCase’d!
- References to the old color names have been updated, as have the references in Storybook.

Feedback welcome!