### PR TITLE
fix(charts): remove M from y tick labels on pos tests chart (except last one)

### DIFF
--- a/src/components/charts/area-chart.js
+++ b/src/components/charts/area-chart.js
@@ -75,7 +75,7 @@ const AreaChart = ({
             ))}
           </g>
           <g>
-            {yScale.ticks(yTicks).map(tick => (
+            {yScale.ticks(yTicks).map((tick, i) => (
               <g key={tick}>
                 <svg
                   y={yScale(tick) + 4}
@@ -83,7 +83,9 @@ const AreaChart = ({
                   className={chartStyles.yTickLabel}
                 >
                   <text className={chartStyles.label} textAnchor="end">
-                    {yFormat ? yFormat(tick) : formatNumber(tick)}
+                    {yFormat
+                      ? yFormat(tick, i, yScale.ticks(yTicks).length)
+                      : formatNumber(tick)}
                   </text>
                 </svg>
                 <line

--- a/src/pages/dashboard/_UsPositiveAndTotalTestsContainer.js
+++ b/src/pages/dashboard/_UsPositiveAndTotalTestsContainer.js
@@ -11,6 +11,16 @@ import {
 
 import dashboardStyles from './dashboard.module.scss'
 
+function yFormat(tick, i, totalTicks) {
+  const formattedTick = format('~s')(tick)
+
+  if (i + 1 !== totalTicks) {
+    return formattedTick.replace(/\D/g, '')
+  }
+
+  return formattedTick
+}
+
 export default function UsAreaChartContainer() {
   const data = useStaticQuery(graphql`
     {
@@ -79,7 +89,7 @@ export default function UsAreaChartContainer() {
             marginTop={10}
             xTicks={2}
             width={400}
-            yFormat={format('~s')}
+            yFormat={yFormat}
           />
         </div>
       </div>


### PR DESCRIPTION
Fixes COVID19Tracking/website#567.

<img width="562" alt="Screen Shot 2020-04-17 at 5 35 34 PM" src="https://user-images.githubusercontent.com/63169602/79615958-df3c1b80-80d1-11ea-8d4c-cc69679271a0.png">
