### PR TITLE
chore: Add config file for TypoCI

### DIFF
--- a/.typo-ci.yml
+++ b/.typo-ci.yml
@@ -1,0 +1,10 @@
+dictionaries:
+  - en
+excluded_files:
+  - 'node_modules/**/*'
+  - '*.module.scss'
+  - 'package-lock.json'
+  - '.typo-ci.yml'
+
+excluded_words:
+  - covid


### PR DESCRIPTION
Added a config file for TypoCI. Mostly to teach it the word "covid"