### PR TITLE
fix(choropleth): update color schemes

### DIFF
--- a/src/pages/dashboard/charts/_Map.js
+++ b/src/pages/dashboard/charts/_Map.js
@@ -4,7 +4,6 @@ import { format } from 'd3-format'
 import { geoPath, geoAlbersUsa } from 'd3-geo'
 import { max } from 'd3-array'
 import { scaleSqrt, scaleThreshold } from 'd3-scale'
-import { schemeGreys, schemePurples } from 'd3-scale-chromatic'
 
 import { formatNumber, formatDate, parseDate } from '../_utils'
 import StatesWithPopulation from '../data/_state-populations'
@@ -59,7 +58,7 @@ const colorLimits = {
   totalTestResults: [250, 500, 1000, 2500, 5000, 10000, 25000],
 }
 
-const customSchemeOranges = [
+const customSchemeHoney = [
   '#fcf9eb',
   '#fbe8a9',
   '#f6ce7a',
@@ -70,33 +69,42 @@ const customSchemeOranges = [
   '#753c2d',
 ]
 
-/*
-const mapColorScale = [
-  '#E5A968',
-  '#ED9C42',
-  '#DC8C3A',
-  '#CA7B32',
-  '#B96A2A',
-  '#A75922',
-  '#96491A',
-  '#843812',
+const customSchemePlum = [
+  '#f2f2ff',
+  '#d1d1e8',
+  '#b6b7db',
+  '#8b8dc7',
+  '#6164ba',
+  '#575aad',
+  '#31347a',
+  '#111354',
 ]
-*/
+
+const customSchemeGrey = [
+  '#d0d7db',
+  '#b2bbbf',
+  '#95a0a6',
+  '#849096',
+  '#6f7e85',
+  '#5b666b',
+  '#4c5559',
+  '#3d4245',
+]
 
 const getColor = {
-  death: scaleThreshold(colorLimits.death, schemeGreys[8]),
-  positive: scaleThreshold(colorLimits.positive, customSchemeOranges),
+  death: scaleThreshold(colorLimits.death, customSchemeGrey),
+  positive: scaleThreshold(colorLimits.positive, customSchemeHoney),
   totalTestResults: scaleThreshold(
     colorLimits.totalTestResults,
-    schemePurples[8],
+    customSchemePlum,
   ),
 }
 
 // should be imported from constants file
 const colors = {
-  totalTestResults: '#696DC2',
-  positive: '#E5A968',
-  death: '#404856',
+  totalTestResults: customSchemePlum[5],
+  positive: customSchemeHoney[4],
+  death: customSchemeGrey[6],
 }
 
 export default function Map({ data, currentField, getValue, useChoropleth }) {


### PR DESCRIPTION
Uses new custom color schemes for total test results and death maps.

### Positive

![choropleth-positive](https://user-images.githubusercontent.com/63169602/78837576-5f6fcc00-79c2-11ea-8720-dbf58fc2e86e.jpg)

### Totals

![choropleth-total](https://user-images.githubusercontent.com/63169602/78837591-6696da00-79c2-11ea-9ff6-507297946746.jpg)

### Deaths

![choropleth-deaths](https://user-images.githubusercontent.com/63169602/78837599-6ac2f780-79c2-11ea-84ef-0076ae666bc5.jpg)

Fixes COVIDTracking/website#349