### PR TITLE
fix: Screenshot order

### DIFF
--- a/src/templates/state.js
+++ b/src/templates/state.js
@@ -76,7 +76,7 @@ export const query = graphql`
     }
     allCovidScreenshot(
       filter: { state: { eq: $state }, secondary: { eq: false } }
-      sort: { fields: dateChecked, order: ASC }
+      sort: { fields: dateChecked }
     ) {
       edges {
         node {

--- a/src/templates/state.js
+++ b/src/templates/state.js
@@ -76,7 +76,7 @@ export const query = graphql`
     }
     allCovidScreenshot(
       filter: { state: { eq: $state }, secondary: { eq: false } }
-      sort: { fields: dateChecked, order: DESC }
+      sort: { fields: dateChecked, order: ASC }
     ) {
       edges {
         node {


### PR DESCRIPTION
Fixes #507 

Reorders screenshots by `dateChecked` in ascending instead of descending order