### PR TITLE
chore: Remove timezone from date format

### DIFF
--- a/src/components/utils/format.js
+++ b/src/components/utils/format.js
@@ -9,11 +9,7 @@ function formatDateToString(date, format = "ccc LLL d yyyy h:mm a 'ET'") {
   if (typeof date === 'undefined') {
     return null
   }
-  return lowercaseMeridiem(
-    DateTime.fromISO(date)
-      .setZone('America/New_York')
-      .toFormat(format),
-  )
+  return lowercaseMeridiem(DateTime.fromISO(date).toFormat(format))
 }
 
 const FormatDate = ({ date, format = "ccc LLL d yyyy h:mm a 'ET'" }) => {


### PR DESCRIPTION
<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.
-->

## Description
Fixed a flash-of-wrong-date format in the US pages. By putting dates into timezones on the server, the client pulls the dates back.
<!-- Write a brief description of what this PR is for -->


## Related Issues
Fixes #710

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

<!--
## Go-live time

  If this PR is for a feature that should not 
  be merged until a specific time, let us know!
-->


<!--
## Post-merge steps

  Outline things that need to be done once this is merged.
  This is usually work that has to be done in our CMS to change
  content or navigation.
-->
