### PR TITLE
feat: Centralize formatting functions into components, also, date formatting

### DIFF
--- a/src/components/common/format.js
+++ b/src/components/common/format.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { DateTime } from 'luxon'
+
+const FormatDate = ({ date, format = 'ccc LLLL d yyyy' }) => {
+  if (typeof date === 'undefined') {
+    return null
+  }
+  return <>{DateTime.fromISO(date).toFormat(format)}</>
+}
+
+const FormatNumber = ({ number }) => (
+  <>
+    {number ? number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',') : 'N/A'}
+  </>
+)
+
+export { FormatDate, FormatNumber }

--- a/src/components/common/format.js
+++ b/src/components/common/format.js
@@ -9,9 +9,7 @@ const FormatDate = ({ date, format = 'ccc LLLL d yyyy' }) => {
 }
 
 const FormatNumber = ({ number }) => (
-  <>
-    {number ? number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',') : 'N/A'}
-  </>
+  <>{number || number === 0 ? number.toLocaleString() : 'N/A'}</>
 )
 
 export { FormatDate, FormatNumber }

--- a/src/components/common/summary-table.js
+++ b/src/components/common/summary-table.js
@@ -61,44 +61,44 @@ export default ({ data, lastUpdated, showOutcomes = true }) => (
     <tbody>
       <tr>
         <td>
-          <FormatNumber FormatNumber={data.positive} />
+          <FormatNumber number={data.positive} />
         </td>
         <td>
-          <FormatNumber FormatNumber={data.negative} />
+          <FormatNumber number={data.negative} />
         </td>
         <td>
-          <FormatNumber FormatNumber={data.pending} />
+          <FormatNumber number={data.pending} />
         </td>
         {showOutcomes && (
           <>
             <td>
-              <FormatNumber FormatNumber={data.hospitalizedCurrently} />
+              <FormatNumber number={data.hospitalizedCurrently} />
             </td>
             <td>
-              <FormatNumber FormatNumber={data.hospitalizedCumulative} />
+              <FormatNumber number={data.hospitalizedCumulative} />
             </td>
             <td>
-              <FormatNumber FormatNumber={data.inIcuCurrently} />
+              <FormatNumber number={data.inIcuCurrently} />
             </td>
             <td>
-              <FormatNumber FormatNumber={data.inIcuCumulative} />
+              <FormatNumber number={data.inIcuCumulative} />
             </td>
             <td>
-              <FormatNumber FormatNumber={data.onVentilatorCurrently} />
+              <FormatNumber number={data.onVentilatorCurrently} />
             </td>
             <td>
-              <FormatNumber FormatNumber={data.onVentilatorCumulative} />
+              <FormatNumber number={data.onVentilatorCumulative} />
             </td>
             <td>
-              <FormatNumber FormatNumber={data.recovered} />
+              <FormatNumber number={data.recovered} />
             </td>
           </>
         )}
         <td>
-          <FormatNumber FormatNumber={data.death} />
+          <FormatNumber number={data.death} />
         </td>
         <td>
-          <FormatNumber FormatNumber={data.totalTestResults} />
+          <FormatNumber number={data.totalTestResults} />
         </td>
       </tr>
     </tbody>

--- a/src/components/common/summary-table.js
+++ b/src/components/common/summary-table.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import Table from './table'
-import thousands from '../../utilities/format-thousands'
+import { FormatNumber } from './format'
 
 export default ({ data, lastUpdated, showOutcomes = true }) => (
   <Table tableLabel={lastUpdated && `Last updated: ${lastUpdated} ET`}>
@@ -60,43 +60,45 @@ export default ({ data, lastUpdated, showOutcomes = true }) => (
     </thead>
     <tbody>
       <tr>
-        <td>{data.positive ? thousands(data.positive) : 'N/A'}</td>
-        <td>{data.negative ? thousands(data.negative) : 'N/A'}</td>
-        <td>{data.pending ? thousands(data.pending) : 'N/A'}</td>
+        <td>
+          <FormatNumber FormatNumber={data.positive} />
+        </td>
+        <td>
+          <FormatNumber FormatNumber={data.negative} />
+        </td>
+        <td>
+          <FormatNumber FormatNumber={data.pending} />
+        </td>
         {showOutcomes && (
           <>
             <td>
-              {data.hospitalizedCurrently
-                ? thousands(data.hospitalizedCurrently)
-                : 'N/A'}
+              <FormatNumber FormatNumber={data.hospitalizedCurrently} />
             </td>
             <td>
-              {data.hospitalizedCumulative
-                ? thousands(data.hospitalizedCumulative)
-                : 'N/A'}
+              <FormatNumber FormatNumber={data.hospitalizedCumulative} />
             </td>
             <td>
-              {data.inIcuCurrently ? thousands(data.inIcuCurrently) : 'N/A'}
+              <FormatNumber FormatNumber={data.inIcuCurrently} />
             </td>
             <td>
-              {data.inIcuCumulative ? thousands(data.inIcuCumulative) : 'N/A'}
+              <FormatNumber FormatNumber={data.inIcuCumulative} />
             </td>
             <td>
-              {data.onVentilatorCurrently
-                ? thousands(data.onVentilatorCurrently)
-                : 'N/A'}
+              <FormatNumber FormatNumber={data.onVentilatorCurrently} />
             </td>
             <td>
-              {data.onVentilatorCumulative
-                ? thousands(data.onVentilatorCumulative)
-                : 'N/A'}
+              <FormatNumber FormatNumber={data.onVentilatorCumulative} />
             </td>
-            <td>{data.recovered ? thousands(data.recovered) : 'N/A'}</td>
+            <td>
+              <FormatNumber FormatNumber={data.recovered} />
+            </td>
           </>
         )}
-        <td>{data.death ? thousands(data.death) : 'N/A'}</td>
         <td>
-          {data.totalTestResults ? thousands(data.totalTestResults) : 'N/A'}
+          <FormatNumber FormatNumber={data.death} />
+        </td>
+        <td>
+          <FormatNumber FormatNumber={data.totalTestResults} />
         </td>
       </tr>
     </tbody>

--- a/src/components/pages/state/state-history.js
+++ b/src/components/pages/state/state-history.js
@@ -1,8 +1,7 @@
 import React from 'react'
 import Screenshots from './screenshots'
 import Table from '../../common/table'
-import formatDate from '../../../utilities/format-date'
-import thousands from '../../../utilities/format-thousands'
+import { FormatNumber, FormatDate } from '../../common/format'
 import stateHistoryStyle from './state-history.module.scss'
 
 export default ({ history, screenshots }) => (
@@ -22,16 +21,30 @@ export default ({ history, screenshots }) => (
     <tbody className={`state-history-table ${stateHistoryStyle.history}`}>
       {history.map(({ node }) => (
         <tr key={`history-${node.dateChecked}`}>
-          <td>{formatDate(node.dateChecked)}</td>
+          <td>
+            <FormatDate date={node.dateChecked} />
+          </td>
           <td>
             <Screenshots date={node.dateChecked} screenshots={screenshots} />
           </td>
-          <td>{thousands(node.positive)}</td>
-          <td>{thousands(node.negative)}</td>
-          <td>{thousands(node.pending)}</td>
-          <td>{thousands(node.hospitalized)}</td>
-          <td>{thousands(node.death)}</td>
-          <td>{thousands(node.totalTestResults)}</td>
+          <td>
+            <FormatNumber FormatNumber={node.positive} />
+          </td>
+          <td>
+            <FormatNumber FormatNumber={node.negative} />
+          </td>
+          <td>
+            <FormatNumber FormatNumber={node.pending} />
+          </td>
+          <td>
+            <FormatNumber FormatNumber={node.hospitalized} />
+          </td>
+          <td>
+            <FormatNumber FormatNumber={node.death} />
+          </td>
+          <td>
+            <FormatNumber FormatNumber={node.totalTestResults} />
+          </td>
         </tr>
       ))}
     </tbody>

--- a/src/components/pages/state/state-history.js
+++ b/src/components/pages/state/state-history.js
@@ -28,22 +28,22 @@ export default ({ history, screenshots }) => (
             <Screenshots date={node.dateChecked} screenshots={screenshots} />
           </td>
           <td>
-            <FormatNumber FormatNumber={node.positive} />
+            <FormatNumber number={node.positive} />
           </td>
           <td>
-            <FormatNumber FormatNumber={node.negative} />
+            <FormatNumber number={node.negative} />
           </td>
           <td>
-            <FormatNumber FormatNumber={node.pending} />
+            <FormatNumber number={node.pending} />
           </td>
           <td>
-            <FormatNumber FormatNumber={node.hospitalized} />
+            <FormatNumber number={node.hospitalized} />
           </td>
           <td>
-            <FormatNumber FormatNumber={node.death} />
+            <FormatNumber number={node.death} />
           </td>
           <td>
-            <FormatNumber FormatNumber={node.totalTestResults} />
+            <FormatNumber number={node.totalTestResults} />
           </td>
         </tr>
       ))}

--- a/src/pages/data/us-daily.js
+++ b/src/pages/data/us-daily.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import { graphql } from 'gatsby'
-import { DateTime } from 'luxon'
 import Layout from '../../components/layout'
 import { FormatDate, FormatNumber } from '../../components/common/format'
 import { SyncInfobox } from '../../components/common/infobox'
@@ -39,9 +38,7 @@ const ContentPage = ({ data }) => (
         {data.allCovidUsDaily.edges.map(({ node }) => (
           <tr>
             <td>
-              <FormatDate
-                date={DateTime.fromFormat(node.date.toString(), 'yyyyMMdd')}
-              />
+              <FormatDate date={node.date} />
             </td>
             <td>{node.states}</td>
             <td>

--- a/src/pages/data/us-daily.js
+++ b/src/pages/data/us-daily.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import { DateTime } from 'luxon'
 import Layout from '../../components/layout'
+import { FormatDate, FormatNumber } from '../../components/common/format'
 import { SyncInfobox } from '../../components/common/infobox'
 import Table from '../../components/common/table'
 
@@ -38,17 +39,29 @@ const ContentPage = ({ data }) => (
         {data.allCovidUsDaily.edges.map(({ node }) => (
           <tr>
             <td>
-              {DateTime.fromFormat(node.date.toString(), 'yyyyMMdd').toFormat(
-                'dd LLL yyyy ccc',
-              )}
+              <FormatDate
+                date={DateTime.fromFormat(node.date.toString(), 'yyyyMMdd')}
+              />
             </td>
             <td>{node.states}</td>
-            <td>{node.positive.toLocaleString()}</td>
-            <td>{node.negative.toLocaleString()}</td>
-            <td>{(node.positive + node.negative).toLocaleString()}</td>
-            <td>{node.pending.toLocaleString()}</td>
-            <td>{node.death ? node.death.toLocaleString() : 'N/A'}</td>
-            <td>{node.totalTestResults.toLocaleString()}</td>
+            <td>
+              <FormatNumber number={node.positive} />
+            </td>
+            <td>
+              <FormatNumber number={node.negative} />
+            </td>
+            <td>
+              <FormatNumber number={node.positive + node.negative} />
+            </td>
+            <td>
+              <FormatNumber number={node.pending} />
+            </td>
+            <td>
+              <FormatNumber number={node.death} />
+            </td>
+            <td>
+              <FormatNumber number={node.totalTestResults} />
+            </td>
           </tr>
         ))}
       </tbody>

--- a/src/stories/2-components/02-Typography.stories.js
+++ b/src/stories/2-components/02-Typography.stories.js
@@ -5,6 +5,7 @@ import {
   OrderedList,
   UnstyledList,
 } from '../../components/common/lists'
+import { FormatDate, FormatNumber } from '../../components/common/format'
 
 const sampleText = `Testing is a crucial part of any public health response, 
 and sharing test data is essential to understanding this outbreak. The CDC is 
@@ -106,3 +107,43 @@ unstyledList.story = {
 }
 
 export const leadParagraph = () => <LeadParagraph>{sampleText}</LeadParagraph>
+
+export const numberFormat = () => (
+  <>
+    <p>
+      <strong>Number:</strong> <FormatNumber number={13022} />
+    </p>
+    <p>
+      <strong>Number:</strong> <FormatNumber number={false} />
+    </p>
+  </>
+)
+
+numberFormat.story = {
+  parameters: {
+    info: {
+      text:
+        'Use the FormatNumber component to add commas to "thousands" and use a default palceholder if the number doesn\'t exist.',
+    },
+  },
+}
+
+export const dateFormat = () => (
+  <>
+    <p>
+      <strong>Without defined format:</strong> <FormatDate date={20200101} />
+    </p>
+    <p>
+      <strong>With the format "yyyy MM d":</strong>{' '}
+      <FormatDate date={20200101} format="yyyy MM d" />
+    </p>
+  </>
+)
+
+dateFormat.story = {
+  parameters: {
+    info: {
+      text: `Use the DateFormat component to consistently format dates. We use [Luxon to format dates](https://moment.github.io/luxon/docs/manual/formatting.html#table-of-tokens)`,
+    },
+  },
+}

--- a/src/utilities/format-date.js
+++ b/src/utilities/format-date.js
@@ -1,8 +1,0 @@
-import { DateTime } from 'luxon'
-
-export default (date, format = 'dd LLL yyyy ccc') => {
-  if (typeof date === 'undefined') {
-    return ''
-  }
-  return DateTime.fromISO(date).toFormat(format)
-}

--- a/src/utilities/format-thousands.js
+++ b/src/utilities/format-thousands.js
@@ -1,2 +1,0 @@
-export default number =>
-  number ? number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',') : number


### PR DESCRIPTION
Fixes #458 

This PR:

- Moves the `formatDate` and `thousands` utilities to regular React components
- Makes numbers default to 'N/A' if not available so you don't have to have ternary operators all over the place
- Uses a more readable default date format