### PR TITLE
fix: dashboard contributor spacing

### DIFF
--- a/src/pages/dashboard/index.js
+++ b/src/pages/dashboard/index.js
@@ -44,7 +44,7 @@ const DashboardPage = () => {
         <strong>Source:</strong> The COVID Tracking Project
       </p>
       <p>
-        By Daniel Gilbert,
+        By Daniel Gilbert,{' '}
         <a href="https://gabeoleary.com/">Gabe O&apos;Leary</a>, Jeremia
         Kimelman, <a href="https://julialedur.com.br/">Júlia Ledur</a> and Melba
         Madrigal.


### PR DESCRIPTION
Fixes the spacing between contributor's names
----

Proposed:
![image](https://user-images.githubusercontent.com/18607205/79138139-3dcf6580-7d71-11ea-8518-67df67f18313.png)

Current:
![image](https://user-images.githubusercontent.com/18607205/79138159-47f16400-7d71-11ea-8795-45403cf69209.png)
