### PR TITLE
fix(charts): fix regression issues with charts layout and responsiveness

### DIFF
--- a/src/components/charts/bar-chart.js
+++ b/src/components/charts/bar-chart.js
@@ -43,68 +43,61 @@ const BarChart = ({
   )
 
   return (
-    <div align={align}>
-      <svg
-        className={chartStyles.chart}
-        width={width}
-        height={height}
-        viewBox={`0 0 ${width} ${height}`}
-      >
-        <g transform={`translate(${marginLeft} ${marginTop})`}>
-          <g>
-            {yScale.ticks(yTicks).map((tick, i) => (
-              <g key={tick}>
-                {i < showTicks && (
-                  <>
-                    <text
-                      className={chartStyles.yTickLabel}
-                      y={yScale(tick) + 6}
-                      x={`${tick}`.length * -12}
-                    >
-                      {formatNumber(tick)}
-                    </text>
-                    <line
-                      className={chartStyles.gridLine}
-                      x1={0}
-                      x2={width - totalXMargin}
-                      y1={yScale(tick)}
-                      y2={yScale(tick)}
-                    />
-                  </>
-                )}
-              </g>
-            ))}
-          </g>
-        </g>
-
-        <g transform={`translate(${marginLeft}, ${height - marginBottom})`}>
-          {ticks.map(d => {
-            const date = xScale.domain()[d]
-            return (
-              <text
-                className={`${chartStyles.label} ${chartStyles.xTickLabel}`}
-                key={d}
-                x={xScale(date)}
-                y="25"
-              >{`${formatDate(date)}`}</text>
-            )
-          })}
-        </g>
-
-        <g transform={`translate(${marginLeft} ${marginTop})`}>
-          {data.map(d => (
-            <rect
-              key={d.date}
-              x={xScale(d.date)}
-              y={yScale(d.value)}
-              height={yScale(0) - yScale(d.value)}
-              width={xScale.bandwidth()}
-              fill={fill}
-            />
+    <svg className={chartStyles.chart} viewBox={`0 0 ${width} ${height}`}>
+      <g transform={`translate(${marginLeft} ${marginTop})`}>
+        <g>
+          {yScale.ticks(yTicks).map((tick, i) => (
+            <g key={tick}>
+              {i < showTicks && (
+                <>
+                  <text
+                    className={chartStyles.yTickLabel}
+                    y={yScale(tick) + 6}
+                    x={`${tick}`.length * -12}
+                  >
+                    {formatNumber(tick)}
+                  </text>
+                  <line
+                    className={chartStyles.gridLine}
+                    x1={0}
+                    x2={width - totalXMargin}
+                    y1={yScale(tick)}
+                    y2={yScale(tick)}
+                  />
+                </>
+              )}
+            </g>
           ))}
         </g>
-      </svg>
-    </div>
+      </g>
+
+      <g transform={`translate(${marginLeft}, ${height - marginBottom})`}>
+        {ticks.map(d => {
+          const date = xScale.domain()[d]
+          return (
+            <text
+              className={`${chartStyles.label} ${chartStyles.xTickLabel}`}
+              key={d}
+              x={xScale(date)}
+              y="25"
+            >{`${formatDate(date)}`}</text>
+          )
+        })}
+      </g>
+
+      <g transform={`translate(${marginLeft} ${marginTop})`}>
+        {data.map(d => (
+          <rect
+            key={d.date}
+            x={xScale(d.date)}
+            y={yScale(d.value)}
+            height={yScale(0) - yScale(d.value)}
+            width={xScale.bandwidth()}
+            fill={fill}
+          />
+        ))}
+      </g>
+    </svg>
   )
 }
 

--- a/src/components/charts/horizontal-bar-chart.js
+++ b/src/components/charts/horizontal-bar-chart.js
@@ -31,57 +31,55 @@ export default function HorizontalBarChart({
     .range([width - totalXMargin, 0])
 
   return (
-    <div>
-      <svg className={chartStyles.chart} viewBox={`0 0 ${width} ${height}`}>
-        <g transform={`translate(${marginLeft} ${marginTop})`}>
-          {xScale.ticks(xTicks).map(tick => (
-            <g key={tick}>
-              <text
-                className={`${chartStyles.label} ${chartStyles.xTickLabel}`}
-                x={245 - xScale(tick)}
-                y={height - marginBottom}
-              >
-                {formatTick(tick)}
-              </text>
-              <line
-                className={chartStyles.gridLine}
-                x1={xScale(tick)}
-                x2={xScale(tick)}
-                y1={0}
-                y2={height - totalYMargin}
-              />
-            </g>
-          ))}
-        </g>
-
-        <g transform={`translate(0, ${marginTop})`}>
-          {data.map(d => (
-            <svg
-              y={yScale(d.name) + 11}
-              x={marginLeft - 10}
-              className={chartStyles.yTickLabel}
-              key={d.name}
+    <svg className={chartStyles.chart} viewBox={`0 0 ${width} ${height}`}>
+      <g transform={`translate(${marginLeft} ${marginTop})`}>
+        {xScale.ticks(xTicks).map(tick => (
+          <g key={tick}>
+            <text
+              className={`${chartStyles.label} ${chartStyles.xTickLabel}`}
+              x={245 - xScale(tick)}
+              y={height - marginBottom}
             >
-              <text className={chartStyles.label} textAnchor="end">
-                {`${d.name}`}
-              </text>
-            </svg>
-          ))}
-        </g>
-
-        <g transform={`translate(${marginLeft}, ${marginTop})`}>
-          {data.map(d => (
-            <rect
-              key={d.name}
-              x={0}
-              y={yScale(d.name)}
-              height={yScale.bandwidth()}
-              width={xScale(0) - xScale(d.value)}
-              fill={fill}
+              {formatTick(tick)}
+            </text>
+            <line
+              className={chartStyles.gridLine}
+              x1={xScale(tick)}
+              x2={xScale(tick)}
+              y1={0}
+              y2={height - totalYMargin}
             />
-          ))}
-        </g>
-      </svg>
-    </div>
+          </g>
+        ))}
+      </g>
+
+      <g transform={`translate(0, ${marginTop})`}>
+        {data.map(d => (
+          <svg
+            y={yScale(d.name) + 11}
+            x={marginLeft - 10}
+            className={chartStyles.yTickLabel}
+            key={d.name}
+          >
+            <text className={chartStyles.label} textAnchor="end">
+              {`${d.name}`}
+            </text>
+          </svg>
+        ))}
+      </g>
+
+      <g transform={`translate(${marginLeft}, ${marginTop})`}>
+        {data.map(d => (
+          <rect
+            key={d.name}
+            x={0}
+            y={yScale(d.name)}
+            height={yScale.bandwidth()}
+            width={xScale(0) - xScale(d.value)}
+            fill={fill}
+          />
+        ))}
+      </g>
+    </svg>
   )
 }


### PR DESCRIPTION
Looks like some merge conflict resolution snuck older markup back. In this PR:

- Removed width/height attributes in `BarChart` svg
- Removed unnecessary wrapper divs around `BarChart` and `HorizontalBarChart`

Fixes #644. Regression issues will be fully resolved with the additional merge of https://github.com/COVID19Tracking/website/pull/641.

## Before

<img width="374" alt="Screen Shot 2020-04-18 at 10 42 15 AM" src="https://user-images.githubusercontent.com/63169602/79640843-e7439c00-8161-11ea-909b-550bdc8a4dee.png">

<img width="373" alt="Screen Shot 2020-04-18 at 10 42 41 AM" src="https://user-images.githubusercontent.com/63169602/79640844-e7dc3280-8161-11ea-95c7-05256289cbab.png">

## After

<img width="371" alt="Screen Shot 2020-04-20 at 2 59 43 PM" src="https://user-images.githubusercontent.com/63169602/79789205-d76db880-8317-11ea-9f8b-ffccbff1b36c.png">

<img width="372" alt="Screen Shot 2020-04-20 at 3 00 17 PM" src="https://user-images.githubusercontent.com/63169602/79789207-d76db880-8317-11ea-9a36-5653996373e6.png">
