### PR TITLE
fix(visual): blog headshots are stretched on Safari #759

### DIFF
--- a/src/components/pages/blog/byline.module.scss
+++ b/src/components/pages/blog/byline.module.scss
@@ -10,6 +10,7 @@
   .headshot-container {
     margin-right: 12px;
     display: inline-flex;
+    align-items: flex-start;
     img {
       width: 47px;
       border-radius: 50%;


### PR DESCRIPTION

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.

tests passing locally



## Description

fixes - blog headshots are stretched on Safari #759


## Related Issues

blog headshots are stretched on Safari #759