### PR TITLE
fix(header): reverse mobile header title/menu

### DIFF
--- a/src/components/common/list-arrow.js
+++ b/src/components/common/list-arrow.js
@@ -5,7 +5,7 @@ export default ({ items }) => {
   return (
     <ul className={listArrowStyles.listArrow}>
       {items.map(node => (
-        <li className={listArrowStyles.listArrowItem}>
+        <li key={node.props.children} className={listArrowStyles.listArrowItem}>
           {node}
           <span aria-hidden className={listArrowStyles.listArrowIcon}>
             →

--- a/src/components/layout/header.module.scss
+++ b/src/components/layout/header.module.scss
@@ -149,7 +149,7 @@
       }
 
       @media (max-width: $viewport-sm) {
-        flex-direction: column-reverse;
+        flex-direction: column;
       }
 
       @media (max-width: $viewport-ms) {

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -2,6 +2,17 @@
 @import './colors.module.scss';
 @import './breakpoints.module.scss';
 
+html {
+  box-sizing: border-box;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
+
 body {
   color: $text;
   font: normal 100%/1.5 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Helvetica', 'Arial', 'sans-serif';


### PR DESCRIPTION
## Description
Fixes for https://github.com/COVID19Tracking/website/pull/638

* Fix reverted header menu/title on small screens  
* Add box-sizing declaration to HTML  
* Fix missing `key` attr in `list-arrow.js`

## Related Issues
https://github.com/COVID19Tracking/website/pull/638

## Post-merge steps

Still an issue with `<col>` being a direct child of `<table>` (see orig PR)