### PR TITLE
Make state borders white on grey deaths map

### DIFF
--- a/src/pages/dashboard/charts/_Map.js
+++ b/src/pages/dashboard/charts/_Map.js
@@ -91,6 +91,9 @@ const customSchemeGrey = [
   '#3d4245',
 ]
 
+const strokeGrey = '#ababab'
+const strokeWhite = '#fff'
+
 const getColor = {
   death: scaleThreshold(colorLimits.death, customSchemeGrey),
   positive: scaleThreshold(colorLimits.positive, customSchemeHoney),
@@ -98,6 +101,12 @@ const getColor = {
     colorLimits.totalTestResults,
     customSchemePlum,
   ),
+}
+
+const getStrokeColor = {
+  death: strokeWhite,
+  positive: strokeGrey,
+  totalTestResults: strokeGrey,
 }
 
 // should be imported from constants file
@@ -196,13 +205,14 @@ const States = ({
       value / (d.properties.population / normalizationPopulation)
     return getColor[currentField](normalizedValue)
   }
+  const strokeColor = useChoropleth ? getStrokeColor[currentField] : strokeGrey
   const states = geoJson.features.map(d => (
     <path
       key={`path${d.properties.NAME}`}
       d={path(d)}
       className="countries"
       fill={getColorFromFeature(d)}
-      stroke="#ababab"
+      stroke={strokeColor}
       onMouseEnter={() => {
         setHoveredState({
           coordinates: [


### PR DESCRIPTION
As per https://github.com/COVID19Tracking/website/pull/450#issuecomment-611578337

Changed state border color to white on grey/deaths map for better contrast.

<img width="1091" alt="Screen Shot 2020-04-09 at 12 46 40 PM" src="https://user-images.githubusercontent.com/63169602/78919631-30a83300-7a60-11ea-9d70-7764972281c0.png">
