### PR TITLE
fix(design): Homepage hero chart is more responsive

### DIFF
--- a/src/components/pages/homepage/header-hero.js
+++ b/src/components/pages/homepage/header-hero.js
@@ -29,7 +29,7 @@ const Chart = ({ data }) => {
   })
 
   data.allCovidUsDaily.nodes.forEach(node => {
-    if (node.date > maxDate) {
+    if (node.date > maxDate || node.date < 20200226) {
       return
     }
     ctp.push({
@@ -64,6 +64,7 @@ const Chart = ({ data }) => {
         {ctp.map(d => (
           <rect
             key={d.date + d.value}
+            className={heroStyle.chartBar}
             x={xScale(d.date)}
             y={yScale(d.value)}
             height={yScale(0) - yScale(d.value)}
@@ -76,6 +77,7 @@ const Chart = ({ data }) => {
         {cdc.map(d => (
           <rect
             key={d.date + d.value}
+            className={heroStyle.chartBar}
             x={xScale(d.date)}
             y={yScale(d.value)}
             height={yScale(0) - yScale(d.value)}
@@ -84,7 +86,7 @@ const Chart = ({ data }) => {
           />
         ))}
       </g>
-      <g transform="translate(0 0)">
+      <g transform="translate(0 0)" className={heroStyle.chartYAxis}>
         {yScale.ticks(4).map(
           (tick, i) =>
             i !== 0 &&
@@ -95,13 +97,13 @@ const Chart = ({ data }) => {
                   x={width + labelOffset / 2}
                   className={heroStyle.chartLegend}
                 >
-                  <text style={{ fill: 'white' }} x="0" y="0">
+                  <text x="0" y="0">
                     {tick === 300000 ? (
                       <>
-                        <tspan x="0" dy="16px">
+                        <tspan x="0" dy="0">
                           {tick.toLocaleString()}
                         </tspan>
-                        <tspan x="0" dy="16px">
+                        <tspan x="0" dy="1em">
                           {' '}
                           new tests
                         </tspan>
@@ -122,7 +124,7 @@ const Chart = ({ data }) => {
             ),
         )}
       </g>
-      <g transform="translate(0, 0)">
+      <g transform="translate(0, 0)" className={heroStyle.chartXAxis}>
         {ctp.map(d => {
           if (DateTime.fromISO(d.date).day !== 1) {
             return null

--- a/src/components/pages/homepage/header-hero.module.scss
+++ b/src/components/pages/homepage/header-hero.module.scss
@@ -1,6 +1,9 @@
 @import '~scss/colors.module.scss';
 @import '~scss/breakpoints.module.scss';
 
+$mobile-offset-x: 4.5%;
+$mobile-offset-y: -3%;
+
 .hero {
   padding-top: 35px;
   background: $color-plum-550;
@@ -61,20 +64,44 @@
 
 .chart-bar {
   margin: 0 1px;
+
+  transform: translateY($mobile-offset-y);
+
+  @media (min-width: $viewport-ms) {
+    transform: translateY(0);
+  }
 }
 
 .chart-line {
   stroke: $color-plum-550;
   stroke-width: 1.5px;
+  transform: translateX($mobile-offset-x * -1.1);
+
+  @media (min-width: $viewport-ms) {
+    transform: translateX(0);
+  }
 }
 
 .chart-legend {
-  color: white;
-  font-size: 14px;
+  fill: white;
+  font-size: 30px;
   overflow: visible !important;
   text-anchor: end;
-  text {
-    color: white;
+  
+  @media (min-width: $viewport-ms) {
+    font-size: 14px;
+  }
+}
+
+.chart-x-axis {
+
+}
+
+.chart-y-axis {
+  transform: translateX($mobile-offset-x) translateY($mobile-offset-y);
+
+  @media (min-width: $viewport-ms) {
+    transform: translateX(0) translateY(0);
   }
 }
 


### PR DESCRIPTION
Adjust CSS for hero chart so that it is responsive per #778 

![responsive-homepage-chart](https://user-images.githubusercontent.com/780941/81114791-8d6c0180-8ed7-11ea-978e-d333e3d2323e.gif)
