### PR TITLE
fix: sub-nav

### DIFF
--- a/src/components/layout/header/header.module.scss
+++ b/src/components/layout/header/header.module.scss
@@ -366,6 +366,7 @@
 
       div {
         text-align: left;
+        margin: 0 -1em;
       }
 
       @media (max-width: $viewport-lg) and (min-width: $viewport-ms) {
@@ -427,12 +428,6 @@
           display: inline-block;
           @media (min-width: $viewport-ms) {
             margin: 0;
-            &:last-child a {
-              margin-right: 0;
-            }
-            &:first-child a {
-              margin-left: 0;
-            }
           }
         }
       }


### PR DESCRIPTION
<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.
-->

<!--
  API CHANGES:
  If this PR includes changes to anything in the `/build` directory, make
  sure to note that in the PR. API changes have a different build and
  testing command than regular PRs.
-->

## Description

<!-- Write a brief description of what this PR is for -->

In order to address the potential for wrapped sub nav items, we keep the 1em left margin on the first item, as well as the 1em right margin on the last item, and compensate by adding a -1em left and right margin on the containing element. 

## Related Issues

https://github.com/COVID19Tracking/website/issues/856

**Before:** 
![Screen Shot 2020-05-15 at 9 31 37 AM](https://user-images.githubusercontent.com/173215/82055791-08c77300-968f-11ea-8100-37bdec977b4e.png)

**After:**
![Screen Shot 2020-05-15 at 9 31 54 AM](https://user-images.githubusercontent.com/173215/82055798-0b29cd00-968f-11ea-8679-ef98b6264b57.png)

<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

<!--
## Go-live time

  If this PR is for a feature that should not 
  be merged until a specific time, let us know!
-->


<!--
## Post-merge steps

  Outline things that need to be done once this is merged.
  This is usually work that has to be done in our CMS to change
  content or navigation.
-->
