### PR TITLE
feat: yAxis tick gap, relocate data href link

### DIFF
--- a/src/pages/dashboard/_SmallMultiplesContainer.js
+++ b/src/pages/dashboard/_SmallMultiplesContainer.js
@@ -182,7 +182,15 @@ const SmallMultiplesContainer = () => {
               data-state={state.key}
               key={state.key}
             >
-              <h4>{stateName}</h4>
+              <h4>
+                <a
+                  href={`/data/state/${stateName
+                    .toLowerCase()
+                    .replace(/\s/g, '-')}`}
+                >
+                  {stateName}
+                </a>
+              </h4>
               <AreaChart
                 annotations={annotations}
                 data={stateData}
@@ -201,15 +209,6 @@ const SmallMultiplesContainer = () => {
                 yMax={secondMaxTotal}
                 yTicks={2}
               />
-              <p>
-                <a
-                  href={`/data/state/${stateName
-                    .toLowerCase()
-                    .replace(/\s/g, '-')}`}
-                >
-                  See all data from state
-                </a>
-              </p>
             </div>
           )
         })}

--- a/src/pages/dashboard/charts/_AreaChart.js
+++ b/src/pages/dashboard/charts/_AreaChart.js
@@ -79,7 +79,7 @@ export default function AreaChart({
               </text>
               <line
                 stroke="black"
-                x1={0}
+                x1={8}
                 x2={width - totalXMargin}
                 y1={yScale(tick)}
                 y2={yScale(tick)}


### PR DESCRIPTION
1. added gap on yAxis between text and horizontal line tick
2. utilize state Acronym on top of each small-multiple as link to data
    instead of repetitive"See all data from state" text link
![image](https://user-images.githubusercontent.com/58993339/79076523-d1992700-7cc8-11ea-9003-5849ef7dac29.png)
