### PR TITLE
fix(dashboard): align map legend with toggle

### DIFF
--- a/src/pages/dashboard/charts/map.scss
+++ b/src/pages/dashboard/charts/map.scss
@@ -41,7 +41,7 @@
 
 .map-legend {
   position: absolute;
-  bottom: 510px;
+  bottom: 539px;
   right: 20px;
   @media screen and (max-width: $viewport-sm) {
     bottom: 300px;


### PR DESCRIPTION
Fixes #581

<img width="999" alt="Screen Shot 2020-04-16 at 8 17 00 PM" src="https://user-images.githubusercontent.com/1994207/79518564-709e8580-801f-11ea-97bc-cf65c4e3dc66.png">

This does not affect positioning on small screen sizes, which currently looks like this:

<img width="354" alt="Screen Shot 2020-04-16 at 8 17 29 PM" src="https://user-images.githubusercontent.com/1994207/79518587-7dbb7480-801f-11ea-8be9-5c894e52a69b.png">
