### PR TITLE
fix(hero): add 'tests' after our count

### DIFF
--- a/src/components/pages/homepage/header-hero.js
+++ b/src/components/pages/homepage/header-hero.js
@@ -192,8 +192,9 @@ export default () => {
             tests to date across the US. Using a rigorous data-collection
             process, we&apos;ve counted{' '}
             <span className={`${heroStyle.legend} ${heroStyle.ctp}`}>
-              {data.allCovidUs.nodes[0].posNeg.toLocaleString()}.
-            </span>
+              {data.allCovidUs.nodes[0].posNeg.toLocaleString()}
+            </span>{' '}
+            tests.
           </p>
         </div>
         <div className={heroStyle.chartWrapper}>


### PR DESCRIPTION
## Description

Add "tests" after our count in the hero.
[Slack thread](https://covid-tracking.slack.com/archives/C0133BX4H7E/p1588885928027800)