### PR TITLE
chore: Make API build a production-only command

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,13 @@
   Make sure that running `npm run test` works locally before opening a PR.
 -->
 
+<!--
+  API CHANGES:
+  If this PR includes changes to anything in the `/build` directory, make
+  sure to note that in the PR. API changes have a different build and
+  testing command than regular PRs.
+-->
+
 ## Description
 
 <!-- Write a brief description of what this PR is for -->

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,6 +2,15 @@
   publish = "public"
   command = "npm run build"
 
+[context.production]
+  command = "npm run build"
+
+[context.deploy-preview]
+  command = "npm run build-preview"
+
+[context.branch-deploy]
+  command = "npm run build"
+
 [[headers]]
   for = "/api/*"
   [headers.values]

--- a/package.json
+++ b/package.json
@@ -102,6 +102,7 @@
   },
   "scripts": {
     "build": "run-s build:fetch build:gatsby build:data build:data-archive build:test",
+    "build-preview": "run-s setup:api-data build:gatsby build:data build:data-archive build:test",
     "build:fetch": "node build/index.js",
     "build:gatsby": "gatsby build",
     "build:data": "cp -R _data/* public/api/",


### PR DESCRIPTION
<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.
-->

## Description
This ensures that the full API build only occurs on `master` or specific deploy branches within Netlify. This should:

- Prevent bumping against API call limits
- Cause developer previews to build *way faster*

This only affects Netlify, CircleCI would continue to run API tests under #705 

If a build in Netlfy is a deploy preview, it will run `npm run build-preview`, which **downloads** the API file tarball from the website, and does not run `npm run build:fetch`.

<!-- Write a brief description of what this PR is for -->


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

<!--
## Go-live time

  If this PR is for a feature that should not 
  be merged until a specific time, let us know!
-->


<!--
## Post-merge steps

  Outline things that need to be done once this is merged.
  This is usually work that has to be done in our CMS to change
  content or navigation.
-->
