### PR TITLE
Fix tooltip tables styling

### DIFF
--- a/src/pages/dashboard/_utils.js
+++ b/src/pages/dashboard/_utils.js
@@ -3,7 +3,7 @@ import { format, formatPrefix } from 'd3-format'
 import { timeFormat, timeParse } from 'd3-time-format'
 
 export const formatDate = timeFormat('%b. %e')
-export const formatNumber = format(',')
+export const formatNumber = format(',.0f')
 export const parseDate = timeParse('%Y%m%d')
 export const formatMillionShort = (d, last) => {
   let formattedNumber = formatPrefix(',.1', 1e6)(d)

--- a/src/pages/dashboard/charts/_Map.js
+++ b/src/pages/dashboard/charts/_Map.js
@@ -315,7 +315,7 @@ const Tooltip = ({ hoveredState, currentDate, getValue }) => {
   const death = getValue(d, 'death')
   const deathNorm = getValue(d, 'death', true)
   return (
-    <div id="map-tooltip" style={{ top: y, left: x }}>
+    <div className="map-tooltip" style={{ top: y, left: x }}>
       <table>
         <caption>
           {d.properties.NAME}

--- a/src/pages/dashboard/charts/map.scss
+++ b/src/pages/dashboard/charts/map.scss
@@ -2,22 +2,24 @@
   position: relative;
 }
 
-#map-tooltip {
+.map-tooltip {
   background: white;
   pointer-events: none;
   position: absolute;
   border: 2px solid #000;
   table {
-    table-layout: fixed;
-    width: 270px;
+    line-height: 1rem;
     border-collapse: collapse;
     margin: -1px;
+    font-size: 0.85em;
   }
   caption {
-    font-size: 16px;
-    padding: 6px 12px;
+    font-weight: bold;
+    font-size: 1.25rem;
+    text-align: left;
+    padding: 0.75rem 0.75rem 0.375rem 0.75rem;
     span.date {
-      font-size: 11px;
+      font-size: 0.7rem;
       color: gray;
       text-transform: uppercase;
     }
@@ -25,25 +27,12 @@
   td,
   th {
     border: 1px solid #000;
-    border-collapse: collapse;
     text-align: center;
-    background: none;
-  }
-  td {
-    font-size: 12px;
+    padding: 0.4rem 0.8rem;
   }
   th {
-    font-size: 11px;
     font-weight: bold;
     white-space: nowrap;
-    span {
-      font-size: 11px;
-    }
-  }
-  tbody {
-    th {
-      font-size: 11px;
-    }
   }
 }
 


### PR DESCRIPTION
Fixes #477 

![Screen Shot 2020-04-11 at 2 53 56 PM](https://user-images.githubusercontent.com/1994207/79052411-5110f280-7c04-11ea-93cc-973d548a8e5c.png)

One question before merging this: I noticed the per capita numbers in the tooltip table had lots of digits after the decimal point... I updated the formatNumber util to render them as integers. Let me know if this is not what is desired.