### PR TITLE
Tweaking the color naming scheme (closes #460, closes #465)

### DIFF
--- a/src/components/common/detail-text.module.scss
+++ b/src/components/common/detail-text.module.scss
@@ -3,5 +3,5 @@
 .detail-text {
   font-size: 0.8rem;
   margin-bottom: 0.3rem;
-  color: $color-slate-3;
+  color: $color-slate-800;
 }

--- a/src/components/common/detail-text.module.scss
+++ b/src/components/common/detail-text.module.scss
@@ -3,5 +3,5 @@
 .detail-text {
   font-size: 0.8rem;
   margin-bottom: 0.3rem;
-  color: $color-slate-800;
+  color: $color-slate-700;
 }

--- a/src/components/layout/footer.module.scss
+++ b/src/components/layout/footer.module.scss
@@ -46,7 +46,7 @@
 
         &:hover,
         &:focus {
-          color: $color-plum-7;
+          color: $color-plum-200;
         }
       }
     }

--- a/src/components/layout/header.module.scss
+++ b/src/components/layout/header.module.scss
@@ -108,11 +108,11 @@
         }
         a:hover,
         a:focus {
-          color: $color-blueberry-5;
+          color: $color-blueberry-100;
         }
         a:hover,
         a[aria-current] {
-          border-bottom: 3px solid $color-blueberry-4;
+          border-bottom: 3px solid $color-blueberry-200;
           padding-bottom: 2px;
         }
         a[aria-current] {
@@ -192,7 +192,7 @@
         list-style-type: none;
         margin: 0;
         text-align: left;
-        background: $color-plum-7;
+        background: $color-plum-200;
         border-top-right-radius: 5px;
         border-top-left-radius: 5px;
 
@@ -212,7 +212,7 @@
         }
 
         a {
-          color: $color-plum-3;
+          color: $color-plum-600;
           display: block;
           padding: 0.4rem 0.6rem;
           font-size: 0.72rem;

--- a/src/components/layout/hero.module.scss
+++ b/src/components/layout/hero.module.scss
@@ -45,22 +45,22 @@
 
       &:hover,
       &:focus {
-        color: $color-blueberry-5;
+        color: $color-blueberry-100;
       }
     }
 
     .button {
-      background: $color-blueberry-4;
+      background: $color-blueberry-200;
       text-decoration: none;
       padding: 1rem 0;
       width: 25%;
       text-align: center;
-      color: $color-blueberry-1;
+      color: $color-blueberry-500;
       &:hover,
       &:focus,
       &:active {
-        background: $color-blueberry-5;
-        color: $color-blueberry-1;
+        background: $color-blueberry-100;
+        color: $color-blueberry-500;
       }
       @media only screen and (max-width: $viewport-sm) {
         width: 100%;

--- a/src/components/pages/data/state-data.module.scss
+++ b/src/components/pages/data/state-data.module.scss
@@ -31,7 +31,7 @@
 }
 
 .top-link {
-  color: $color-slate-4;
+  color: $color-slate-700;
   margin-top: 1.8rem;
   display: inline-block;
 }

--- a/src/components/pages/data/state-data.module.scss
+++ b/src/components/pages/data/state-data.module.scss
@@ -31,7 +31,7 @@
 }
 
 .top-link {
-  color: $color-slate-700;
+  color: $color-slate-600;
   margin-top: 1.8rem;
   display: inline-block;
 }

--- a/src/components/pages/data/state-nav.module.scss
+++ b/src/components/pages/data/state-nav.module.scss
@@ -16,7 +16,7 @@
   }
   input {
     padding: 0.3rem;
-    border: 1px solid $color-slate-4;
+    border: 1px solid $color-slate-700;
   }
 }
 

--- a/src/components/pages/data/state-nav.module.scss
+++ b/src/components/pages/data/state-nav.module.scss
@@ -16,7 +16,7 @@
   }
   input {
     padding: 0.3rem;
-    border: 1px solid $color-slate-700;
+    border: 1px solid $color-slate-600;
   }
 }
 

