### PR TITLE
fix:Change path for get involved #769

### DIFF
--- a/src/__tests__/components/layout/__snapshots__/header.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/header.js.snap
@@ -72,7 +72,7 @@ exports[`Components : Layout : Header renders correctly 1`] = `
         </nav>
         <a
           className="getInvolved"
-          href="/help"
+          href="/about-project/help"
         >
           Get Involved
         </a>
@@ -191,7 +191,7 @@ exports[`Components : Layout : Header renders correctly 1`] = `
                 </div>
                 <a
                   className="getInvolved"
-                  href="/help"
+                  href="/about-project/help"
                 >
                   Get involved
                 </a>
@@ -326,7 +326,7 @@ exports[`Components : Layout : Header renders correctly 2`] = `
           </nav>
           <a
             className="getInvolved"
-            href="/help"
+            href="/about-project/help"
           >
             Get Involved
           </a>
@@ -445,7 +445,7 @@ exports[`Components : Layout : Header renders correctly 2`] = `
                   </div>
                   <a
                     className="getInvolved"
-                    href="/help"
+                    href="/about-project/help"
                   >
                     Get involved
                   </a>
@@ -618,7 +618,7 @@ exports[`Components : Layout : Header renders correctly 3`] = `
         </nav>
         <a
           className="getInvolved"
-          href="/help"
+          href="/about-project/help"
         >
           Get Involved
         </a>
@@ -737,7 +737,7 @@ exports[`Components : Layout : Header renders correctly 3`] = `
                 </div>
                 <a
                   className="getInvolved"
-                  href="/help"
+                  href="/about-project/help"
                 >
                   Get involved
                 </a>

--- a/src/__tests__/components/layout/__snapshots__/index.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/index.js.snap
@@ -80,7 +80,7 @@ Array [
           </nav>
           <a
             className="getInvolved"
-            href="/help"
+            href="/about-project/help"
           >
             Get Involved
           </a>
@@ -199,7 +199,7 @@ Array [
                   </div>
                   <a
                     className="getInvolved"
-                    href="/help"
+                    href="/about-project/help"
                   >
                     Get involved
                   </a>
@@ -431,7 +431,7 @@ Array [
           </nav>
           <a
             className="getInvolved"
-            href="/help"
+            href="/about-project/help"
           >
             Get Involved
           </a>
@@ -550,7 +550,7 @@ Array [
                   </div>
                   <a
                     className="getInvolved"
-                    href="/help"
+                    href="/about-project/help"
                   >
                     Get involved
                   </a>

--- a/src/components/layout/header.js
+++ b/src/components/layout/header.js
@@ -178,7 +178,10 @@ const Header = withSearch(
                     <HeaderSearch>
                       <SearchAutocomplete id="header-search" />
                     </HeaderSearch>
-                    <Link to="/about-project/help" className={headerStyle.getInvolved}>
+                    <Link
+                      to="/about-project/help"
+                      className={headerStyle.getInvolved}
+                    >
                       Get involved
                     </Link>
                   </div>

--- a/src/components/layout/header.js
+++ b/src/components/layout/header.js
@@ -109,7 +109,7 @@ const MobileMenu = () => {
       </HeaderSearch>
 
       <HeaderNavigation />
-      <Link to="/help" className={headerStyle.getInvolved}>
+      <Link to="/about-project/help" className={headerStyle.getInvolved}>
         Get Involved
       </Link>
       <div className={headerStyle.mobilePointer} />
@@ -178,7 +178,7 @@ const Header = withSearch(
                     <HeaderSearch>
                       <SearchAutocomplete id="header-search" />
                     </HeaderSearch>
-                    <Link to="/help" className={headerStyle.getInvolved}>
+                    <Link to="/about-project/help" className={headerStyle.getInvolved}>
                       Get involved
                     </Link>
                   </div>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -58,7 +58,7 @@ export default ({ data }) => (
                 </p>,
                 <p>
                   Want to get involved?{' '}
-                  <Link to="/help">Help us get better data</Link>.
+                  <Link to="/about-project/help">Help us get better data</Link>.
                 </p>,
               ]}
             />


### PR DESCRIPTION
<!--

  Testing!

Updated snapshots to pass
-->


## Description

So we don't hit a redirect and force a page refresh, change the "Get Involved" link component in the header to /about-project/help


## Related Issues

<!--
Change path for get involved #769
-->

