### PR TITLE
fix(text-heavy): add L/R margins on smaller viewports

### DIFF
--- a/src/components/common/container.module.scss
+++ b/src/components/common/container.module.scss
@@ -17,6 +17,10 @@
   }
   & .container-narrow {
     max-width: 42rem;
+    @media (max-width: $viewport-lg) {
+      margin-right: 1.5rem;
+      margin-left: 1.5rem;
+    }
   }
   &.text-heavy {
     margin: 5em auto;


### PR DESCRIPTION
current:
![image](https://user-images.githubusercontent.com/18607205/79358549-9122ee80-7efe-11ea-87ef-a7481d07bf0b.png)

proposed :sparkles: :
![image](https://user-images.githubusercontent.com/18607205/79358620-aa2b9f80-7efe-11ea-903c-d2501d85cab3.png)


(this mirrors the 1.5rem spacing on mobile for other pages)