### PR TITLE
Add toggle to switch between states' total tests versus per capita

### DIFF
--- a/src/pages/dashboard/_MapContainer.js
+++ b/src/pages/dashboard/_MapContainer.js
@@ -137,7 +137,7 @@ const MapContainer = () => {
   return (
     <div id="state-map">
       <div
-        id="map-style-button"
+        className="map-toggle"
         onClick={toggleMapStyle}
         onKeyPress={toggleMapStyle}
         role="switch"

--- a/src/pages/dashboard/_StateCumulativeTestsContainer.js
+++ b/src/pages/dashboard/_StateCumulativeTestsContainer.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-import { max } from 'd3-array'
 import { nest } from 'd3-collection'
 import { graphql, useStaticQuery } from 'gatsby'
 import React, { useMemo, useState } from 'react'
@@ -128,14 +126,6 @@ function groupAndSortStateDaily(query) {
     totals: sortGroupedData(grouped),
     perCapita: sortGroupedData(groupedPerCapita),
   }
-}
-
-function normalizeByStatePopulation(val, stateKey) {
-  if (!val) return 0
-  const statePop = statePopulations[stateKey]
-    ? statePopulations[stateKey]
-    : territoryPopulations[stateKey]
-  return val / statePop
 }
 
 export default function CumulativeTestsByStateContainer() {

--- a/src/pages/dashboard/_StateCumulativeTestsContainer.js
+++ b/src/pages/dashboard/_StateCumulativeTestsContainer.js
@@ -139,17 +139,15 @@ export default function CumulativeTestsByStateContainer() {
 
   const toggleChartData = () => setUseTestsPerCapita(u => !u)
 
-  const allData = useMemo(() => {
-    return groupAndSortStateDaily(query)
-  })
+  const allData = useMemo(() => groupAndSortStateDaily(query), [query])
 
   const data = useMemo(() => {
     return useTestsPerCapita ? allData.perCapita : allData.totals
-  })
+  }, [useTestsPerCapita])
 
   const maxStateTests = useMemo(() => {
     return data[0].values[0].totalTestResults
-  })
+  }, [useTestsPerCapita])
 
   return (
     <div>

--- a/src/pages/dashboard/_StateCumulativeTestsContainer.js
+++ b/src/pages/dashboard/_StateCumulativeTestsContainer.js
@@ -165,9 +165,7 @@ export default function CumulativeTestsByStateContainer() {
   })
 
   const maxStateTests = useMemo(() => {
-    return max(data, stateData => {
-      return max(stateData.values, d => calculateTotal(d))
-    })
+    return calculateTotal(data[0].values[0])
   })
 
   return (

--- a/src/pages/dashboard/_StateCumulativeTestsContainer.js
+++ b/src/pages/dashboard/_StateCumulativeTestsContainer.js
@@ -6,13 +6,7 @@ import cloneDeep from 'lodash/cloneDeep'
 import AreaChart from './charts/_AreaChart'
 import StatesWithPopulation from '../../data/visualization/state-populations.json'
 
-import {
-  calculateTotal,
-  getStateName,
-  parseDate,
-  totalColor,
-  positiveColor,
-} from './_utils'
+import { getStateName, parseDate, totalColor, positiveColor } from './_utils'
 
 import './dashboard.scss'
 
@@ -76,12 +70,7 @@ const territoryPopulations = {
 
 function sortGroupedData(groupedData) {
   return groupedData.sort((a, b) => {
-    const lastA = a.values[0]
-    const lastB = b.values[0]
-
-    const lastATotal = calculateTotal(lastA)
-    const lastBTotal = calculateTotal(lastB)
-    return lastBTotal - lastATotal
+    return b.values[0].totalTestResults - a.values[0].totalTestResults
   })
 }
 
@@ -115,6 +104,7 @@ function groupAndSortStateDaily(query) {
       // divide by population to determine per capita percentages
       clonedValue.positive /= population
       clonedValue.negative /= population
+      clonedValue.totalTestResults /= population
 
       return clonedValue
     })
@@ -138,6 +128,7 @@ export default function CumulativeTestsByStateContainer() {
             state
             positive
             negative
+            totalTestResults
           }
         }
       }
@@ -157,7 +148,7 @@ export default function CumulativeTestsByStateContainer() {
   })
 
   const maxStateTests = useMemo(() => {
-    return calculateTotal(data[0].values[0])
+    return data[0].values[0].totalTestResults
   })
 
   return (
@@ -239,7 +230,7 @@ export default function CumulativeTestsByStateContainer() {
             stateData.push({
               date,
               label: 'Total',
-              value: calculateTotal(d),
+              value: d.totalTestResults,
             })
           })
 

