### PR TITLE
fix(typography): restore box-sizing globally

### DIFF
--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -2,9 +2,21 @@
 @import './colors.module.scss';
 @import './breakpoints.module.scss';
 
+html {
+  box-sizing: border-box;
+}
+
+*,
+*:before,
+*:after {
+  box-sizing: inherit;
+}
+
 body {
   color: $text;
-  font: normal 100%/1.5 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', 'Helvetica', 'Arial', 'sans-serif';
+  font: normal 100%/1.5 'system-ui', '-apple-system', 'BlinkMacSystemFont',
+    'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
+    'Droid Sans', 'Helvetica Neue', 'Helvetica', 'Arial', 'sans-serif';
 }
 
 img {
@@ -109,8 +121,6 @@ select,
   }
 }
 
-
-
 /*
 
 Layout blocks
@@ -146,8 +156,6 @@ Layout blocks
   }
 }
 
-
-
 /*
 
 Headline treatments
@@ -181,8 +189,6 @@ Headline treatments
   font-variant: all-small-caps;
   margin: 0 0 0.2rem;
 }
-
-
 
 /*
 


### PR DESCRIPTION
## Description

Removing Typography.js seems to have eliminated global border-box sizing, which negatively affects several layouts in the Visualization Guide.

Setting box-sizing to border-box changes how the browser calculates width of elements, including their paddings in the final width calculation.

So if you have an element with width of 100px, and 20px left/right padding, the browser will render it at 100px with 60px of content area. Without border-box, that same container would be rendered to 140px total.

## Related Issues

See comment in https://github.com/COVID19Tracking/website/pull/638#issuecomment-617871028.

## Screenshots

### Before:

![Screen Shot 2020-04-22 at 11 50 37 AM](https://user-images.githubusercontent.com/63169602/80007523-57b92880-8494-11ea-9544-9f0ae84b982f.png)

![Screen Shot 2020-04-22 at 11 54 11 AM](https://user-images.githubusercontent.com/63169602/80007622-80d9b900-8494-11ea-8b3c-0d7c273a1158.png)

### After:

![Screen Shot 2020-04-22 at 11 50 46 AM](https://user-images.githubusercontent.com/63169602/80007544-5ee03680-8494-11ea-9989-674a5a0ea524.png)

![Screen Shot 2020-04-22 at 12 26 07 PM](https://user-images.githubusercontent.com/63169602/80007619-7e775f00-8494-11ea-9ac1-1677a556c26d.png)

