### PR TITLE
Add tests per day to historical tables (closes #471)

### DIFF
--- a/src/components/pages/state/state-history.js
+++ b/src/components/pages/state/state-history.js
@@ -10,6 +10,7 @@ export default ({ history, screenshots }) => (
       <tr>
         <th scope="col">Date</th>
         <th scope="col">Screenshot</th>
+        <th scope="col">New Tests</th>
         <th scope="col">Positive</th>
         <th scope="col">Negative</th>
         <th scope="col">Pending</th>
@@ -26,6 +27,9 @@ export default ({ history, screenshots }) => (
           </td>
           <td>
             <Screenshots date={node.dateChecked} screenshots={screenshots} />
+          </td>
+          <td>
+            <FormatNumber number={node.totalTestResultsIncrease} />
           </td>
           <td>
             <FormatNumber number={node.positive} />

--- a/src/pages/data/us-daily.js
+++ b/src/pages/data/us-daily.js
@@ -26,6 +26,7 @@ const ContentPage = ({ data }) => (
         <tr>
           <th scope="col">Date</th>
           <th scope="col">States Tracked</th>
+          <th scope="col">New Tests</th>
           <th scope="col">Positive</th>
           <th scope="col">Negative</th>
           <th scope="col">Pos + Neg</th>
@@ -41,6 +42,9 @@ const ContentPage = ({ data }) => (
               <FormatDate date={node.date} />
             </td>
             <td>{node.states}</td>
+            <td>
+              <FormatNumber number={node.totalTestResultsIncrease} />
+            </td>
             <td>
               <FormatNumber number={node.positive} />
             </td>
@@ -85,6 +89,7 @@ export const query = graphql`
       edges {
         node {
           totalTestResults
+          totalTestResultsIncrease
           states
           positive
           pending

--- a/src/templates/state.js
+++ b/src/templates/state.js
@@ -64,6 +64,7 @@ export const query = graphql`
       edges {
         node {
           totalTestResults
+          totalTestResultsIncrease
           positive
           pending
           negative


### PR DESCRIPTION
This PR adds a tests per day ("New Tests") column to the US and state historical tables:
![image](https://user-images.githubusercontent.com/18607205/79018106-35d4b300-7b30-11ea-95c2-8a379e2592ed.png)

See #471 