--- a/src/components/pages/homepage/visualizations.module.scss
+++ b/src/components/pages/homepage/visualizations.module.scss
@@ -1,10 +1,10 @@
 @import '../../../scss/colors.scss';
 
 .visualizations-wrapper {
-  background: $color-slate-10;
+  background: $color-slate-100;
   padding: 2rem 0;
-  border-top: 1px solid $color-slate-8;
-  border-bottom: 1px solid $color-slate-8;
+  border-top: 1px solid $color-slate-300;
+  border-bottom: 1px solid $color-slate-300;
 }
 
 .visualization {

--- a/src/pages/data/index.module.scss
+++ b/src/pages/data/index.module.scss
@@ -23,7 +23,7 @@
     margin: 0;
   }
   .state-nav-inner {
-    border-bottom: 2px solid $color-slate-6;
+    border-bottom: 2px solid $color-slate-500;
     width: 100%;
   }
 }

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -40,7 +40,7 @@
   margin: 1.5rem 0;
   padding: 2rem 0;
   h2 {
-    color: $color-slate-800;
+    color: $color-slate-700;
     font-size: 1rem;
     text-align: center;
     font-variant: all-small-caps;

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -28,7 +28,7 @@
 
   .get-involved-icon {
     flex: 0 0 30px;
-    color: $color-plum-2;
+    color: $color-plum-700;
     font-size: 1.3rem;
   }
   a {
@@ -40,7 +40,7 @@
   margin: 1.5rem 0;
   padding: 2rem 0;
   h2 {
-    color: $color-slate-3;
+    color: $color-slate-800;
     font-size: 1rem;
     text-align: center;
     font-variant: all-small-caps;

--- a/src/scss/colors.scss
+++ b/src/scss/colors.scss
@@ -34,15 +34,13 @@ $color-blueberry-500: #012656;
 
 // Slate
 $color-slate-100: #EDF1F2;
-$color-slate-200: #D0D7DB;
-$color-slate-300: #B2BBBF;
-$color-slate-400: #95A0A6;
-$color-slate-500: #849096;
-$color-slate-600: #6F7E85;
-$color-slate-700: #5B666B;
-$color-slate-800: #4C5559;
-$color-slate-900: #3D4245;
-$color-slate-1000: #313638;
+$color-slate-200: #D2D6D7;
+$color-slate-300: #B7BCBD;
+$color-slate-400: #9CA1A2;
+$color-slate-500: #828688;
+$color-slate-600: #676B6D;
+$color-slate-700: #4C5153;
+$color-slate-800: #313638;
 
 
 /*
@@ -96,6 +94,4 @@ $color-infobox-alert-dark: #802509;
   colorSlate600: $color-slate-600;
   colorSlate700: $color-slate-700;
   colorSlate800: $color-slate-800;
-  colorSlate900: $color-slate-900;
-  colorSlate1000: $color-slate-1000;
 }

--- a/src/scss/colors.scss
+++ b/src/scss/colors.scss
@@ -6,14 +6,14 @@ Brand colors
 
 */
 // Plum
-$color-plum-1: #111354;
-$color-plum-2: #31347A;
-$color-plum-3: #575AAD;
-$color-plum-4: #6164BA;
-$color-plum-5: #8B8DC7;
-$color-plum-6: #B6B7DB;
-$color-plum-7: #D1D1E8;
-$color-plum-8: #F2F2FF;
+$color-plum-100: #F2F2FF;
+$color-plum-200: #D1D1E8;
+$color-plum-300: #B6B7DB;
+$color-plum-400: #8B8DC7;
+$color-plum-500: #6164BA;
+$color-plum-600: #575AAD;
+$color-plum-700: #31347A;
+$color-plum-800: #111354;
 
 // Honey
 $color-honey-1: #6E2F1F;
@@ -26,23 +26,23 @@ $color-honey-7: #FBE8A9;
 $color-honey-8: #FCF9EB;
 
 // Blueberry
-$color-blueberry-1: #012656;
-$color-blueberry-2: #004399;
-$color-blueberry-3: #0091EA;
-$color-blueberry-4: #8CC7F4;
-$color-blueberry-5: #E2F1FC;
+$color-blueberry-100: #E2F1FC;
+$color-blueberry-200: #8CC7F4;
+$color-blueberry-300: #0091EA;
+$color-blueberry-400: #004399;
+$color-blueberry-500: #012656;
 
 // Slate
-$color-slate-1: #313638;
-$color-slate-2: #3D4245;
-$color-slate-3: #4C5559;
-$color-slate-4: #5B666B;
-$color-slate-5: #6F7E85;
-$color-slate-6: #849096;
-$color-slate-7: #95A0A6;
-$color-slate-8: #B2BBBF;
-$color-slate-9: #D0D7DB;
-$color-slate-10: #EDF1F2;
+$color-slate-100: #EDF1F2;
+$color-slate-200: #D0D7DB;
+$color-slate-300: #B2BBBF;
+$color-slate-400: #95A0A6;
+$color-slate-500: #849096;
+$color-slate-600: #6F7E85;
+$color-slate-700: #5B666B;
+$color-slate-800: #4C5559;
+$color-slate-900: #3D4245;
+$color-slate-1000: #313638;
 
 
 /*
@@ -50,9 +50,9 @@ $color-slate-10: #EDF1F2;
 Color primitives
 
 */
-$color-link: $color-plum-3;
-$color-link--active: $color-plum-5;
-$color-link--hover: $color-plum-5;
+$color-link: $color-plum-600;
+$color-link--active: $color-plum-400;
+$color-link--hover: $color-plum-400;
 
 $color-infobox-question-light: #fef9cd;
 $color-infobox-question-dark: #5e4f24;
@@ -67,35 +67,35 @@ $color-infobox-alert-dark: #802509;
   text: $text;
   link: $color-link;
   linkActive: $color-link--active;
-  colorPlum01: $color-plum-1;
-  colorPlum02: $color-plum-2;
-  colorPlum03: $color-plum-3;
-  colorPlum04: $color-plum-4;
-  colorPlum05: $color-plum-5;
-  colorPlum06: $color-plum-6;
-  colorPlum07: $color-plum-7;
-  colorPlum08: $color-plum-8;
-  colorHoney01: $color-honey-1;
-  colorHoney02: $color-honey-2;
-  colorHoney03: $color-honey-3;
-  colorHoney04: $color-honey-4;
-  colorHoney05: $color-honey-5;
-  colorHoney06: $color-honey-6;
-  colorHoney07: $color-honey-7;
-  colorHoney08: $color-honey-8;
-  colorBlueberry01: $color-blueberry-1;
-  colorBlueberry02: $color-blueberry-2;
-  colorBlueberry03: $color-blueberry-3;
-  colorBlueberry04: $color-blueberry-4;
-  colorBlueberry05: $color-blueberry-5;
-  colorSlate01: $color-slate-1;
-  colorSlate02: $color-slate-2;
-  colorSlate03: $color-slate-3;
-  colorSlate04: $color-slate-4;
-  colorSlate05: $color-slate-5;
-  colorSlate06: $color-slate-6;
-  colorSlate07: $color-slate-7;
-  colorSlate08: $color-slate-8;
-  colorSlate09: $color-slate-9;
-  colorSlate10: $color-slate-10;
+  colorPlum100: $color-plum-100;
+  colorPlum200: $color-plum-200;
+  colorPlum300: $color-plum-300;
+  colorPlum400: $color-plum-400;
+  colorPlum500: $color-plum-500;
+  colorPlum600: $color-plum-600;
+  colorPlum700: $color-plum-700;
+  colorPlum800: $color-plum-800;
+  colorHoney800: $color-honey-1;
+  colorHoney700: $color-honey-2;
+  colorHoney600: $color-honey-3;
+  colorHoney500: $color-honey-4;
+  colorHoney400: $color-honey-5;
+  colorHoney300: $color-honey-6;
+  colorHoney200: $color-honey-7;
+  colorHoney100: $color-honey-8;
+  colorBlueberry100: $color-blueberry-100;
+  colorBlueberry200: $color-blueberry-200;
+  colorBlueberry300: $color-blueberry-300;
+  colorBlueberry400: $color-blueberry-400;
+  colorBlueberry500: $color-blueberry-500;
+  colorSlate100: $color-slate-100;
+  colorSlate200: $color-slate-200;
+  colorSlate300: $color-slate-300;
+  colorSlate400: $color-slate-400;
+  colorSlate500: $color-slate-500;
+  colorSlate600: $color-slate-600;
+  colorSlate700: $color-slate-700;
+  colorSlate800: $color-slate-800;
+  colorSlate900: $color-slate-900;
+  colorSlate1000: $color-slate-1000;
 }

--- a/src/scss/colors.scss
+++ b/src/scss/colors.scss
@@ -16,14 +16,14 @@ $color-plum-700: #31347A;
 $color-plum-800: #111354;
 
 // Honey
-$color-honey-1: #6E2F1F;
-$color-honey-2: #924F34;
-$color-honey-3: #C66B3E;
-$color-honey-4: #E2894E;
-$color-honey-5: #FFAD4A;
-$color-honey-6: #F6CE7A;
-$color-honey-7: #FBE8A9;
-$color-honey-8: #FCF9EB;
+$color-honey-100: #FCF9EB;
+$color-honey-200: #FBE8A9;
+$color-honey-300: #F6CE7A;
+$color-honey-400: #FFAD4A;
+$color-honey-500: #E2894E;
+$color-honey-600: #C66B3E;
+$color-honey-700: #924F34;
+$color-honey-800: #6E2F1F;
 
 // Blueberry
 $color-blueberry-100: #E2F1FC;
@@ -75,14 +75,14 @@ $color-infobox-alert-dark: #802509;
   colorPlum600: $color-plum-600;
   colorPlum700: $color-plum-700;
   colorPlum800: $color-plum-800;
-  colorHoney800: $color-honey-1;
-  colorHoney700: $color-honey-2;
-  colorHoney600: $color-honey-3;
-  colorHoney500: $color-honey-4;
-  colorHoney400: $color-honey-5;
-  colorHoney300: $color-honey-6;
-  colorHoney200: $color-honey-7;
-  colorHoney100: $color-honey-8;
+  colorHoney100: $color-honey-100;
+  colorHoney200: $color-honey-200;
+  colorHoney300: $color-honey-300;
+  colorHoney400: $color-honey-400;
+  colorHoney500: $color-honey-500;
+  colorHoney600: $color-honey-600;
+  colorHoney700: $color-honey-700;
+  colorHoney800: $color-honey-800;
   colorBlueberry100: $color-blueberry-100;
   colorBlueberry200: $color-blueberry-200;
   colorBlueberry300: $color-blueberry-300;

--- a/src/stories/2-components/03-Colors.stories.js
+++ b/src/stories/2-components/03-Colors.stories.js
@@ -173,8 +173,6 @@ export const colorsSlate = () => (
       colors.colorSlate600,
       colors.colorSlate700,
       colors.colorSlate800,
-      colors.colorSlate900,
-      colors.colorSlate1000,
     ]}
     names={[
       '$color-slate-100',
@@ -185,8 +183,6 @@ export const colorsSlate = () => (
       '$color-slate-600',
       '$color-slate-700',
       '$color-slate-800',
-      '$color-slate-900',
-      '$color-slate-1000',
     ]}
   />
 )

--- a/src/stories/2-components/03-Colors.stories.js
+++ b/src/stories/2-components/03-Colors.stories.js
@@ -131,14 +131,14 @@ export const colorsHoney = () => (
       colors.colorHoney800,
     ]}
     names={[
-      '$color-honey-1',
-      '$color-honey-2',
-      '$color-honey-3',
-      '$color-honey-4',
-      '$color-honey-5',
-      '$color-honey-6',
-      '$color-honey-7',
-      '$color-honey-8',
+      '$color-honey-100',
+      '$color-honey-200',
+      '$color-honey-300',
+      '$color-honey-400',
+      '$color-honey-500',
+      '$color-honey-600',
+      '$color-honey-700',
+      '$color-honey-800',
     ]}
   />
 )

