### PR TITLE
feat(docs): API sandbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "react-typography": "^0.16.19",
     "reflexbox": "^4.0.6",
     "slugify": "^1.4.0",
+    "swagger-ui-react": "^3.25.0",
     "typography": "^0.16.19",
     "understory": "^1.11.0"
   },

--- a/src/components/common/swagger-sandbox.js
+++ b/src/components/common/swagger-sandbox.js
@@ -1,11 +1,12 @@
 import React from 'react'
 import SwaggerUI from 'swagger-ui-react'
 import 'swagger-ui-react/swagger-ui.css'
+import './swagger-sandbox.scss'
 
 export default () => (
   <SwaggerUI
     defaultModelExpandDepth={10}
     docExpansion="list"
-    url="https://api.swaggerhub.com/apis/janelastname/COVID-endpoints/1.0/swagger.json"
+    url="/api-docs/COVID-tracking-endpoints-1.0-docs.json"
   />
 )

--- a/src/components/common/swagger-sandbox.js
+++ b/src/components/common/swagger-sandbox.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import SwaggerUI from 'swagger-ui-react'
+import 'swagger-ui-react/swagger-ui.css'
+
+export default () => (
+  <SwaggerUI
+    defaultModelExpandDepth={10}
+    docExpansion="list"
+    url="https://api.swaggerhub.com/apis/janelastname/COVID-endpoints/1.0/swagger.json"
+  />
+)

--- a/src/components/common/swagger-sandbox.scss
+++ b/src/components/common/swagger-sandbox.scss
@@ -1,0 +1,21 @@
+.swagger-ui {
+  pre.microlight {
+  	line-height: 1rem;
+  }	
+  .download-contents {
+  	font-size: .7rem;
+  	line-height: 1.2rem;
+  }
+
+  td {
+  	font-size:.8rem;
+  }
+
+  tr {
+	line-height: 1.5rem;
+  }
+
+  ul {
+  	margin: auto;
+  }
+}

--- a/src/pages/data/api-sandbox.js
+++ b/src/pages/data/api-sandbox.js
@@ -1,14 +1,7 @@
 import React from 'react'
 import { graphql } from 'gatsby'
 import SwaggerSandbox from '../../components/common/swagger-sandbox'
-// import { Flex, Box } from '../../components/common/flexbox'
-// import DetailText from '../../components/common/detail-text'
 import Layout from '../../components/layout'
