### PR TITLE
fix: Slash redirects

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -33,7 +33,6 @@ module.exports = {
     'gatsby-plugin-sass',
     'gatsby-transformer-yaml',
     'gatsby-plugin-eslint',
-    `gatsby-plugin-remove-trailing-slashes`,
     'gatsby-plugin-netlify',
     {
       resolve: 'gatsby-source-covid-tracking-api',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -35,6 +35,12 @@ module.exports = {
     'gatsby-plugin-eslint',
     'gatsby-plugin-netlify',
     {
+      resolve: `gatsby-plugin-canonical-urls`,
+      options: {
+        siteUrl: `https://covidtracking.com`,
+      },
+    },
+    {
       resolve: 'gatsby-source-covid-tracking-api',
       options: {
         file: './_data/v1/press.json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -14849,6 +14849,14 @@
         "micromatch": "^3.1.10"
       }
     },
+    "gatsby-plugin-canonical-urls": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-canonical-urls/-/gatsby-plugin-canonical-urls-2.2.1.tgz",
+      "integrity": "sha512-bbNfFlyZ1ksSbJ0iA+IPyybgcIaFF9EK+bEWTK01YqUEgUuosS+pY553qJ8AakxERaAgwxn1WwsovmeNgsOH3A==",
+      "requires": {
+        "@babel/runtime": "^7.8.7"
+      }
+    },
     "gatsby-plugin-eslint": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-eslint/-/gatsby-plugin-eslint-2.0.8.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15228,14 +15228,6 @@
         "@babel/runtime": "^7.8.7"
       }
     },
-    "gatsby-plugin-remove-trailing-slashes": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/gatsby-plugin-remove-trailing-slashes/-/gatsby-plugin-remove-trailing-slashes-2.2.1.tgz",
-      "integrity": "sha512-V/pLK1VkmqePlrPkEagsY4LSGVVG73+quiYOoNOWGzPi4FFSUu3GSiA8is4hiejB5fOs81TDhjYfvIIPbv5Q7w==",
-      "requires": {
-        "@babel/runtime": "^7.8.7"
-      }
-    },
     "gatsby-plugin-sass": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-sass/-/gatsby-plugin-sass-2.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "fast-xml-parser": "^3.16.0",
     "gatsby": "^2.19.45",
     "gatsby-image": "^2.2.44",
+    "gatsby-plugin-canonical-urls": "^2.2.1",
     "gatsby-plugin-eslint": "^2.0.8",
     "gatsby-plugin-manifest": "^2.2.48",
     "gatsby-plugin-netlify": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "gatsby-plugin-offline": "^3.0.41",
     "gatsby-plugin-page-creator": "^2.2.1",
     "gatsby-plugin-react-helmet": "^3.1.24",
-    "gatsby-plugin-remove-trailing-slashes": "^2.2.1",
     "gatsby-plugin-sass": "^2.2.0",
     "gatsby-plugin-sharp": "^2.4.13",
     "gatsby-plugin-typography": "^2.4.1",


### PR DESCRIPTION
Fixes #519 

- Removes the slash redirect plugin
- Adds a plugin to create canonical links

Leaving as draft so we can test the deploy previews.