### PR TITLE
fix(dashboard): update bubble legend style closes #593

### DIFF
--- a/src/pages/dashboard/charts/_Map.js
+++ b/src/pages/dashboard/charts/_Map.js
@@ -346,7 +346,13 @@ const BubbleLegend = ({ r, maxValue, width, height }) => {
     />
   ))
   const legendText = legendData.map(d => (
-    <text key={`legendText${d}`} x={(width * 2) / 3} y={height - 2 * r(d)}>
+    <text
+      key={`legendText${d}`}
+      x={(width * 2) / 3 + 4}
+      y={height - 2 * r(d) - 2}
+      fill="#ababab"
+      fontSize="15px"
+    >
       {formatNumber(d)}
     </text>
   ))

--- a/src/pages/dashboard/charts/map.scss
+++ b/src/pages/dashboard/charts/map.scss
@@ -44,7 +44,7 @@
   bottom: 510px;
   right: 20px;
   @media screen and (max-width: $viewport-sm) {
-    bottom: 300px;
+    bottom: 380px;
     right: 5px;
   }
 }


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/16123225/79494626-2e9e2100-7fd8-11ea-9d9e-389630577552.png)

after:
![image](https://user-images.githubusercontent.com/16123225/79494593-20500500-7fd8-11ea-92b4-d361b4e065c9.png)

(change in position is a function of different window sizes while taking screenshots)