### PR TITLE
fix(charts): adjust small multiples container for left and right alignment

### DIFF
--- a/src/pages/dashboard/dashboard.scss
+++ b/src/pages/dashboard/dashboard.scss
@@ -180,15 +180,19 @@
   padding: 0 5px;
 }
 
+$small-multiples-chart-gutter: 1%;
+
 .small-multiples-chart {
   line-height: 1rem;
-  padding: 0 1%;
+  padding: 0 ($small-multiples-chart-gutter * 2);
   width: 50%;
+
   svg {
     background-color: $color-slate-100;
   }
 
   @media screen and (min-width: $viewport-sm) {
+    padding: 0 $small-multiples-chart-gutter;
     width: calc(100% / 4);
   }
 
@@ -216,6 +220,11 @@
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+  margin: 0 - ($small-multiples-chart-gutter * 2);
+
+  @media screen and (min-width: $viewport-sm) {
+    margin: 0 - $small-multiples-chart-gutter;
+  }
 }
 
 .small-multiples-chart-container--collapsed {


### PR DESCRIPTION
Fixes a minor display issue in small multiple charts caused by padding set on the individual charts. Now the left edges of the charts aligns properly with the heading/toggle. Also increases the gutters slightly at smallest breakpoint.

## Before:

<img width="1221" alt="Screen Shot 2020-04-16 at 5 50 44 PM" src="https://user-images.githubusercontent.com/63169602/79510259-07ad1280-800b-11ea-9676-d3aebea419ce.png">

## After:

<img width="1238" alt="Screen Shot 2020-04-16 at 5 50 31 PM" src="https://user-images.githubusercontent.com/63169602/79510254-05e34f00-800b-11ea-816b-a079f88c84f9.png">