### PR TITLE
chore: Use only lower-case paths in API

### DIFF
--- a/build/__tests__/post-build/v1/states/all-states.js
+++ b/build/__tests__/post-build/v1/states/all-states.js
@@ -5,10 +5,10 @@ describe('File : US : All states', () => {
   it('generated files for every state', async done => {
     const states = await fs.readJSON('_data/v1/states/info.json')
     states.forEach(state => {
-      checkFile(`_data/v1/states/${state.state}/current`)
-      checkFile(`_data/v1/states/${state.state}/daily`)
-      checkFile(`_data/v1/states/${state.state}/info`)
-      checkFile(`_data/v1/states/${state.state}/screenshots`)
+      checkFile(`_data/v1/states/${state.state.toLowerCase()}/current`)
+      checkFile(`_data/v1/states/${state.state.toLowerCase()}/daily`)
+      checkFile(`_data/v1/states/${state.state.toLowerCase()}/info`)
+      checkFile(`_data/v1/states/${state.state.toLowerCase()}/screenshots`)
     })
     done()
   })

--- a/build/datasources/screenshots.js
+++ b/build/datasources/screenshots.js
@@ -82,7 +82,6 @@ const datePages = _.flow(_.groupBy('date'), _.map(dateStatePages))
 const statePages = _.flow(
   _.groupBy('state'),
   _.flatMap(value => [
-    { path: `states/${value[0].state}/screenshots`, value },
     { path: `states/${value[0].state.toLowerCase()}/screenshots`, value },
     ...datePages(value),
   ]),

--- a/build/datasources/states.js
+++ b/build/datasources/states.js
@@ -86,10 +86,6 @@ const updateFunc = () =>
 
 const statePages = _.flatMap(value => [
   {
-    path: `states/${value.state}/current`,
-    value,
-  },
-  {
     path: `states/${value.state.toLowerCase()}/current`,
     value,
   },

--- a/build/datasources/statesDaily.js
+++ b/build/datasources/statesDaily.js
@@ -4,10 +4,6 @@ const { fixDaily, sheets } = require('./sheets')
 // Each state, specific date.
 const stateDatePages = _.flatMap(value => [
   {
-    path: `states/${value.state}/${value.date}`,
-    value,
-  },
-  {
     path: `states/${value.state.toLowerCase()}/${value.date}`,
     value,
   },
@@ -17,8 +13,6 @@ const stateDatePages = _.flatMap(value => [
 const statePages = _.flow(
   _.groupBy('state'),
   _.flatMap(value => [
-    { path: `states/${value[0].fips}/daily`, value },
-    { path: `states/${value[0].state}/daily`, value },
     { path: `states/${value[0].state.toLowerCase()}/daily`, value },
     ...stateDatePages(value),
   ]),

--- a/build/datasources/statesInfo.js
+++ b/build/datasources/statesInfo.js
@@ -6,7 +6,7 @@ const fixStatesInfo = _.map(_.flow(addFips, addName))
 
 const statePages = _.flatMap(value => [
   {
-    path: `states/${value.state}/info`,
+    path: `states/${value.state.toLowerCase()}/info`,
     value,
   },
 ])

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,9 @@
 [context.branch-deploy]
   command = "npm run build-preview"
 
+[context."kevee/api-file-paths"]
+  command = "npm run build"
+
 [[headers]]
   for = "/api/*"
   [headers.values]


### PR DESCRIPTION
<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.
-->

<!--
  API CHANGES:
  If this PR includes changes to anything in the `/build` directory, make
  sure to note that in the PR. API changes have a different build and
  testing command than regular PRs.
-->

## Description

- Removes upper-case state names in API routes, since Netlify automatically matches paths to lower-case.
- Removes unused FIPS-based file paths.

<!-- Write a brief description of what this PR is for -->


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

<!--
## Go-live time

  If this PR is for a feature that should not 
  be merged until a specific time, let us know!
-->


<!--
## Post-merge steps

  Outline things that need to be done once this is merged.
  This is usually work that has to be done in our CMS to change
  content or navigation.
-->
