### PR TITLE
fix(charts): Add legend to "Positive tests and total tests in the US" chart

### DIFF
--- a/src/pages/dashboard/_UsPositiveAndTotalTestsContainer.js
+++ b/src/pages/dashboard/_UsPositiveAndTotalTestsContainer.js
@@ -3,7 +3,11 @@ import { graphql, useStaticQuery } from 'gatsby'
 import { format } from 'd3-format'
 
 import AreaChart from '../../components/charts/area-chart'
-import { parseDate } from '../../utilities/visualization'
+import {
+  parseDate,
+  totalColor,
+  positiveColor,
+} from '../../utilities/visualization'
 
 export default function UsAreaChartContainer() {
   const data = useStaticQuery(graphql`
@@ -40,6 +44,22 @@ export default function UsAreaChartContainer() {
       </p>
       <div style={{ width: '50%', align: 'center', margin: 'auto' }}>
         <h4>Positive tests and total tests in the US</h4>
+        <ul className="chart-legend">
+          <li>
+            <div
+              className="chart-legend-color"
+              style={{ backgroundColor: positiveColor }}
+            />
+            <div>Positive tests</div>
+          </li>
+          <li>
+            <div
+              className="chart-legend-color"
+              style={{ backgroundColor: totalColor }}
+            />
+            <div>Total tests</div>
+          </li>
+        </ul>
         <AreaChart
           data={transformedData}
           fill={d => {


### PR DESCRIPTION
Before:
<img width="570" alt="Screen Shot 2020-04-16 at 10 50 36 AM" src="https://user-images.githubusercontent.com/780941/79471073-1fb37080-7fd0-11ea-9f24-c19a122a8eb6.png">

After:
<img width="645" alt="Screen Shot 2020-04-16 at 10 47 58 AM" src="https://user-images.githubusercontent.com/780941/79470989-090d1980-7fd0-11ea-9d36-68a8f4317342.png">

Refs #578