### PR TITLE
chore: Add abbr around EST

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -9,9 +9,9 @@ module.exports = {
     production:
       typeof process.env.BRANCH !== 'undefined' &&
       process.env.BRANCH === 'master',
-    buildDate: `${DateTime.fromObject({ zone: 'America/New_York' })
+    buildDate: DateTime.fromObject({ zone: 'America/New_York' })
       .toFormat('h:mm a')
-      .toLowerCase()} ET`,
+      .toLowerCase(),
   },
   plugins: [
     'gatsby-plugin-react-helmet',

--- a/src/components/common/infobox.js
+++ b/src/components/common/infobox.js
@@ -54,7 +54,13 @@ const SyncInfobox = () => (
         <img src={syncIcon} alt="Sync icon" />
         <div>
           <InfoboxInner header="Last updated from our data:">
-            {data.site.siteMetadata.buildDate}
+            {data.site.siteMetadata.buildDate}{' '}
+            <abbr
+              title="Eastern Standard Time"
+              aria-label="Eastern Standard Time"
+            >
+              EST
+            </abbr>
           </InfoboxInner>
         </div>
       </div>

--- a/src/components/common/summary-table.js
+++ b/src/components/common/summary-table.js
@@ -5,7 +5,17 @@ import { formatDateToString, FormatNumber } from '../utils/format'
 export default ({ data, lastUpdated, showOutcomes = true }) => (
   <Table
     tableLabel={
-      lastUpdated && `Last updated: ${formatDateToString(lastUpdated)}`
+      lastUpdated && (
+        <>
+          Last updated: {formatDateToString(lastUpdated)}{' '}
+          <abbr
+            title="Eastern Standard Time"
+            aria-label="Eastern Standard Time"
+          >
+            EST
+          </abbr>
+        </>
+      )
     }
   >
     <colgroup span="3" />

--- a/src/pages/data/us-daily.js
+++ b/src/pages/data/us-daily.js
@@ -22,7 +22,12 @@ const ContentPage = ({ data }) => (
     <SyncInfobox />
 
     <Table>
-      <caption>US Daily Cumulative Totals - 4 pm ET</caption>
+      <caption>
+        US Daily Cumulative Totals - 4 pm{' '}
+        <abbr title="Eastern Standard Time" aria-label="Eastern Standard Time">
+          EST
+        </abbr>
+      </caption>
       <thead>
         <tr>
           <th scope="col">Date</th>


### PR DESCRIPTION
<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.
-->

<!--
  API CHANGES:
  If this PR includes changes to anything in the `/build` directory, make
  sure to note that in the PR. API changes have a different build and
  testing command than regular PRs.
-->

## Description
Adds a `abbr` element around all instances of the Eastern Standard Time timezone.
<!-- Write a brief description of what this PR is for -->


## Related Issues
https://github.com/COVID19Tracking/website/pull/720#pullrequestreview-404213205
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

<!--
## Go-live time

  If this PR is for a feature that should not 
  be merged until a specific time, let us know!
-->


<!--
## Post-merge steps

  Outline things that need to be done once this is merged.
  This is usually work that has to be done in our CMS to change
  content or navigation.
-->
