### PR TITLE
fix(blog): rm duplicate blog title

### DIFF
--- a/src/__tests__/components/layout/__snapshots__/index.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/index.js.snap
@@ -731,3 +731,369 @@ Array [
   </footer>,
 ]
 `;
+
+exports[`Components : Layout : Header renders correctly 3`] = `
+Array [
+  <a
+    data-reach-skip-link=""
+    data-reach-skip-nav-link=""
+    href="#reach-skip-nav"
+  >
+    Skip site navigation
+  </a>,
+  <header
+    className="site-header siteHeader  "
+  >
+    <div
+      className="container container"
+    >
+      <div
+        className=""
+        style={
+          Object {
+            "height": 0,
+            "opacity": 0,
+            "overflow": "hidden",
+            "transition": "height 500ms ease-in-out,opacity 500ms ease-in-out,background 500ms ease-in-out",
+          }
+        }
+      >
+        <div
+          className="mobileMenu"
+        >
+          <div
+            className="searchInput"
+          >
+            <form
+              action="/search"
+              method="get"
+              onSubmit={[Function]}
+            >
+              <label
+                className="a11y-only"
+                htmlFor="mobile-menu-search"
+              >
+                Search
+              </label>
+              <input
+                autoComplete="off"
+                id="mobile-menu-search"
+                name="q"
+                onBlur={[Function]}
+                onFocus={[Function]}
+                placeholder="Search"
+                type="search"
+              />
+            </form>
+            <button
+              aria-label="Submit search"
+              className="searchSubmit"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </button>
+          </div>
+          <nav
+            className="js-disabled-block"
+          >
+            <ul>
+              <li>
+                <a
+                  href="/test-a"
+                >
+                  Test A
+                </a>
+              </li>
+              <li>
+                <a
+                  href="/test-b"
+                >
+                  Test B
+                </a>
+              </li>
+            </ul>
+          </nav>
+          <a
+            className="getInvolved"
+            href="/about-project/help"
+          >
+            Get Involved
+          </a>
+          <div
+            className="mobilePointer"
+          />
+        </div>
+      </div>
+      <div
+        className=""
+        style={
+          Object {
+            "background": "colorPlum800",
+            "height": "auto",
+            "opacity": 1,
+            "overflow": "unset",
+            "transition": "height 500ms ease-in-out,opacity 500ms ease-in-out,background 500ms ease-in-out",
+          }
+        }
+      >
+        <div
+          className="banner"
+        >
+          <span
+            className="new"
+          >
+            New
+          </span>
+           
+          <a
+            href="/race"
+          >
+            We just launched the COVID Racial Data Tracker
+          </a>
+        </div>
+      </div>
+      <div
+        className="container false container"
+      >
+        <div
+          className="layout--content-full"
+        >
+          <div
+            className="layout--content-primary"
+          >
+            <div
+              className="siteTitleContainer"
+            >
+              <div
+                className="siteTitleInner"
+              >
+                <a
+                  href="/"
+                >
+                  <img
+                    alt="The COVID Tracking Project"
+                    src="test-file-stub"
+                    width="176px"
+                  />
+                </a>
+              </div>
+              <div
+                className="siteNavContainer"
+              >
+                <div
+                  className="navContainer"
+                >
+                  <button
+                    aria-expanded={false}
+                    className="mobileToggle"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    Menu
+                  </button>
+                </div>
+                <div
+                  className="tools"
+                >
+                  <div
+                    className="searchInput"
+                  >
+                    <div
+                      data-reach-combobox=""
+                    >
+                      <label
+                        className="a11y-only"
+                        htmlFor="header-search-autocomplete"
+                      >
+                        Search
+                      </label>
+                      <input
+                        aria-autocomplete="both"
+                        aria-controls="listbox--4"
+                        aria-expanded={false}
+                        aria-haspopup="listbox"
+                        autoComplete="off"
+                        data-reach-combobox-input=""
+                        id="header-search-autocomplete"
+                        onBlur={[Function]}
+                        onChange={[Function]}
+                        onClick={[Function]}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onSelect={[Function]}
+                        placeholder="Search"
+                        role="combobox"
+                        value=""
+                      />
+                    </div>
+                    <button
+                      aria-label="Submit search"
+                      className="searchSubmit"
+                      onClick={[Function]}
+                      type="button"
+                    >
+                      <img
+                        alt=""
+                        aria-hidden="true"
+                        src="test-file-stub"
+                      />
+                    </button>
+                  </div>
+                  <a
+                    className="getInvolved"
+                    href="/about-project/help"
+                  >
+                    Get involved
+                  </a>
+                </div>
+                <nav
+                  className="js-disabled-block"
+                >
+                  <ul>
+                    <li>
+                      <a
+                        href="/test-a"
+                      >
+                        Test A
+                      </a>
+                    </li>
+                    <li>
+                      <a
+                        href="/test-b"
+                      >
+                        Test B
+                      </a>
+                    </li>
+                  </ul>
+                </nav>
+              </div>
+            </div>
+            <div
+              className="atlanticBanner"
+            >
+              <span>
+                From
+              </span>
+               
+              <img
+                alt="The Atlantic"
+                src="test-file-stub"
+              />
+              <div />
+            </div>
+            <div
+              className="titleSubnavContainer"
+            >
+              <div
+                className="title"
+              >
+                <h1
+                  className="page-title pageTitle extraSpace"
+                >
+                  Another title
+                </h1>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>,
+  <main
+    id="main"
+  >
+    <div
+      data-reach-skip-nav-content=""
+      id="reach-skip-nav"
+    />
+    <div
+      className="container false container"
+    >
+      <div
+        className="layout--content-full"
+      >
+        <div
+          className="layout--content-primary"
+        >
+          <p>
+            Content
+          </p>
+        </div>
+      </div>
+    </div>
+  </main>,
+  <footer
+    className="footer"
+  >
+    <div
+      className="container false container"
+    >
+      <div
+        className="layout--content-full"
+      >
+        <div
+          className="layout--content-primary"
+        >
+          <div
+            className="container"
+          >
+            <a
+              href="/"
+            >
+              <img
+                alt="The COVID Tracking Project"
+                src="test-file-stub"
+              />
+            </a>
+            <ul
+              className="footerList"
+            >
+              <li>
+                <a
+                  href="/contact"
+                >
+                  Contact
+                </a>
+              </li>
+              <li>
+                <a
+                  href="/accessibility"
+                >
+                  Accessibility
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/COVID19Tracking"
+                >
+                  GitHub
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://twitter.com/COVID19Tracking"
+                >
+                  Twitter
+                </a>
+              </li>
+              <li>
+                <a
+                  className="backToTop"
+                  href="#reach-skip-nav"
+                >
+                  Back to top.
+                </a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>,
+]
+`;

--- a/src/__tests__/components/layout/index.js
+++ b/src/__tests__/components/layout/index.js
@@ -64,5 +64,16 @@ describe('Components : Layout : Header', () => {
       )
       .toJSON()
     expect(textHeavytree).toMatchSnapshot()
+
+    const displayTitleTree = renderer
+      .create(
+        <>
+          <Layout title="Sample title" displayTitle="Another title">
+            <p>Content</p>
+          </Layout>
+        </>,
+      )
+      .toJSON()
+    expect(displayTitleTree).toMatchSnapshot()
   })
 })

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -11,6 +11,7 @@ import '../../scss/global.scss'
 
 const Layout = ({
   title,
+  displayTitle,
   titleLink,
   description,
   children,
@@ -36,7 +37,7 @@ const Layout = ({
       <SkipNavigation />
       <Header
         siteTitle={data.site.siteMetadata.title}
-        title={title}
+        title={displayTitle || title}
         titleLink={titleLink}
         navigation={navigation}
         noMargin={noMargin}

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -25,6 +25,7 @@ export default ({ data }) => {
   return (
     <Layout
       title={`Blog | ${blogPost.title}`}
+      displayTitle="Blog"
       description={blogPost.lede.lede}
       titleLink="/blog"
       textHeavy


### PR DESCRIPTION
also adds a displayTitle param to Layout
- this separates the SEO title (html <title>) from the page title *displayed* in the header

<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.
-->

<!--
  API CHANGES:
  If this PR includes changes to anything in the `/build` directory, make
  sure to note that in the PR. API changes have a different build and
  testing command than regular PRs.
-->

## Description
![image](https://user-images.githubusercontent.com/18607205/81590126-947f8d80-9377-11ea-83d3-057339a49e21.png)
Removes the highlighted blog title on individual blog pages
<!-- Write a brief description of what this PR is for -->


## Related Issues

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

<!--
## Go-live time

  If this PR is for a feature that should not 
  be merged until a specific time, let us know!
-->


<!--
## Post-merge steps

  Outline things that need to be done once this is merged.
  This is usually work that has to be done in our CMS to change
  content or navigation.
-->
