### PR TITLE
chore: Use narrow layout container for content pages

### DIFF
--- a/src/components/common/container.js
+++ b/src/components/common/container.js
@@ -2,10 +2,9 @@ import React from 'react'
 import containerStyles from './container.module.scss'
 
 export default ({ children, narrow }) => (
-  <div
-    className={`container ${containerStyles.container} ${narrow &&
-      containerStyles.containerNarrow}`}
-  >
-    {children}
+  <div className={`container ${containerStyles.container}`}>
+    <div className={`${narrow && containerStyles.containerNarrow}`}>
+      {children}
+    </div>
   </div>
 )

--- a/src/components/common/container.js
+++ b/src/components/common/container.js
@@ -2,14 +2,13 @@ import React from 'react'
 import containerStyles from './container.module.scss'
 
 export default ({ children, narrow }) => {
-  if (narrow) {
-    return (
-      <div className={`container ${containerStyles.container}`}>
-        <div className={`${containerStyles.containerNarrow}`}>{children}</div>
-      </div>
-    )
-  }
   return (
-    <div className={`container ${containerStyles.container}`}>{children}</div>
+    <div className={`container ${containerStyles.container}`}>
+      {narrow ? (
+        <div className={`${containerStyles.containerNarrow}`}>{children}</div>
+      ) : (
+        children
+      )}
+    </div>
   )
 }

--- a/src/components/common/container.js
+++ b/src/components/common/container.js
@@ -4,7 +4,7 @@ import containerStyles from './container.module.scss'
 export default ({ children, narrow }) => (
   <div
     className={`container ${containerStyles.container} ${narrow &&
-      containerStyles.narrow}`}
+      containerStyles.containerNarrow}`}
   >
     {children}
   </div>

--- a/src/components/common/container.js
+++ b/src/components/common/container.js
@@ -5,9 +5,7 @@ export default ({ children, narrow }) => {
   if (narrow) {
     return (
       <div className={`container ${containerStyles.container}`}>
-        <div className={`${narrow && containerStyles.containerNarrow}`}>
-          {children}
-        </div>
+        <div className={`${containerStyles.containerNarrow}`}>{children}</div>
       </div>
     )
   }

--- a/src/components/common/container.js
+++ b/src/components/common/container.js
@@ -1,10 +1,17 @@
 import React from 'react'
 import containerStyles from './container.module.scss'
 
-export default ({ children, narrow }) => (
-  <div className={`container ${containerStyles.container}`}>
-    <div className={`${narrow && containerStyles.containerNarrow}`}>
-      {children}
-    </div>
-  </div>
-)
+export default ({ children, narrow }) => {
+  if (narrow) {
+    return (
+      <div className={`container ${containerStyles.container}`}>
+        <div className={`${narrow && containerStyles.containerNarrow}`}>
+          {children}
+        </div>
+      </div>
+    )
+  }
+  return (
+    <div className={`container ${containerStyles.container}`}>{children}</div>
+  )
+}

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -17,8 +17,5 @@
   }
   &.container-narrow {
     max-width: 900px;
-    @media (min-width: $viewport-lg) {
-      margin-top: 5rem;
-    }
   }
 }

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -15,7 +15,7 @@
   @media (min-width: $viewport-xl) {
     max-width: 1140px;
   }
-  &.container-narrow {
-    max-width: 900px;
+  & .container-narrow {
+    max-width: 42rem;
   }
 }

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -17,5 +17,8 @@
   }
   &.container-narrow {
     max-width: 900px;
+    @media (min-width: $viewport-lg) {
+      margin-top: 5rem;
+    }
   }
 }

--- a/src/components/layout/header.module.scss
+++ b/src/components/layout/header.module.scss
@@ -16,7 +16,7 @@
 }
 
 .site-header {
-  margin-bottom: 1.5rem;
+  margin-bottom: 3rem;
   &.no-margin {
     margin-bottom: 0;
   }

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -9,7 +9,7 @@ import Container from '../common/container'
 import SkipNavigation from '../common/skip-navigation'
 import '../../scss/global.scss'
 
-const Layout = ({ title, children, navigation, noMargin, hasHero }) => {
+const Layout = ({ title, children, navigation, noMargin, hasHero, narrow }) => {
   const data = useStaticQuery(graphql`
     query SiteTitleQuery {
       site {
@@ -33,7 +33,7 @@ const Layout = ({ title, children, navigation, noMargin, hasHero }) => {
       />
       <main id="main">
         <SkipNavContent />
-        <Container>{children}</Container>
+        <Container narrow={narrow}>{children}</Container>
       </main>
       <Footer />
     </>

--- a/src/stories/2-components/01-Layout.stories.js
+++ b/src/stories/2-components/01-Layout.stories.js
@@ -33,7 +33,7 @@ containerNarrow.story = {
   parameters: {
     info: {
       text:
-        'A narrow element that floats in the middle of the page and is useful to wrap content.',
+        'A narrow element that aligns to the left side of the page and is useful to wrap content.',
     },
   },
 }

--- a/src/templates/content.js
+++ b/src/templates/content.js
@@ -8,7 +8,7 @@ const ContentPage = ({ data }) => {
     <Layout
       title={page.title}
       navigation={page.navigationGroup ? page.navigationGroup.pages : false}
-      narrow="true"
+      narrow
     >
       <div
         dangerouslySetInnerHTML={{ __html: page.body.childMarkdownRemark.html }}

--- a/src/templates/content.js
+++ b/src/templates/content.js
@@ -8,6 +8,7 @@ const ContentPage = ({ data }) => {
     <Layout
       title={page.title}
       navigation={page.navigationGroup ? page.navigationGroup.pages : false}
+      narrow="true"
     >
       <div
         dangerouslySetInnerHTML={{ __html: page.body.childMarkdownRemark.html }}


### PR DESCRIPTION
This addresses #452, updating to use the narrow container for content pages on the site. I also felt like it needed some additional space between the header and start of the content on larger screens, but I defer to @beep and the design team.

Feedback welcome, especially since this is my first time poking my head into React.