--- a/src/stories/2-components/03-Colors.stories.js
+++ b/src/stories/2-components/03-Colors.stories.js
@@ -1,6 +1,6 @@
 import React from 'react'
-import colors from '../../scss/colors.scss'
 import contrast from 'get-contrast'
+import colors from '../../scss/colors.scss'
 
 const ColorSwatch = ({ colors, names }) => (
   <>
@@ -96,24 +96,24 @@ export const textColors = () => (
 export const colorsPlum = () => (
   <ColorSwatch
     colors={[
-      colors.colorPlum01,
-      colors.colorPlum02,
-      colors.colorPlum03,
-      colors.colorPlum04,
-      colors.colorPlum05,
-      colors.colorPlum06,
-      colors.colorPlum07,
-      colors.colorPlum08,
+      colors.colorPlum100,
+      colors.colorPlum200,
+      colors.colorPlum300,
+      colors.colorPlum400,
+      colors.colorPlum500,
+      colors.colorPlum600,
+      colors.colorPlum700,
+      colors.colorPlum800,
     ]}
     names={[
-      '$color-plum-1',
-      '$color-plum-2',
-      '$color-plum-3',
-      '$color-plum-4',
-      '$color-plum-5',
-      '$color-plum-6',
-      '$color-plum-7',
-      '$color-plum-8',
+      '$color-plum-100',
+      '$color-plum-200',
+      '$color-plum-300',
+      '$color-plum-400',
+      '$color-plum-500',
+      '$color-plum-600',
+      '$color-plum-700',
+      '$color-plum-800',
     ]}
   />
 )
@@ -121,14 +121,14 @@ export const colorsPlum = () => (
 export const colorsHoney = () => (
   <ColorSwatch
     colors={[
-      colors.colorHoney01,
-      colors.colorHoney02,
-      colors.colorHoney03,
-      colors.colorHoney04,
-      colors.colorHoney05,
-      colors.colorHoney06,
-      colors.colorHoney07,
-      colors.colorHoney08,
+      colors.colorHoney100,
+      colors.colorHoney200,
+      colors.colorHoney300,
+      colors.colorHoney400,
+      colors.colorHoney500,
+      colors.colorHoney600,
+      colors.colorHoney700,
+      colors.colorHoney800,
     ]}
     names={[
       '$color-honey-1',
@@ -146,18 +146,18 @@ export const colorsHoney = () => (
 export const colorsBlueberry = () => (
   <ColorSwatch
     colors={[
-      colors.colorBlueberry01,
-      colors.colorBlueberry02,
-      colors.colorBlueberry03,
-      colors.colorBlueberry04,
-      colors.colorBlueberry05,
+      colors.colorBlueberry100,
+      colors.colorBlueberry200,
+      colors.colorBlueberry300,
+      colors.colorBlueberry400,
+      colors.colorBlueberry500,
     ]}
     names={[
-      '$color-blueberry-1',
-      '$color-blueberry-2',
-      '$color-blueberry-3',
-      '$color-blueberry-4',
-      '$color-blueberry-5',
+      '$color-blueberry-100',
+      '$color-blueberry-200',
+      '$color-blueberry-300',
+      '$color-blueberry-400',
+      '$color-blueberry-500',
     ]}
   />
 )
@@ -165,28 +165,28 @@ export const colorsBlueberry = () => (
 export const colorsSlate = () => (
   <ColorSwatch
     colors={[
-      colors.colorSlate01,
-      colors.colorSlate02,
-      colors.colorSlate03,
-      colors.colorSlate04,
-      colors.colorSlate05,
-      colors.colorSlate06,
-      colors.colorSlate07,
-      colors.colorSlate08,
-      colors.colorSlate09,
-      colors.colorSlate10,
+      colors.colorSlate100,
+      colors.colorSlate200,
+      colors.colorSlate300,
+      colors.colorSlate400,
+      colors.colorSlate500,
+      colors.colorSlate600,
+      colors.colorSlate700,
+      colors.colorSlate800,
+      colors.colorSlate900,
+      colors.colorSlate1000,
     ]}
     names={[
-      '$color-slate-1',
-      '$color-slate-2',
-      '$color-slate-3',
-      '$color-slate-4',
-      '$color-slate-5',
-      '$color-slate-6',
-      '$color-slate-7',
-      '$color-slate-8',
-      '$color-slate-9',
-      '$color-slate-10',
+      '$color-slate-100',
+      '$color-slate-200',
+      '$color-slate-300',
+      '$color-slate-400',
+      '$color-slate-500',
+      '$color-slate-600',
+      '$color-slate-700',
+      '$color-slate-800',
+      '$color-slate-900',
+      '$color-slate-1000',
     ]}
   />
 )


### PR DESCRIPTION
As suggested by @jasonsantamaria, this PR proposes we adopt a `font-weight`-like naming scheme for our color variables. Specifically:

- Current color variables increment by steps of 100. (`$color-plum-100`, $color-plum-200`, and so on)
- Darker shades of each color—think “heavier weights”—are placed toward the upper range of each variable set. (`$color-honey-200` is lighter than `$color-honey-300`; `$color-honey-800` is darker than both)

Feedback/discussion welcome!