### PR TITLE
feat: Add distinct field to search

### DIFF
--- a/src/context/search-context.js
+++ b/src/context/search-context.js
@@ -111,9 +111,11 @@ export function useSearch() {
   return [useSearchState(), useSearchDispatch()]
 }
 
-async function queryIndex(index, query) {
+async function queryIndex(index, query, distinct = false) {
   try {
-    const hits = await index.search(query)
+    const hits = await index.search(query, {
+      distinct,
+    })
 
     return hits
   } catch (e) {
@@ -128,8 +130,8 @@ export async function querySearch(s, dispatch) {
   try {
     const [state, blogPost, page] = await Promise.all([
       queryIndex(stateIndex, s.query),
-      queryIndex(blogIndex, s.query),
-      queryIndex(pageIndex, s.query),
+      queryIndex(blogIndex, s.query, true),
+      queryIndex(pageIndex, s.query, true),
     ])
     NProgress.done()
     dispatch({ type: 'fetchSuccess', payload: { state, blogPost, page } })

--- a/src/utilities/algolia.js
+++ b/src/utilities/algolia.js
@@ -38,7 +38,7 @@ const blogPostQuery = `{
   posts: allContentfulBlogPost {
     edges {
       node {
-        objectID: contentful_id
+        contentful_id
         title
         authors {
           name
@@ -60,7 +60,7 @@ const pagesQuery = `{
   posts: allContentfulPage {
     edges {
       node {
-        objectID: contentful_id
+        contentful_id
         title
         slug
         updatedAt(formatString: "MMMM D, YYYY")
@@ -176,6 +176,7 @@ function chunkBlogPosts(data) {
       lede: node.lede.lede,
       updatedAt: node.updatedAt,
       section: node.section,
+      contentful_id: node.contentful_id,
     }
     const firstChunk = { ...baseChunk, section: 'section0' }
     const bodyChunks = marked(node.body.body)
@@ -196,8 +197,7 @@ const stateSettings = {
  * (see https://www.algolia.com/doc/guides/building-search-ui/going-further/backend-search/how-to/highlighting-snippeting/)
  */
 const pageSettings = {
-  attributeForDistinct: 'section',
-  distinct: true,
+  attributeForDistinct: 'contentful_id',
   attributesToSnippet: ['body:50'],
 }
 const blogPostSettings = {


### PR DESCRIPTION
<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.
-->

<!--
  API CHANGES:
  If this PR includes changes to anything in the `/build` directory, make
  sure to note that in the PR. API changes have a different build and
  testing command than regular PRs.
-->

## Description

<!-- Write a brief description of what this PR is for -->
This:

- Adds contentful_id to blog and page indexes
- Flags the field as distinct using `attributeForDistinct`, but doesn't filter them out in the index
- Uses `distinct` to only return one value per record

## Related Issues
Fixes #761 

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

<!--
## Go-live time

  If this PR is for a feature that should not 
  be merged until a specific time, let us know!
-->


<!--
## Post-merge steps

  Outline things that need to be done once this is merged.
  This is usually work that has to be done in our CMS to change
  content or navigation.
-->
