### PR TITLE
Move chart legend to right of toggle on large screens

### DIFF
--- a/src/pages/dashboard/_MapContainer.js
+++ b/src/pages/dashboard/_MapContainer.js
@@ -137,7 +137,7 @@ const MapContainer = () => {
   return (
     <div id="state-map">
       <div
-        className="map-toggle"
+        className="dashboard-toggle"
         onClick={toggleMapStyle}
         onKeyPress={toggleMapStyle}
         role="switch"

--- a/src/pages/dashboard/_StateCumulativeTestsContainer.js
+++ b/src/pages/dashboard/_StateCumulativeTestsContainer.js
@@ -150,7 +150,7 @@ export default function CumulativeTestsByStateContainer() {
   }, [useTestsPerCapita])
 
   return (
-    <div>
+    <div className="dashboard-cumulative-tests">
       <p>
         By comparing the positive tests to the total tests in each state, we can
         get a sense of how widespread a state’s testing regime might be (though
@@ -161,47 +161,38 @@ export default function CumulativeTestsByStateContainer() {
         they’re also giving more tests.
       </p>
       <h3>Cumulative tests by state</h3>
-      <div
-        className="map-toggle chart-tests-toggle"
-        onClick={toggleChartData}
-        onKeyPress={toggleChartData}
-        role="switch"
-        aria-checked={useTestsPerCapita}
-        tabIndex={0}
-      >
-        <span className={useTestsPerCapita ? '' : 'active'}>Total Tests</span>
-        <span className={useTestsPerCapita ? 'active' : ''}>
-          Tests Per Capita
-        </span>
-      </div>
-      <div className="chart-controls">
+      <div className="chart-header">
+        <div
+          className="dashboard-toggle"
+          onClick={toggleChartData}
+          onKeyPress={toggleChartData}
+          role="switch"
+          aria-checked={useTestsPerCapita}
+          tabIndex={0}
+        >
+          <span className={useTestsPerCapita ? '' : 'active'}>Total Tests</span>
+          <span className={useTestsPerCapita ? 'active' : ''}>
+            Tests Per Capita
+          </span>
+        </div>
         <ul className="chart-legend">
           <li>
-            <span
+            <div
               className="chart-legend-color"
               style={{ backgroundColor: positiveColor }}
             />
-            Positive tests {useTestsPerCapita && ' per capita'}
+            <div>Positive tests {useTestsPerCapita && ' per capita'}</div>
           </li>
           <li>
-            <span
+            <div
               className="chart-legend-color"
               style={{ backgroundColor: totalColor }}
-            />{' '}
-            Total tests {useTestsPerCapita && ' per capita'}
+            />
+            <div>Total tests {useTestsPerCapita && ' per capita'}</div>
           </li>
           <li>
-            <span
-              className="chart-legend-color"
-              style={{
-                backgroundColor: 'black',
-                height: '20px',
-                margin: '0 14px 0 0',
-                verticalAlign: 'middle',
-                width: '2px',
-              }}
-            />
-            Stay-at-home order*
+            <div className="chart-legend-color chart-legend-stay-at-home" />
+            <div>Stay-at-home order*</div>
           </li>
         </ul>
       </div>

--- a/src/pages/dashboard/dashboard.scss
+++ b/src/pages/dashboard/dashboard.scss
@@ -1,3 +1,45 @@
+%dashboard-toggle-active {
+  color: black;
+  border-color: black;
+  font-weight: 500;
+}
+
+%dashboard-toggle-inactive {
+  color: lightgray;
+  border: solid lightgray 2px;
+  font-weight: initial;
+}
+
+.dashboard-toggle {
+  align-self: flex-start;
+  cursor: pointer;
+  display: flex;
+
+  span {
+    @extend %dashboard-toggle-inactive;
+    font-size: 14px;
+    margin: -1px;
+    padding: 2px 15px;
+    white-space: nowrap;
+
+    &:nth-child(1) {
+      border-radius: 8px 0 0 8px;
+    }
+    &:nth-child(2) {
+      border-radius: 0 8px 8px 0;
+      border-left-color: black !important;
+    }
+    &.active {
+      @extend %dashboard-toggle-active;
+    }
+  }
+}
+
+.dashboard-cumulative-tests {
+  display: flex;
+  flex-direction: column;
+}
+
 .us-area-chart-container {
   margin: 50px auto;
   max-width: 800px;
@@ -9,60 +51,66 @@
   justify-content: space-between;
 }
 
-ul.chart-legend {
-  background-color: #fff;
+$chart-header-bp: 960px;
+
+.chart-header {
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 2rem;
+
+  @media screen and (min-width: $chart-header-bp) {
+    flex-direction: row;
+    justify-content: space-between;
+    margin: 0 0 2rem;
+  }
+}
+
+.chart-legend {
   display: flex;
   font-size: 14px;
   flex-direction: column;
   list-style-type: none;
-  justify-content: flex-start;
-  margin-left: 0;
-  padding: 0.1rem 0 0.5rem;
-  position: sticky;
-  top: 0rem;
-  width: 100%;
+  margin: 1.5rem 0 0;
 
-  @media screen and (min-width: 960px) {
+  @media screen and (min-width: $chart-header-bp) {
     flex-direction: row;
+    justify-content: flex-end;
+    margin-top: 0;
   }
 
   li {
+    align-items: center;
     display: flex;
     line-height: 1.2;
-    margin: 1rem 2rem 0 0;
+    white-space: nowrap;
 
-    @media screen and (min-width: 960px) {
-      flex-direction: row;
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    @media screen and (min-width: $chart-header-bp) {
+      margin: 0 0 0 2rem;
     }
   }
 }
 
 .chart-legend-color {
   display: inline-block;
-  height: 0.7rem;
-  margin: 0.1rem 0.5rem 0 0;
-  width: 0.7rem;
+  height: 14px;
+  margin: 0 8px 0 0;
+  width: 14px;
+
+  &.chart-legend-stay-at-home {
+    background-color: #000;
+    height: 20px;
+    margin: 0 14px 0 6px;
+    verticalalign: middle;
+    width: 2px;
+  }
 }
 
 .chart-legend-note {
   font-size: 12px;
-}
-
-.chart-controls {
-  align-content: space-between;
-  align-items: center;
-  display: flex;
-  flex-direction: column;
-
-  @media screen and (min-width: 600px) {
-    flex-direction: row;
-  }
-}
-
-.chart-tests-toggle {
-  margin-bottom: 1rem;
-  max-width: 260px;
-  padding: 0 5px;
 }
 
 .small-multiples-chart {

--- a/src/pages/dashboard/dashboard.scss
+++ b/src/pages/dashboard/dashboard.scss
@@ -51,14 +51,15 @@
   justify-content: space-between;
 }
 
-$chart-header-bp: 960px;
+$chart-header-bp-md: 640px;
+$chart-header-bp-lg: 960px;
 
 .chart-header {
   display: flex;
   flex-direction: column;
   margin-bottom: 2rem;
 
-  @media screen and (min-width: $chart-header-bp) {
+  @media screen and (min-width: $chart-header-bp-lg) {
     flex-direction: row;
     justify-content: space-between;
     margin: 0 0 2rem;
@@ -72,7 +73,11 @@ $chart-header-bp: 960px;
   list-style-type: none;
   margin: 1.5rem 0 0;
 
-  @media screen and (min-width: $chart-header-bp) {
+  @media screen and (min-width: $chart-header-bp-md) {
+    flex-direction: row;
+  }
+
+  @media screen and (min-width: $chart-header-bp-lg) {
     flex-direction: row;
     justify-content: flex-end;
     margin-top: 0;
@@ -88,7 +93,11 @@ $chart-header-bp: 960px;
       margin-bottom: 0;
     }
 
-    @media screen and (min-width: $chart-header-bp) {
+    @media screen and (min-width: $chart-header-bp-md) {
+      margin: 0 2rem 0 0;
+    }
+
+    @media screen and (min-width: $chart-header-bp-lg) {
       margin: 0 0 0 2rem;
     }
   }

--- a/src/pages/dashboard/map-container.scss
+++ b/src/pages/dashboard/map-container.scss
@@ -50,39 +50,6 @@ $death-color: #404856;
   }
 }
 
-%map-toggle-active {
-  color: black;
-  border-color: black;
-  font-weight: 500;
-}
-%map-toggle-inactive {
-  color: lightgray;
-  border: solid lightgray 2px;
-  font-weight: initial;
-}
-
-.map-toggle {
-  cursor: pointer;
-  align-self: flex-start;
-  span {
-    @extend %map-toggle-inactive;
-    display: inline-block;
-    font-size: 14px;
-    margin: -1px;
-    padding: 2px 15px;
-    &:nth-child(1) {
-      border-radius: 8px 0 0 8px;
-    }
-    &:nth-child(2) {
-      border-radius: 0 8px 8px 0;
-      border-left-color: black !important;
-    }
-    &.active {
-      @extend %map-toggle-active;
-    }
-  }
-}
-
 .legend-text {
   border-bottom: solid 3px;
   &.total {


### PR DESCRIPTION
Updating the small area charts toggle and legend to make better use of available space on larger screens. See conversation in https://github.com/COVID19Tracking/website/pull/494#issuecomment-612313777.

### Notes:
- Uses updated toggle styles from https://github.com/COVID19Tracking/website/pull/500
- Moves `.map-toggle` to `.dashboard-toggle` and into `dashboard.scss`, since this
  component is shared between the map and small area charts

### Small screens (< 960px):

<img width="764" alt="Screen Shot 2020-04-12 at 1 13 15 PM" src="https://user-images.githubusercontent.com/63169602/79075207-6c8d0380-7cbf-11ea-8e67-c070a7e101fc.png">

### Large screens (960px and above):

<img width="1304" alt="Screen Shot 2020-04-12 at 1 13 57 PM" src="https://user-images.githubusercontent.com/63169602/79075224-80386a00-7cbf-11ea-91ab-0e49f5c3215a.png">

cc @goleary @AaronMullan @julialedur