### PR TITLE
chore: Add visualization sub nav to page

### DIFF
--- a/src/pages/about-data/visualization-guide/index.js
+++ b/src/pages/about-data/visualization-guide/index.js
@@ -14,7 +14,7 @@ import dashboardStyles from './dashboard.module.scss'
 const VisualizationGuidePage = ({ data }) => {
   return (
     <Layout
-      title="Visualization guide"
+      title="Visualization Guide"
       navigation={data.allContentfulNavigationGroup.edges[0].node.pages}
     >
       <div className="subhead">

--- a/src/pages/about-data/visualization-guide/index.js
+++ b/src/pages/about-data/visualization-guide/index.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import { graphql } from 'gatsby'
 import Layout from '../../../components/layout'
 import CDCComparisonContainer from './_CDCComparisonContainer'
 import MapContainer from './_MapContainer'
@@ -10,9 +11,12 @@ import UsPositiveAndTotalTestsContainer from './_UsPositiveAndTotalTestsContaine
 import './dashboard.scss'
 import dashboardStyles from './dashboard.module.scss'
 
-const VisualizationGuidePage = () => {
+const VisualizationGuidePage = ({ data }) => {
   return (
-    <Layout title="Visualization guide">
+    <Layout
+      title="Visualization guide"
+      navigation={data.allContentfulNavigationGroup.edges[0].node.pages}
+    >
       <div className="subhead">
         Explore graphics made with the COVID Tracking Project dataset along with
         tips to help you present the data in the clearest and most accurate way
@@ -243,3 +247,24 @@ const VisualizationGuidePage = () => {
 }
 
 export default VisualizationGuidePage
+
+export const query = graphql`
+  query {
+    allContentfulNavigationGroup(filter: { slug: { eq: "about-data" } }) {
+      edges {
+        node {
+          pages {
+            ... on ContentfulPage {
+              title
+              link: slug
+            }
+            ... on ContentfulNavigationLink {
+              title
+              link: url
+            }
+          }
+        }
+      }
+    }
+  }
+`


### PR DESCRIPTION
<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.
-->

## Description

Added subnavigation to the visualization page.


## Related Issues
Fixes #672 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

## Go-live time
Anytime
<!--
  If this PR is for a feature that should not 
  be merged until a specific time, let us know!
-->


<!--
## Post-merge steps

  Outline things that need to be done once this is merged.
  This is usually work that has to be done in our CMS to change
  content or navigation.
-->