--- a/src/pages/dashboard/_StateCumulativeTestsContainer.js
+++ b/src/pages/dashboard/_StateCumulativeTestsContainer.js
@@ -148,7 +148,9 @@ export default function CumulativeTestsByStateContainer() {
 
   const toggleChartData = () => setUseTestsPerCapita(u => !u)
 
-  const allData = groupAndSortStateDaily(query)
+  const allData = useMemo(() => {
+    return groupAndSortStateDaily(query)
+  })
 
   const data = useMemo(() => {
     return useTestsPerCapita ? allData.perCapita : allData.totals

--- a/src/pages/dashboard/_StateCumulativeTestsContainer.js
+++ b/src/pages/dashboard/_StateCumulativeTestsContainer.js
@@ -1,9 +1,12 @@
+/* eslint-disable no-unused-vars */
 import { max } from 'd3-array'
 import { nest } from 'd3-collection'
 import { graphql, useStaticQuery } from 'gatsby'
-import React, { useMemo } from 'react'
+import React, { useMemo, useState } from 'react'
+import cloneDeep from 'lodash/cloneDeep'
 
 import AreaChart from './charts/_AreaChart'
+import StatesWithPopulation from '../../data/visualization/state-populations.json'
 
 import {
   calculateTotal,
@@ -61,11 +64,35 @@ const stayAtHomeOrders = {
   WI: 20200325,
 }
 
+const statePopulations = StatesWithPopulation.features.reduce((acc, cur) => {
+  acc[cur.properties.STUSPS] = cur.properties.population
+  return acc
+}, {})
+
+const territoryPopulations = {
+  GU: 164229,
+  VI: 107268,
+  MP: 55144,
+  AS: 55641,
+}
+
+function sortGroupedData(groupedData) {
+  return groupedData.sort((a, b) => {
+    const lastA = a.values[0]
+    const lastB = b.values[0]
+
+    const lastATotal = calculateTotal(lastA)
+    const lastBTotal = calculateTotal(lastB)
+    return lastBTotal - lastATotal
+  })
+}
+
 function groupAndSortStateDaily(query) {
   const data = query.allCovidStateDaily.edges.map(edge => {
     const { node } = edge
     return node
   })
+
   const grouped = nest()
     .key(d => d.state)
     .sortValues((a, b) => {
@@ -78,14 +105,37 @@ function groupAndSortStateDaily(query) {
     })
     .entries(data)
 
-  return grouped.sort((a, b) => {
-    const lastA = a.values[0]
-    const lastB = b.values[0]
+  const groupedPerCapita = grouped.map(stateData => {
+    const population = statePopulations[stateData.key]
+      ? statePopulations[stateData.key]
+      : territoryPopulations[stateData.key]
+    const clonedData = cloneDeep(stateData)
 
-    const lastATotal = calculateTotal(lastA)
-    const lastBTotal = calculateTotal(lastB)
-    return lastBTotal - lastATotal
+    clonedData.values = clonedData.values.map(value => {
+      const clonedValue = cloneDeep(value)
+
+      // divide by population to determine per capita percentages
+      clonedValue.positive /= population
+      clonedValue.negative /= population
+
+      return clonedValue
+    })
+
+    return clonedData
   })
+
+  return {
+    totals: sortGroupedData(grouped),
+    perCapita: sortGroupedData(groupedPerCapita),
+  }
+}
+
+function normalizeByStatePopulation(val, stateKey) {
+  if (!val) return 0
+  const statePop = statePopulations[stateKey]
+    ? statePopulations[stateKey]
+    : territoryPopulations[stateKey]
+  return val / statePop
 }
 
 export default function CumulativeTestsByStateContainer() {
@@ -104,7 +154,15 @@ export default function CumulativeTestsByStateContainer() {
     }
   `)
 
-  const data = groupAndSortStateDaily(query)
+  const [useTestsPerCapita, setUseTestsPerCapita] = useState(false)
+
+  const toggleChartData = () => setUseTestsPerCapita(u => !u)
+
+  const allData = groupAndSortStateDaily(query)
+
+  const data = useMemo(() => {
+    return useTestsPerCapita ? allData.perCapita : allData.totals
+  })
 
   const maxStateTests = useMemo(() => {
     return max(data, stateData => {
@@ -124,35 +182,50 @@ export default function CumulativeTestsByStateContainer() {
         they’re also giving more tests.
       </p>
       <h3>Cumulative tests by state</h3>
-      <ul className="chart-legend">
-        <li>
-          <span
-            className="chart-legend-color"
-            style={{ backgroundColor: positiveColor }}
-          />
-          Positive tests
-        </li>
-        <li>
-          <span
-            className="chart-legend-color"
-            style={{ backgroundColor: totalColor }}
-          />{' '}
-          Total tests
-        </li>
-        <li>
-          <span
-            className="chart-legend-color"
-            style={{
-              backgroundColor: 'black',
-              height: '20px',
-              margin: '0 14px 0 0',
-              verticalAlign: 'middle',
-              width: '2px',
-            }}
-          />
-          Stay-at-home order*
-        </li>
-      </ul>
+      <div className="chart-controls">
+        <ul className="chart-legend">
+          <li>
+            <span
+              className="chart-legend-color"
+              style={{ backgroundColor: positiveColor }}
+            />
+            Positive tests
+          </li>
+          <li>
+            <span
+              className="chart-legend-color"
+              style={{ backgroundColor: totalColor }}
+            />{' '}
+            Total tests
+          </li>
+          <li>
+            <span
+              className="chart-legend-color"
+              style={{
+                backgroundColor: 'black',
+                height: '20px',
+                margin: '0 14px 0 0',
+                verticalAlign: 'middle',
+                width: '2px',
+              }}
+            />
+            Stay-at-home order*
+          </li>
+        </ul>
+        <div
+          className="map-toggle chart-tests-toggle"
+          onClick={toggleChartData}
+          onKeyPress={toggleChartData}
+          role="switch"
+          aria-checked={useTestsPerCapita}
+          tabIndex={0}
+        >
+          <span className={useTestsPerCapita ? '' : 'active'}>Total Tests</span>
+          <span className={useTestsPerCapita ? 'active' : ''}>
+            Tests Per Capita
+          </span>
+        </div>
+      </div>
       <div className="small-multiples-chart-container">
         {data.map(state => {
           // because we're just charting two variables we make them here
@@ -163,6 +236,7 @@ export default function CumulativeTestsByStateContainer() {
           const annotations = stayAtHomeOrder
             ? [{ date: parseDate(stayAtHomeOrder) }]
             : null
+
           state.values.forEach(d => {
             const date = parseDate(d.date)
 

--- a/src/pages/dashboard/_utils.js
+++ b/src/pages/dashboard/_utils.js
@@ -5,9 +5,6 @@ import { timeFormat, timeParse } from 'd3-time-format'
 export const formatDate = timeFormat('%b. %e')
 export const formatNumber = format(',')
 export const parseDate = timeParse('%Y%m%d')
-export const calculateTotal = d => {
-  return d.positive + (d.negative || 0)
-}
 export const getStateName = abbr => {
   const names = {
     AK: 'Alaska',

--- a/src/pages/dashboard/_utils.js
+++ b/src/pages/dashboard/_utils.js
@@ -37,7 +37,7 @@ export const getStateName = abbr => {
     MI: 'Michigan',
     MN: 'Minnesota',
     MO: 'Missouri',
-    MP: 'Marshall Islands',
+    MP: 'Northern Mariana Islands',
     MS: 'Mississippi',
     MT: 'Montana',
     NC: 'North Carolina',

--- a/src/pages/dashboard/dashboard.scss
+++ b/src/pages/dashboard/dashboard.scss
@@ -48,7 +48,25 @@ ul.chart-legend {
   font-size: 12px;
 }
 
+.chart-controls {
+  align-content: space-between;
+  align-items: center;
+  display: flex;
+  flex-direction: column;
+
+  @media screen and (min-width: 600px) {
+    flex-direction: row;
+  }
+}
+
+.chart-tests-toggle {
+  margin-bottom: 1.8rem;
+  max-width: 260px;
+  padding: 0 5px;
+}
+
 .small-multiples-chart {
+  line-height: 1rem;
   padding: 0 1%;
   width: 50%;
 

--- a/src/pages/dashboard/map-container.scss
+++ b/src/pages/dashboard/map-container.scss
@@ -61,7 +61,7 @@ $death-color: #404856;
   font-weight: initial;
 }
 
-#map-style-button {
+.map-toggle {
   cursor: pointer;
   width: 100%;
   span {


### PR DESCRIPTION
This adds a toggle that allows user to switch the state cumulative tests charts between total number of tests and per capita testing amount.

### Total tests:

![tests-total](https://user-images.githubusercontent.com/63169602/79025362-83164c00-7b53-11ea-89b3-181b943aa1dd.jpg)

### Per capita:

![tests-per-capita](https://user-images.githubusercontent.com/63169602/79025371-89a4c380-7b53-11ea-8fb3-6e8c8d1574cb.jpg)

### Notes:

- Existing state with population does not include the territories; added them as a [local hash in _StateCumulativeTestsContainer](https://github.com/vijaysharwar/website/blob/7e48dcd4db7e8249015bb3af02b809202b989212/src/pages/dashboard/_StateCumulativeTestsContainer.js#L72-L77)
- The data and state calling code (`MP`) are actually for "Northern Mariana Islands", not "Marshall Islands". [Renamed here](https://github.com/vijaysharwar/website/blob/7e48dcd4db7e8249015bb3af02b809202b989212/src/pages/dashboard/_utils.js#L40) as per conversation in https://github.com/COVID19Tracking/website/issues/479#issuecomment-612198044
- Changed `#map-style-button` to a [class named `.map-toggle`](https://github.com/COVID19Tracking/website/issues/479#issuecomment-612198044) for reusability. Side note: best practice usually dictates avoiding styling IDs for this precise reason 

Fixes COVID19Tracking/website#479