### PR TITLE
fix(dashboard): Makes the div containing the two death charts space better

### DIFF
--- a/src/pages/dashboard/index.js
+++ b/src/pages/dashboard/index.js
@@ -130,7 +130,7 @@ const DashboardPage = () => {
         <a href="https://twitter.com/jburnmurdoch">John Burn-Murdoch</a>, a data
         journalist at the <em>Financial Times</em>, pointed out.
       </p>
-      <div style={{ display: 'flex' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-around' }}>
         <UsCumulativeDeathsContainer />
         <StateCumulativeDeathsContainer />
       </div>


### PR DESCRIPTION
I think this looks better on the page.
![Screen Shot 2020-04-14 at 5 56 35 PM](https://user-images.githubusercontent.com/50382381/79287855-f254ae80-7e79-11ea-978a-b59571be1e6b.png)

