### PR TITLE
fix: text-heavy page design

### DIFF
--- a/src/components/common/container.js
+++ b/src/components/common/container.js
@@ -1,9 +1,13 @@
 import React from 'react'
 import containerStyles from './container.module.scss'
 
-export default ({ children, narrow }) => {
+export default ({ children, narrow, textHeavy = false }) => {
   return (
-    <div className={`container ${containerStyles.container}`}>
+    <div
+      className={`container ${textHeavy && containerStyles.textHeavy} ${
+        containerStyles.container
+      }`}
+    >
       {narrow ? (
         <div className={`${containerStyles.containerNarrow}`}>{children}</div>
       ) : (

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -27,6 +27,7 @@
     }
     h2 {
       font-size: 30px;
+      font-size: 1.875rem;
       line-height: 33px;
       margin: 2rem 0 1rem;
       padding-top: 1em;

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -29,8 +29,7 @@
       font-size: 30px;
       font-size: 1.875rem;
       line-height: 37.5px;
-      margin: 2rem 0 0.5rem;
-      padding-top: 1em;
+      margin: 4rem 0 0.5rem;
     }
     h3 {
       margin-bottom: 1em;

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -26,6 +26,9 @@
     margin: 2rem 0 1rem;
     padding-top: 1em;
   }
+  h3 {
+    margin-bottom: 1em;
+  }
   li {
     margin-bottom: 0.75rem;
   }

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -19,6 +19,7 @@
     max-width: 42rem;
   }
   &.text-heavy {
+    margin: 5em auto;
     @media (min-width: $viewport-lg) {
       font-size: 22px;
       line-height: 1.5;

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -41,7 +41,7 @@
     p,
     ul,
     ol {
-      margin-bottom: 2em;
+      margin-bottom: 1.6em;
     }
   }
 }

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -29,7 +29,7 @@
       font-size: 30px;
       font-size: 1.875rem;
       line-height: 37.5px;
-      margin: 2rem 0 1rem;
+      margin: 2rem 0 0.5rem;
       padding-top: 1em;
     }
     h3 {

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -22,6 +22,7 @@
     margin: 5em auto;
     @media (min-width: $viewport-lg) {
       font-size: 22px;
+      font-size: 1.375rem;
       line-height: 1.5;
     }
     h2 {

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -24,8 +24,13 @@
     font-size: 30px;
     line-height: 33px;
     margin: 2rem 0 1rem;
+    padding-top: 1em;
   }
   li {
     margin-bottom: 0.75rem;
+  }
+  p,
+  ul {
+    margin-bottom: 2em;
   }
 }

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -11,6 +11,8 @@
   @media (min-width: $viewport-lg) {
     margin-left: auto;
     margin-right: auto;
+    font-size: 22px;
+    line-height: 1.5;
   }
   @media (min-width: $viewport-xl) {
     max-width: 1140px;

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -28,7 +28,7 @@
     h2 {
       font-size: 30px;
       font-size: 1.875rem;
-      line-height: 33px;
+      line-height: 37.5px;
       margin: 2rem 0 1rem;
       padding-top: 1em;
     }

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -20,4 +20,9 @@
   &.container-narrow {
     max-width: 900px;
   }
+  h2 {
+    font-size: 30px;
+    line-height: 33px;
+    margin: 2rem 0 1rem;
+  }
 }

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -25,4 +25,7 @@
     line-height: 33px;
     margin: 2rem 0 1rem;
   }
+  li {
+    margin-bottom: 0.75rem;
+  }
 }

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -11,8 +11,6 @@
   @media (min-width: $viewport-lg) {
     margin-left: auto;
     margin-right: auto;
-    font-size: 22px;
-    line-height: 1.5;
   }
   @media (min-width: $viewport-xl) {
     max-width: 1140px;
@@ -20,21 +18,27 @@
   & .container-narrow {
     max-width: 42rem;
   }
-  h2 {
-    font-size: 30px;
-    line-height: 33px;
-    margin: 2rem 0 1rem;
-    padding-top: 1em;
-  }
-  h3 {
-    margin-bottom: 1em;
-  }
-  li {
-    margin-bottom: 0.75rem;
-  }
-  p,
-  ul,
-  ol {
-    margin-bottom: 2em;
+  &.text-heavy {
+    @media (min-width: $viewport-lg) {
+      font-size: 22px;
+      line-height: 1.5;
+    }
+    h2 {
+      font-size: 30px;
+      line-height: 33px;
+      margin: 2rem 0 1rem;
+      padding-top: 1em;
+    }
+    h3 {
+      margin-bottom: 1em;
+    }
+    li {
+      margin-bottom: 0.75rem;
+    }
+    p,
+    ul,
+    ol {
+      margin-bottom: 2em;
+    }
   }
 }

--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -33,7 +33,8 @@
     margin-bottom: 0.75rem;
   }
   p,
