### PR TITLE
fix(hero): nowrap last part of title, add some spacing

### DIFF
--- a/src/components/pages/homepage/header-hero.js
+++ b/src/components/pages/homepage/header-hero.js
@@ -181,7 +181,8 @@ export default () => {
             <abbr title="United States" aria-label="United States">
               US
             </abbr>
-            . No official source is providing it, so we are.
+            . No official source is providing it,{' '}
+            <span className="nowrap">so we are</span>.
           </h2>
           <p className={`hero-paragraph ${heroStyle.paragraph}`}>
             CDC numbers don&apos;t tell the full story. Their official count

--- a/src/components/pages/homepage/header-hero.module.scss
+++ b/src/components/pages/homepage/header-hero.module.scss
@@ -49,12 +49,12 @@ $chart-color: #0f1551;
     @media (min-width: $viewport-lg) {
       font-size: 18px;
       max-width: 30rem;
-      bottom: 4rem;
+      bottom: 2.5rem;
       position: absolute;
     }
     @media (min-width: $viewport-xl) {
       // max-width: 30rem;
-      bottom: 10rem;
+      bottom: 9rem;
     }
   }
   .chart-wrapper {

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -89,6 +89,10 @@ select,
   }
 }
 
+.nowrap {
+  white-space: nowrap;
+}
+
 * {
   transition: color 0.2s;
   transition: background-color 0.2s;


### PR DESCRIPTION
## Description

Quick fixes for the homepage hero: 
* Add some spacing between title and paragraph  
* Prevent `so we are.` of being wrapped.

## Related Issues

https://github.com/COVID19Tracking/website/issues/832