-// import StateList from '../../components/pages/data/state-list'
-// import StatesNav from '../../components/pages/data/state-nav'
-// import SummaryTable from '../../components/common/summary-table'
-// import { SyncInfobox } from '../../components/common/infobox'
-// import stateNavStyles from './index.module.scss'
 
 export default ({ data }) => (
   <Layout

--- a/src/pages/data/api-sandbox.js
+++ b/src/pages/data/api-sandbox.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import { graphql } from 'gatsby'
+import SwaggerSandbox from '../../components/common/swagger-sandbox'
+// import { Flex, Box } from '../../components/common/flexbox'
+// import DetailText from '../../components/common/detail-text'
+import Layout from '../../components/layout'
+// import StateList from '../../components/pages/data/state-list'
+// import StatesNav from '../../components/pages/data/state-nav'
+// import SummaryTable from '../../components/common/summary-table'
+// import { SyncInfobox } from '../../components/common/infobox'
+// import stateNavStyles from './index.module.scss'
+
+export default ({ data }) => (
+  <Layout
+    title="API Sandbox"
+    navigation={data.allContentfulNavigationGroup.edges[0].node.pages}
+  >
+    <SwaggerSandbox />
+  </Layout>
+)
+
+export const query = graphql`
+  query {
+    allContentfulNavigationGroup(filter: { slug: { eq: "data" } }) {
+      edges {
+        node {
+          pages {
+            ... on ContentfulPage {
+              title
+              link: slug
+            }
+            ... on ContentfulNavigationLink {
+              title
+              link: url
+            }
+          }
+        }
+      }
+    }
+  }
+`

--- a/static/api-docs/COVID-tracking-endpoints-1.0-docs.json
+++ b/static/api-docs/COVID-tracking-endpoints-1.0-docs.json
@@ -1,0 +1,541 @@
+{
+  "openapi" : "3.0.1",
+  "info" : {
+    "title" : "COVID Tracking API",
+    "description" : "API documentation.",
+    "version" : "1.0"
+  },
+  "servers" : [ {
+    "url" : "http://covidtracking.com"
+  }, {
+    "url" : "https://covidtracking.com"
+  } ],
+  "paths" : {
+    "/api/v1/states/daily.{format}" : {
+      "get" : {
+        "description" : "States historical data. Entries saved each day at 4 pm ET.",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "format",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "json"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/StateData"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/states/{state}/daily.{format}" : {
+      "get" : {
+        "description" : "State historical data. Entries saved each day at 4 pm ET.",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "state",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "CA"
+          }
+        }, {
+          "in" : "path",
+          "name" : "format",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "json"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/StateData"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/states/{state}/{date}.{format}" : {
+      "get" : {
+        "description" : "State historical data for a given date.",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "state",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "CA"
+          }
+        }, {
+          "in" : "path",
+          "name" : "date",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : 20200408
+          }
+        }, {
+          "in" : "path",
+          "name" : "format",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "json"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/StateData"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/states/current.{format}" : {
+      "get" : {
+        "description" : "States current values.",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "format",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "json"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/StateData"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/states/info.{format}" : {
+      "get" : {
+        "description" : "States information.",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "format",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "json"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/StateInfo"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/us/current.{format}" : {
+      "get" : {
+        "description" : "US current values.",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "format",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "json"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/USData"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/us/daily.{format}" : {
+      "get" : {
+        "description" : "US historical data. Entries saved each day at 4 pm ET.",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "format",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "json"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "type" : "array",
+                  "items" : {
+                    "$ref" : "#/components/schemas/USDataWithDate"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/us/{date}.{format}" : {
+      "get" : {
+        "description" : "US historical data for a given date.",
+        "parameters" : [ {
+          "in" : "path",
+          "name" : "date",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : 20200408
+          }
+        }, {
+          "in" : "path",
+          "name" : "format",
+          "required" : true,
+          "schema" : {
+            "type" : "string",
+            "example" : "json"
+          }
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "OK",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/USDataWithDate"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components" : {
+    "schemas" : {
+      "BasicData" : {
+        "type" : "object",
+        "properties" : {
+          "positive" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "Total cumulative positive test results."
+          },
+          "positiveIncrease" : {
+            "type" : "integer",
+            "nullable" : true
+          },
+          "negativeIncrease" : {
+            "type" : "integer",
+            "nullable" : true
+          },
+          "negative" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "Total cumulative negative test results."
+          },
+          "pending" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "Tests that have been submitted to a lab but no results have been reported yet."
+          },
+          "hospitalizedCurrently" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "Number of people currently hospitalized."
+          },
+          "hospitalizedCumulative" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "Total cumulative number of people hospitalized."
+          },
+          "inIcuCurrently" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "Number of people currently in ICU."
+          },
+          "inIcuCumulative" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "Total cumulative number of people in ICU."
+          },
+          "onVentilatorCurrently" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "Number of people currently on a ventilator."
+          },
+          "onVentilatorCumulative" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "Total cumulative number of people on ventilators."
+          },
+          "recovered" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "Total cumulative number of people recovered."
+          },
+          "hash" : {
+            "type" : "string",
+            "description" : "A unique ID changed every time the data updates. Survives a cache reset.",
+            "example" : "c385c4550994322e9818445fdc90e934dd027d4e"
+          },
+          "totalTestResults" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "Calculated value (positive + negative) of total test results."
+          },
+          "totalTestResultsIncrease" : {
+            "type" : "integer",
+            "nullable" : true
+          },
+          "hospitalized" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "Total cumulative number of people hospitalized."
+          },
+          "death" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "Total cumulative number of people that have died."
+          },
+          "deathIncrease" : {
+            "type" : "integer",
+            "nullable" : true
+          },
+          "lastModified" : {
+            "type" : "string",
+            "description" : "The date the API cache was last updated. Even if the values didn't change but the cache was manually cleared or reset the date will reflect that time of reset and doesn't necessarily indicate an update was made. Manual cache clearing is rare however."
+          },
+          "posNeg" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "DEPRECATED. Renamed to totalTestResults."
+          },
+          "total" : {
+            "type" : "integer",
+            "nullable" : true,
+            "description" : "DEPRECATED. Will be removed in the future. (positive + negative + pending). Pending has been an unstable value and should not count in any totals."
+          }
+        }
+      },
+      "USData" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BasicData"
+        } ],
+        "example" : {
+          "positive" : 426757,
+          "negative" : 1807168,
+          "pending" : 16933,
+          "hospitalizedCurrently" : 41264,
+          "hospitalizedCumulative" : 46803,
+          "inIcuCurrently" : 10215,
+          "inIcuCumulative" : 873,
+          "onVentilatorCurrently" : 4416,
+          "onVentilatorCumulative" : 108,
+          "recovered" : 19417,
+          "hash" : "c385c4550994322e9818445fdc90e934dd027d4e",
+          "totalTestResults" : 2233925,
+          "hospitalized" : 46803,
+          "death" : 14705,
+          "lastModified" : "2020-04-09T15:27:17.861Z",
+          "posNeg" : 2233925,
+          "total" : 2250858
+        }
+      },
+      "USDataWithDate" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/USData"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "date" : {
+              "type" : "integer",
+              "description" : "YYMMDD of the time we saved/visited their website."
+            }
+          }
+        } ],
+        "example" : {
+          "date" : 20200408
+        }
+      },
+      "StateData" : {
+        "allOf" : [ {
+          "$ref" : "#/components/schemas/BasicData"
+        }, {
+          "type" : "object",
+          "properties" : {
+            "date" : {
+              "type" : "integer",
+              "nullable" : false
+            },
+            "state" : {
+              "type" : "string",
+              "nullable" : false,
+              "description" : "State or territory postal code abbreviation."
+            },
+            "dateChecked" : {
+              "type" : "string",
+              "nullable" : false,
+              "description" : "ISO 8601 date of the time we saved/visited their website."
+            },
+            "fips" : {
+              "type" : "string",
+              "nullable" : false,
+              "description" : "Federal Information Processing Standard state code."
+            }
+          }
+        } ],
+        "example" : {
+          "date" : 20200408,
+          "state" : "CA",
+          "positive" : 16957,
+          "negative" : 127307,
+          "pending" : 14600,
+          "hospitalizedCurrently" : 2714,
+          "hospitalizedCumulative" : null,
+          "inIcuCurrently" : 1154,
+          "inIcuCumulative" : null,
+          "onVentilatorCurrently" : null,
+          "onVentilatorCumulative" : null,
+          "recovered" : null,
+          "hash" : "c597c8b5b77b179c9e590a881c97d79fea2bd2db",
+          "dateChecked" : "2020-04-08T20:00:00Z",
+          "death" : 442,
+          "hospitalized" : null,
+          "total" : 158864,
+          "totalTestResults" : 144264,
+          "posNeg" : 144264,
+          "fips" : "06",
+          "deathIncrease" : 68,
+          "hospitalizedIncrease" : 0,
+          "negativeIncrease" : 11943,
+          "positiveIncrease" : 1092,
+          "totalTestResultsIncrease" : 1303
+        }
+      },
+      "StateInfo" : {
+        "type" : "object",
+        "properties" : {
+          "state" : {
+            "type" : "string",
+            "nullable" : false,
+            "description" : "State or territory postal code abbreviation.",
+            "example" : "CA"
+          },
+          "name" : {
+            "type" : "string",
+            "nullable" : false,
+            "description" : "Full state or territory name.",
+            "example" : "California"
+          },
+          "covid19SiteOld" : {
+            "type" : "string",
+            "nullable" : true,
+            "example" : "https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/Immunization/ncov2019.aspx"
+          },
+          "covid19Site" : {
+            "type" : "string",
+            "nullable" : true,
+            "example" : "https://www.cdph.ca.gov/Programs/CID/DCDC/Pages/Immunization/ncov2019.aspx",
+            "description" : "Webpage dedicated to making results available to the public. More likely to contain numbers. We make regular screenshots of this URL."
+          },
+          "covid19SiteSecondary" : {
+            "type" : "string",
+            "nullable" : true,
+            "example" : "https://www.cdph.ca.gov/Programs/OPA/Pages/New-Release-2020.aspx",
+            "description" : "Typically more informational."
+          },
+          "twitter" : {
+            "type" : "string",
+            "example" : "@CAPublicHealth",
+            "nullable" : true,
+            "description" : "Twitter for the State Health Department."
+          },
+          "pui" : {
+            "type" : "string",
+            "description" : "Person Under Investigation; it is meant to capture positive, negative, and pending test results.",
+            "nullable" : true,
+            "example" : "Only positives"
+          },
+          "pum" : {
+            "type" : "boolean",
+            "nullable" : false,
+            "example" : false,
+            "description" : "Person Under Monitoring; we don’t collect these numbers as they are reported far less consistently across states."
+          },
+          "notes" : {
+            "type" : "string",
+            "nullable" : true,
+            "description" : "Notes about the information available and how we collect or record it.",
+            "example" : "The state has been inconsistent in its timing of reporting, so we used faster updating sources until 4/1, when we standardized on [California's new data dashboards](https://public.tableau.com/views/COVID-19PublicDashboard/Covid-19Public?:embed=y&:display_count=no&:showVizHome=no). This led to a drop in cases and deaths, as the state's data lags some other sources. We assume that \"tests conducted\" = \"people tested.\" The state also reported a huge batch of negative tests 4/4. Negative, pending, and total test reporting tend to lag positive test reporting by one day."
+          },
+          "fips" : {
+            "type" : "string",
+            "nullable" : false,
+            "example" : "06",
+            "description" : "Federal Information Processing Standard state code."
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
I think this PR could use some eyes (and maybe in the end we won't need it), but I wanted to put it out there and get some comments sooner rather than later!

I took a pass at writing up a spec for the v1 API, and made a little sandbox page (based on `swagger-ui-react`) that lays out the different schema/endpoints, and lets folks try executing queries.

I think ultimately we would want to tie the API and the docs closer together, so there's not two sources of truth (this is just pulling from a json file that I wrote in Swagger)--but this might be a handy in-between til then.