-  ul {
+  ul,
+  ol {
     margin-bottom: 2em;
   }
 }

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -9,7 +9,15 @@ import Container from '../common/container'
 import SkipNavigation from '../common/skip-navigation'
 import '../../scss/global.scss'
 
-const Layout = ({ title, children, navigation, noMargin, hasHero, narrow }) => {
+const Layout = ({
+  title,
+  children,
+  navigation,
+  noMargin,
+  hasHero,
+  narrow,
+  textHeavy,
+}) => {
   const data = useStaticQuery(graphql`
     query SiteTitleQuery {
       site {
@@ -33,7 +41,9 @@ const Layout = ({ title, children, navigation, noMargin, hasHero, narrow }) => {
       />
       <main id="main">
         <SkipNavContent />
-        <Container narrow={narrow}>{children}</Container>
+        <Container narrow={narrow} textHeavy={textHeavy}>
+          {children}
+        </Container>
       </main>
       <Footer />
     </>

--- a/src/pages/about-project/in-the-press.js
+++ b/src/pages/about-project/in-the-press.js
@@ -5,7 +5,7 @@ import PressList from '../../components/common/press-list'
 import Layout from '../../components/layout'
 
 export default ({ data }) => (
-  <Layout title="In the press">
+  <Layout title="In the press" textHeavy>
     <PressLogos />
     <PressList items={data.allCovidPress.edges} />
   </Layout>

--- a/src/pages/blog.js
+++ b/src/pages/blog.js
@@ -4,7 +4,7 @@ import Layout from '../components/layout'
 import DetailText from '../components/common/detail-text'
 
 export default ({ data }) => (
-  <Layout title="Blog">
+  <Layout title="Blog" textHeavy>
     {data.allContentfulBlogPost.edges.map(({ node }) => (
       <>
         <h3>

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -6,7 +6,7 @@ import DetailText from '../components/common/detail-text'
 export default ({ data }) => {
   const blogPost = data.allContentfulBlogPost.edges[0].node
   return (
-    <Layout title={blogPost.title}>
+    <Layout title={blogPost.title} textHeavy>
       <DetailText>{blogPost.updatedAt}</DetailText>
       <div
         dangerouslySetInnerHTML={{

--- a/src/templates/content.js
+++ b/src/templates/content.js
@@ -9,6 +9,7 @@ const ContentPage = ({ data }) => {
       title={page.title}
       navigation={page.navigationGroup ? page.navigationGroup.pages : false}
       narrow
+      textHeavy
     >
       <div
         dangerouslySetInnerHTML={{ __html: page.body.childMarkdownRemark.html }}


### PR DESCRIPTION
This PR resolves the design fixes for text-based pages, per [Ethan's designs](https://www.figma.com/file/fKUKsYMNw3NLSyIEOI1HKc/v2-refresh) in #452 

Here are some screenshots of this design:
![image](https://user-images.githubusercontent.com/18607205/79261892-b3106880-7e4d-11ea-82d8-45e36d4f077b.png)
![image](https://user-images.githubusercontent.com/18607205/79261912-b9064980-7e4d-11ea-925b-98660f2dc8a1.png)
![image](https://user-images.githubusercontent.com/18607205/79261916-bc013a00-7e4d-11ea-9414-128b44572196.png)
![image](https://user-images.githubusercontent.com/18607205/79261926-befc2a80-7e4d-11ea-8fdc-33ba64c9b010.png)

@beep I would _love_ for you to review this :+1: 

Edit: since the scss changes are at the container level, they hit other pages as well:
![image](https://user-images.githubusercontent.com/18607205/79262619-d7207980-7e4e-11ea-8cf6-85990f9bdc3b.png)

I would suggest making a scss class for text-heavy pages and applying these styles there. @kevee what do you think?