### PR TITLE
feat(dashboard): add charts to storybook

### DIFF
--- a/src/pages/dashboard/charts/_AreaChart.js
+++ b/src/pages/dashboard/charts/_AreaChart.js
@@ -8,6 +8,8 @@ import React from 'react'
 
 import { formatDate, formatNumber } from '../_utils'
 
+import './area-chart.scss'
+
 export default function AreaChart({
   annotations = null,
   data,
@@ -59,7 +61,7 @@ export default function AreaChart({
   const strokeColor = '#b2bbbf'
 
   return (
-    <svg viewBox={`0 0 ${width} ${height}`}>
+    <svg viewBox={`0 0 ${width} ${height}`} style={{ overflow: 'visible' }}>
       {showTicks ? (
         <g
           className="axis-group"
@@ -71,7 +73,7 @@ export default function AreaChart({
           >
             {xScale.ticks(xTicks).map(tick => (
               <text
-                className="small-multiples__x-tick-label"
+                className="area-chart__x-tick-label"
                 key={tick}
                 x={xScale(tick)}
                 y={20}
@@ -86,7 +88,7 @@ export default function AreaChart({
                 <svg
                   y={yScale(tick) + 4}
                   x="-10"
-                  className="small-multiples__y-tick-label"
+                  className="area-chart__y-tick-label"
                 >
                   <text textAnchor="end">{formatNumber(tick)}</text>
                 </svg>

--- a/src/pages/dashboard/charts/_AreaChart.js
+++ b/src/pages/dashboard/charts/_AreaChart.js
@@ -1,32 +1,31 @@
-/* eslint-disable no-debugger */
+import React from 'react'
+import PropTypes from 'prop-types'
 
 import { extent, max } from 'd3-array'
 import { nest } from 'd3-collection'
 import { scaleLinear, scaleTime } from 'd3-scale'
 import { area } from 'd3-shape'
-import React from 'react'
 
 import { formatDate, formatNumber } from '../_utils'
 
 import './area-chart.scss'
 
-export default function AreaChart({
-  annotations = null,
+const AreaChart = ({
+  annotations,
   data,
   fill,
   height,
-  labelOrder = false,
-  marginBottom = 0,
-  marginLeft = 0,
-  marginRight = 0,
-  marginTop = 0,
-  xExtent,
-  xTicks = 5,
+  labelOrder,
+  marginBottom,
+  marginLeft,
+  marginRight,
+  marginTop,
+  xTicks,
   width,
-  yMax = null,
-  yTicks = 4,
-  showTicks = true,
-}) {
+  yMax,
+  yTicks,
+  showTicks,
+}) => {
   const grouped = nest()
     .key(d => d.label)
     .entries(data)
@@ -40,7 +39,7 @@ export default function AreaChart({
         })
         .filter(d => d)
 
-  const dateExtent = xExtent || extent(data, d => d.date)
+  const dateExtent = extent(data, d => d.date)
   const valueMax = max(data, d => d.value)
 
   const totalXMargin = marginLeft + marginRight
@@ -141,3 +140,42 @@ export default function AreaChart({
     </svg>
   )
 }
+
+AreaChart.defaultProps = {
+  annotations: null,
+  labelOrder: null,
+  marginBottom: 0,
+  marginLeft: 0,
+  marginRight: 0,
+  marginTop: 0,
+  xTicks: 5,
+  yMax: null,
+  yTicks: 4,
+  showTicks: true,
+}
+
+AreaChart.propTypes = {
+  annotations: PropTypes.arrayOf(
+    PropTypes.objectOf(PropTypes.instanceOf(Date).isRequired),
+  ), // ??
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      date: PropTypes.instanceOf(Date).isRequired,
+      label: PropTypes.string.isRequired,
+      value: PropTypes.number,
+    }),
+  ).isRequired,
+  fill: PropTypes.oneOfType([PropTypes.string, PropTypes.func]).isRequired,
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
+  labelOrder: PropTypes.arrayOf(PropTypes.string),
+  marginBottom: PropTypes.number,
+  marginLeft: PropTypes.number,
+  marginRight: PropTypes.number,
+  marginTop: PropTypes.number,
+  xTicks: PropTypes.number,
+  yMax: PropTypes.number,
+  yTicks: PropTypes.number,
+  showTicks: PropTypes.bool,
+}
+export default AreaChart

--- a/src/pages/dashboard/charts/_BarChart.js
+++ b/src/pages/dashboard/charts/_BarChart.js
@@ -105,9 +105,9 @@ BarChart.defaultProps = {
 
 BarChart.propTypes = {
   data: PropTypes.arrayOf(
-    PropTypes.objectOf({
+    PropTypes.shape({
       date: PropTypes.instanceOf(Date).isRequired,
-      value: PropTypes.number.isRequired,
+      value: PropTypes.number,
     }),
   ).isRequired,
   fill: PropTypes.string.isRequired,

--- a/src/pages/dashboard/charts/_BarChart.js
+++ b/src/pages/dashboard/charts/_BarChart.js
@@ -1,25 +1,24 @@
-/* eslint-disable no-unused-vars */
-/* eslint-disable no-debugger */
+import PropTypes from 'prop-types' // ES6
 
-import { extent, max, range } from 'd3-array'
+import { max, range } from 'd3-array'
 import { scaleBand, scaleLinear } from 'd3-scale'
-import React, { useEffect } from 'react'
+import React from 'react'
 
 import { formatDate, formatNumber } from '../_utils'
 
-export default function BarChart({
+const BarChart = ({
   data,
   fill,
   height,
-  marginBottom = 0,
-  marginLeft = 0,
-  marginRight = 0,
-  marginTop = 0,
-  xTicks = 5,
+  marginBottom,
+  marginLeft,
+  marginRight,
+  marginTop,
+  xTicks,
   width,
-  yMax = null,
-  yTicks = 4,
-}) {
+  yMax,
+  yTicks,
+}) => {
   const totalXMargin = marginLeft + marginRight
   const totalYMargin = marginTop + marginBottom
   const xScale = scaleBand()
@@ -69,7 +68,11 @@ export default function BarChart({
         >
           {ticks.map(d => {
             const date = xScale.domain()[d]
-            return <text x={xScale(date)} y="18">{`${formatDate(date)}`}</text>
+            return (
+              <text key={d} x={xScale(date)} y="18">{`${formatDate(
+                date,
+              )}`}</text>
+            )
           })}
         </g>
 
@@ -89,3 +92,33 @@ export default function BarChart({
     </div>
   )
 }
+
+BarChart.defaultProps = {
+  marginBottom: 0,
+  marginLeft: 0,
+  marginRight: 0,
+  marginTop: 0,
+  xTicks: 5,
+  yMax: null,
+  yTicks: 4,
+}
+
+BarChart.propTypes = {
+  data: PropTypes.arrayOf(
+    PropTypes.objectOf({
+      date: PropTypes.instanceOf(Date).isRequired,
+      value: PropTypes.number.isRequired,
+    }),
+  ).isRequired,
+  fill: PropTypes.string.isRequired,
+  width: PropTypes.number.isRequired,
+  height: PropTypes.number.isRequired,
+  marginBottom: PropTypes.number,
+  marginLeft: PropTypes.number,
+  marginRight: PropTypes.number,
+  marginTop: PropTypes.number,
+  xTicks: PropTypes.number,
+  yMax: PropTypes.number,
+  yTicks: PropTypes.number,
+}
+export default BarChart

--- a/src/pages/dashboard/charts/area-chart.scss
+++ b/src/pages/dashboard/charts/area-chart.scss
@@ -1,0 +1,10 @@
+.area-chart__y-tick-label {
+  font-size: 14px;
+  overflow: visible !important;
+  text-anchor: middle;
+}
+
+.area-chart__x-tick-label {
+  font-size: 14px;
+  text-anchor: middle;
+}

--- a/src/pages/dashboard/dashboard.scss
+++ b/src/pages/dashboard/dashboard.scss
@@ -74,12 +74,3 @@ ul.chart-legend {
 .small-multiples-chart__see-all-link {
   font-size: 12px;
 }
-
-.small-multiples__y-tick-label {
-  font-size: 14px;
-  overflow: visible !important;
-}
-
-.small-multiples__x-tick-label {
-  font-size: 14px;
-}

--- a/src/stories/2-components/15-Charts.stories.js
+++ b/src/stories/2-components/15-Charts.stories.js
@@ -1,0 +1,44 @@
+import React from 'react'
+
+import AreaChart from '../../pages/dashboard/charts/_AreaChart'
+import { parseDate } from '../../pages/dashboard/_utils'
+
+import usDaily from '../../../_data/v1/us/daily.json'
+
+export default {
+  title: 'Charts',
+}
+
+export const areaChart = () => {
+  const data = usDaily
+    .slice(usDaily.length - 10, usDaily.length - 1)
+    .map(node => [
+      {
+        date: parseDate(node.date),
+        label: 'Total',
+        value: node.totalTestResults,
+      },
+      { date: parseDate(node.date), label: 'Positive', value: node.positive },
+    ])
+    .reduce((acc, val) => acc.concat(val), [])
+  const fill = d => {
+    if (d === 'Total') return '#585BC1'
+    return '#FFA270'
+  }
+  const props = {
+    data,
+    fill, // can also be a function
+    height: 200,
+    width: 300,
+    marginBottom: 40,
+    marginLeft: 80,
+    marginRight: 10,
+    marginTop: 10,
+    xTicks: 2,
+  }
+  return (
+    <div style={{ width: props.width, height: props.height }}>
+      <AreaChart {...props} />
+    </div>
+  )
+}

--- a/src/stories/2-components/15-Charts.stories.js
+++ b/src/stories/2-components/15-Charts.stories.js
@@ -1,6 +1,8 @@
 import React from 'react'
 
 import AreaChart from '../../pages/dashboard/charts/_AreaChart'
+import BarChart from '../../pages/dashboard/charts/_BarChart'
+
 import { parseDate } from '../../pages/dashboard/_utils'
 
 import usDaily from '../../../_data/v1/us/daily.json'
@@ -11,7 +13,7 @@ export default {
 
 export const areaChart = () => {
   const data = usDaily
-    .slice(usDaily.length - 10, usDaily.length - 1)
+    .slice(0, 10)
     .map(node => [
       {
         date: parseDate(node.date),
@@ -40,5 +42,35 @@ export const areaChart = () => {
     <div style={{ width: props.width, height: props.height }}>
       <AreaChart {...props} />
     </div>
+  )
+}
+const sortChronologically = (a, b) => {
+  if (a.date > b.date) return 1
+  if (a.date < b.date) return -1
+  return 0
+}
+
+export const barChart = () => {
+  const data = usDaily
+    .slice(0, 20)
+    .map(({ date, totalTestResultsIncrease }) => {
+      return {
+        date: parseDate(date),
+        value: +totalTestResultsIncrease,
+      }
+    })
+    .sort(sortChronologically)
+  return (
+    <BarChart
+      data={data}
+      fill="#585BC1"
+      height={200}
+      marginBottom={40}
+      marginLeft={80}
+      marginRight={10}
+      marginTop={10}
+      xTicks={2}
+      width={400}
+    />
   )
 }


### PR DESCRIPTION
I didn't make much of any modifications to the components themselves.

The AreaChart & the BarChart now show up in storybook.  I also added PropTypes for both to make it clear what props are required and what types they should be.

We could probably do with some further cleanup to make these more friendly for use elsewhere.

The AreaChart specifically doesn't respect the height & width passed, it just seems to use them for proportions & relies on the container element to size it. (i'll add a issue on this one).

The map I'll have to think about a bit more (assuming anyone wants to use it elsewhere). It is a bit more entangled with it's container component at the moment.