### PR TITLE
Update barchart size 503

### DIFF
--- a/src/pages/dashboard/_CDCComparisonContainer.js
+++ b/src/pages/dashboard/_CDCComparisonContainer.js
@@ -71,13 +71,13 @@ export default function CDCComparisonContainer() {
           <BarChart
             data={cdcData}
             fill="#585BC1"
-            height={240}
+            height={252}
             marginBottom={40}
             marginLeft={80}
             marginRight={10}
             marginTop={10}
             xTicks={2}
-            width={240}
+            width={252}
             align="right"
             yMax={dailyMax}
           />
@@ -86,13 +86,13 @@ export default function CDCComparisonContainer() {
           <BarChart
             data={data}
             fill="#585BC1"
-            height={240}
+            height={252}
             marginBottom={40}
             marginLeft={80}
             marginRight={10}
             marginTop={10}
             xTicks={2}
-            width={240}
+            width={252}
             align="left"
           />
         </div>

--- a/src/pages/dashboard/_CDCComparisonContainer.js
+++ b/src/pages/dashboard/_CDCComparisonContainer.js
@@ -67,7 +67,7 @@ export default function CDCComparisonContainer() {
         </p>
       </div>
       <div style={{ display: 'flex' }}>
-        <div style={{ flexGrow: 1, width: '50%' }}>
+        <div style={{ flexGrow: 1, width: '50%', marginRight: 20 }}>
           <BarChart
             data={cdcData}
             fill="#585BC1"
@@ -78,10 +78,11 @@ export default function CDCComparisonContainer() {
             marginTop={10}
             xTicks={2}
             width={240}
+            align="right"
             yMax={dailyMax}
           />
         </div>
-        <div style={{ flexGrow: 1, width: '50%' }}>
+        <div style={{ flexGrow: 1, width: '50%', marginLeft: 20 }}>
           <BarChart
             data={data}
             fill="#585BC1"
@@ -92,6 +93,7 @@ export default function CDCComparisonContainer() {
             marginTop={10}
             xTicks={2}
             width={240}
+            align="left"
           />
         </div>
       </div>

--- a/src/pages/dashboard/_CDCComparisonContainer.js
+++ b/src/pages/dashboard/_CDCComparisonContainer.js
@@ -71,13 +71,13 @@ export default function CDCComparisonContainer() {
           <BarChart
             data={cdcData}
             fill="#585BC1"
-            height={400}
+            height={240}
             marginBottom={40}
             marginLeft={80}
             marginRight={10}
             marginTop={10}
             xTicks={2}
-            width={400}
+            width={240}
             yMax={dailyMax}
           />
         </div>
@@ -85,13 +85,13 @@ export default function CDCComparisonContainer() {
           <BarChart
             data={data}
             fill="#585BC1"
-            height={400}
+            height={240}
             marginBottom={40}
             marginLeft={80}
             marginRight={10}
             marginTop={10}
             xTicks={2}
-            width={400}
+            width={240}
           />
         </div>
       </div>

--- a/src/pages/dashboard/_CDCComparisonContainer.js
+++ b/src/pages/dashboard/_CDCComparisonContainer.js
@@ -80,6 +80,7 @@ export default function CDCComparisonContainer() {
             width={252}
             align="right"
             yMax={dailyMax}
+            showTicks={2}
           />
         </div>
         <div style={{ flexGrow: 1, width: '50%', marginLeft: 20 }}>
@@ -94,6 +95,7 @@ export default function CDCComparisonContainer() {
             xTicks={2}
             width={252}
             align="left"
+            showTicks={5}
           />
         </div>
       </div>

--- a/src/pages/dashboard/_UsCumulativeDeathsContainer.js
+++ b/src/pages/dashboard/_UsCumulativeDeathsContainer.js
@@ -48,6 +48,7 @@ export default function UsAreaChartContainer() {
             marginTop={10}
             xTicks={3}
             width={400}
+            align="center"
           />
         </div>
       </div>

--- a/src/pages/dashboard/_UsCumulativeDeathsContainer.js
+++ b/src/pages/dashboard/_UsCumulativeDeathsContainer.js
@@ -49,6 +49,7 @@ export default function UsAreaChartContainer() {
             xTicks={3}
             width={400}
             align="center"
+            showTicks={5}
           />
         </div>
       </div>

--- a/src/pages/dashboard/charts/_BarChart.js
+++ b/src/pages/dashboard/charts/_BarChart.js
@@ -16,6 +16,7 @@ const BarChart = ({
   marginTop,
   xTicks,
   width,
+  align,
   yMax,
   yTicks,
 }) => {
@@ -38,7 +39,7 @@ const BarChart = ({
     Math.floor(xScaleDomain.length / xTicks),
   )
   return (
-    <div>
+    <div align={align}>
       <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
         <g
           className="axis-group"

--- a/src/pages/dashboard/charts/_BarChart.js
+++ b/src/pages/dashboard/charts/_BarChart.js
@@ -47,7 +47,11 @@ const BarChart = ({
           <g className="chart-grid">
             {yScale.ticks(yTicks).map(tick => (
               <g key={tick}>
-                <text y={yScale(tick) + 6} x={`${tick}`.length * -11}>
+                <text
+                  y={yScale(tick) + 6}
+                  x={`${tick}`.length * -11}
+                  fontSize="smaller"
+                >
                   {formatNumber(tick)}
                 </text>
                 <line
@@ -69,9 +73,9 @@ const BarChart = ({
           {ticks.map(d => {
             const date = xScale.domain()[d]
             return (
-              <text key={d} x={xScale(date)} y="18">{`${formatDate(
-                date,
-              )}`}</text>
+              <text key={d} x={xScale(date)} y="18" fontSize="smaller">
+                {`${formatDate(date)}`}
+              </text>
             )
           })}
         </g>

--- a/src/pages/dashboard/charts/_BarChart.js
+++ b/src/pages/dashboard/charts/_BarChart.js
@@ -5,6 +5,7 @@ import { scaleBand, scaleLinear } from 'd3-scale'
 import React from 'react'
 
 import { formatDate, formatNumber } from '../_utils'
+import colors from '../../../scss/colors.scss'
 
 const BarChart = ({
   data,
@@ -19,6 +20,7 @@ const BarChart = ({
   align,
   yMax,
   yTicks,
+  showTicks,
 }) => {
   const totalXMargin = marginLeft + marginRight
   const totalYMargin = marginTop + marginBottom
@@ -38,6 +40,7 @@ const BarChart = ({
     xScaleDomain.length,
     Math.floor(xScaleDomain.length / xTicks),
   )
+  const textColor = { textColor: colors.text }
   return (
     <div align={align}>
       <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
@@ -46,17 +49,18 @@ const BarChart = ({
           transform={`translate(${marginLeft} ${marginTop})`}
         >
           <g className="chart-grid">
-            {yScale.ticks(yTicks).map(tick => (
+            {yScale.ticks(yTicks).map((tick, i) => (
               <g key={tick}>
                 <text
                   y={yScale(tick) + 6}
                   x={`${tick}`.length * -11}
                   fontSize="smaller"
+                  fill={i < showTicks ? { textColor } : 'none'}
                 >
                   {formatNumber(tick)}
                 </text>
                 <line
-                  stroke="black"
+                  stroke={i < showTicks ? 'black' : 'none'}
                   x1={0}
                   x2={width - totalXMargin}
                   y1={yScale(tick)}
@@ -106,6 +110,7 @@ BarChart.defaultProps = {
   xTicks: 5,
   yMax: null,
   yTicks: 4,
+  showTicks: 4,
 }
 
 BarChart.propTypes = {
@@ -125,5 +130,6 @@ BarChart.propTypes = {
   xTicks: PropTypes.number,
   yMax: PropTypes.number,
   yTicks: PropTypes.number,
+  showTicks: PropTypes.number,
 }
 export default BarChart


### PR DESCRIPTION

[503](https://github.com/COVID19Tracking/website/issues/503)

- Made the CDC bar charts smaller
- Made the bar chart text smaller 
- Added an `align` property to the bar chart

Before:
![image](https://user-images.githubusercontent.com/3722037/79154139-13939d00-7d9d-11ea-8811-5d343b01c134.png)

After:
![image](https://user-images.githubusercontent.com/3722037/79154790-2e1a4600-7d9e-11ea-9819-2bcc9a516652.png)

After, for the Total cumulative deaths chart
![image](https://user-images.githubusercontent.com/3722037/79154847-41c5ac80-7d9e-11ea-9a02-822def976419.png)
