### PR TITLE
fix(state-nav-no-script): remove unused Link import

### DIFF
--- a/src/components/pages/data/state-nav-no-script.js
+++ b/src/components/pages/data/state-nav-no-script.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import { Link } from 'gatsby'
 import { Box } from '../../common/flexbox'
 import stateNavNoJsStyle from './state-nav-no-js.module.scss'
 


### PR DESCRIPTION
I think I left this out in #523