### PR TITLE
fix(charts): prevent state names from breaking to new lines in small multiples

### DIFF
--- a/src/pages/dashboard/_StateCumulativeTestsContainer.js
+++ b/src/pages/dashboard/_StateCumulativeTestsContainer.js
@@ -253,7 +253,14 @@ export default function CumulativeTestsByStateContainer() {
                   .toLowerCase()
                   .replace(/\s/g, '-')}`}
               >
-                <h4>{stateName}</h4>
+                <h4>
+                  <span className="small-multiples-chart-state-name">
+                    {stateName}
+                  </span>
+                  <span className="small-multiples-chart-state-key">
+                    {state.key}
+                  </span>
+                </h4>
               </a>
               <AreaChart
                 annotations={annotations}

--- a/src/pages/dashboard/dashboard.scss
+++ b/src/pages/dashboard/dashboard.scss
@@ -204,11 +204,26 @@
 .small-multiples-chart__see-all-link {
   display: inline-block;
   margin-bottom: 0.4rem;
+  white-space: nowrap;
 
   h4 {
     font-size: 14px;
     line-height: 1.2;
     margin: 0;
+
+    & .small-multiples-chart-state-name {
+      display: none;
+
+      @media screen and (min-width: $viewport-ms) {
+        display: inline;
+      }
+    }
+
+    & .small-multiples-chart-state-key {
+      @media screen and (min-width: $viewport-ms) {
+        display: none;
+      }
+    }
   }
 }
 

--- a/src/utilities/visualization.js
+++ b/src/utilities/visualization.js
@@ -35,7 +35,7 @@ export const getStateName = abbr => {
     MI: 'Michigan',
     MN: 'Minnesota',
     MO: 'Missouri',
-    MP: 'Northern Mariana Islands',
+    MP: 'N. Mariana Islands',
     MS: 'Mississippi',
     MT: 'Montana',
     NC: 'North Carolina',


### PR DESCRIPTION
- Changes "Northen Mariana Islands" to "N. Mariana Islands"
- Prevents text wrapping on small multiple state name links
- Use states keys on smaller screens

Fixes COVID19Tracking/website#620

<img width="1208" alt="Screen Shot 2020-04-16 at 6 38 30 PM" src="https://user-images.githubusercontent.com/63169602/79513306-85741c80-8011-11ea-8803-82fc809a2f1f.png">
<img width="614" alt="Screen Shot 2020-04-16 at 6 38 40 PM" src="https://user-images.githubusercontent.com/63169602/79513307-85741c80-8011-11ea-93f3-6f6c05e51a84.png">
