### PR TITLE
fix(dashboard): "Massachusetts" typo (minor)

### DIFF
--- a/src/utilities/visualization.js
+++ b/src/utilities/visualization.js
@@ -29,7 +29,7 @@ export const getStateName = abbr => {
     KS: 'Kansas',
     KY: 'Kentucky',
     LA: 'Louisiana',
-    MA: 'Massachusets',
+    MA: 'Massachusetts',
     MD: 'Maryland',
     ME: 'Maine',
     MI: 'Michigan',


### PR DESCRIPTION
## Description

In the chart data, "Massachusetts" only has one T.

## Related issues / Go-Live Time

N/A