### PR TITLE
test(api): Add cumulative value testing for pos/neg daily values

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "build:data": "cp -R _data/* public/api/",
     "build:data-archive": "tar -czf public/api/archive.tar.gz _data/",
     "build:test": "jest --verbose --config=\"{}\" -- src/__tests__/build/index.js",
+    "api:test": "jest --verbose -- src/__tests__/api-test.js",
     "clean": "run-p clean:*",
     "clean:gatsby": "gatsby clean",
     "develop": "gatsby develop",

--- a/src/__tests__/api-test.js
+++ b/src/__tests__/api-test.js
@@ -1,0 +1,160 @@
+const fs = require('fs')
+
+/**
+ * Import the states daily json file
+ */
+const statesDaily = JSON.parse(
+  fs.readFileSync('./_data/v1/states/daily.json', 'utf8'),
+)
+
+/**
+ * List of states
+ */
+const uniqueStates = [...new Set(statesDaily.map(item => item.state))]
+
+/**
+ * These arrays capture the observed anomalies in cumulative testing results.
+ * Explanation:
+ * Since state websites serve as the AOR for cumulative data, their regressions
+ * result in errors in our cumulative positive/negative tests.
+ *
+ * We should verify these anomalies with QA/Data teams and then enter them here.
+ * These anomalies will be removed from the data in tests below so that these
+ * tests will pass. When new anomalies are found, they should be verified with
+ * QA/Data and only then should be entered into the arrays of allowed anomalies
+ * below.
+ */
+
+const allowedNegativeAnomalies = [
+  {
+    state: 'AK',
+    date: 20200413,
+    positive: 277,
+    negative: 7553,
+  },
+  {
+    state: 'AK',
+    date: 20200412,
+    positive: 272,
+    negative: 7766,
+  },
+  {
+    state: 'DE',
+    date: 20200410,
+    positive: 1326,
+    negative: 10415,
+  },
+  {
+    state: 'WI',
+    date: 20200330,
+    positive: 1221,
+    negative: 15856,
+  },
+  {
+    state: 'WI',
+    date: 20200329,
+    positive: 1112,
+    negative: 16550,
+  },
+  {
+    state: 'DC',
+    date: 20200415,
+    positive: 2197,
+    negative: 9328,
+  },
+]
+const allowedPositiveAnomalies = [
+  {
+    state: 'RI',
+    date: 20200307,
+    positive: 2,
+    negative: 30,
+  },
+  {
+    state: 'RI',
+    date: 20200306,
+    positive: 3,
+    negative: 17,
+  },
+  {
+    state: 'WY',
+    date: 20200410,
+    positive: 320,
+    negative: 4736,
+  },
+  {
+    state: 'WA',
+    date: 20200419,
+    positive: 11802,
+    negative: 123904,
+  },
+  {
+    state: 'GU',
+    date: 20200420,
+    positive: 133,
+    negative: 991,
+  },
+]
+
+/**
+ * Return true if item is in anomaly array, otherwise false.
+ * @param {String} type - the type of anomaly to check.
+ * @param {Object} item - the daily object from the api:
+ *                        { state, date, positive, negative }
+ */
+const excludeAnomalies = type => item => {
+  const anomaliesArray =
+    type === 'positive' ? allowedPositiveAnomalies : allowedNegativeAnomalies
+  const { state, date } = item
+  const foundAnomaly = anomaliesArray.find(
+    a => a.state === state && a.date === date,
+  )
+  return !foundAnomaly
+}
+
+/**
+ * Sort objects by date
+ * @param {Object} a
+ * @param {Object} b
+ */
+const sortDate = (a, b) => a.date - b.date
+
+describe('API positive cumulative test', () => {
+  const aggregatedPositives = uniqueStates.map(state => ({
+    state,
+    positives: statesDaily
+      .filter(d => d.state === state)
+      .filter(excludeAnomalies('positive'))
+      .sort(sortDate)
+      .map(d => (typeof d.positive === 'undefined' ? 0 : d.positive)),
+  }))
+
+  const testingData = aggregatedPositives.map(items => [
+    items.state,
+    [...items.positives],
+    items.positives.sort((a, b) => a - b),
+  ])
+
+  test.each(testingData)('%s positive data is cumulative', (state, a, b) => {
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b))
+  })
+})
+
+describe('API negative cumulative test', () => {
+  const aggregatedNegatives = uniqueStates.map(state => ({
+    state,
+    negatives: statesDaily
+      .filter(d => d.state === state)
+      .filter(excludeAnomalies('negative'))
+      .sort(sortDate)
+      .map(d => (typeof d.negative === 'undefined' ? 0 : d.negative)),
+  }))
+  const testingData = aggregatedNegatives.map(items => [
+    items.state,
+    [...items.negatives],
+    items.negatives.sort((a, b) => a - b),
+  ])
+  test.each(testingData)('%s negative data is cumulative', (state, a, b) => {
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b))
+  })
+})

--- a/src/stories/1-docs/7-Unit-testing.stories.mdx
+++ b/src/stories/1-docs/7-Unit-testing.stories.mdx
@@ -22,20 +22,26 @@ And make sure that every test passes. Pull requests are automatically checked ag
 
 ## API Testing
 
-In the `build-test.js` script there are a number of API tests. Most are basic right now and there are plans to expand them. If you have difficulty getting these tests to pass see troubleshooting below.
+A number of tests exist here to do some basic testing of the API. For example:
 
 ### Build Process
 
-During the build process -- see package.json `build` step -- the files used to build the API are downloaded and processed before being copied over to the API directory (`./public/api/v1/`). This fetching and processing step is done before tests are run -- see `build:test`. 
+These tests do exist in other places (see [quality-control](https://github.com/COVID19Tracking/quality-control)). However, it makes some sense to have them here as this is where the logic resides to construct the JSON/CSV files served by the API.
 
-### Troubleshooting 
+### Troubleshooting
 
-Since many will not have the required permissions to pull down the required files during `build:fetch`, the local API tests will fail. If the tests fail, try the following commands in your shell:
+You must have the API files installed locally.
 
-```bash session
-> cd {COVID_TRACKING_ROOT}
-> mkdir -p ./public/api/v1/states
-> curl https://covidtracking.com/api/v1/states/daily.json -o ./public/api/v1/states/daily.json
+```bash
+> npm run setup:api-data
 ```
 
-Ensure that there is a `daily.json` file inside the path `./public/api/v1/states/`.
+## Running the tests
+
+```bash
+> npm run api:test
+```
+
+## Anomalies
+
+In `api-test.js` there are a number of tests to check that the daily states API records are cumulative (i.e., they should never decrease). Since the state websites are the authority, there will be times where this does not hold true. In such events, data should be verified via screenshots or with the Data Entry team and exceptions should be added to the `allowedPositiveAnomalies` and `allowedNegativeAnomalies` arrays.


### PR DESCRIPTION
This PR checks `api/v1/states/daily.json` to make sure that values for `positive` and `negative` are cumulative.

Running this test, I was able to see that there were some state errors in positive (RI) and negative (WI, DE, WY).