### PR TITLE
fix: subnav margin

### DIFF
--- a/src/components/layout/header/header.module.scss
+++ b/src/components/layout/header/header.module.scss
@@ -366,7 +366,7 @@
 
       div {
         text-align: left;
-        margin: 0 -1em;
+        margin: 0 -1rem;
       }
 
       @media (max-width: $viewport-lg) and (min-width: $viewport-ms) {
@@ -413,6 +413,7 @@
           @media (max-width: $viewport-md) {
             font-size: 0.8rem;
             padding: 0.5rem 0;
+            margin-left: 1rem;
             margin-right: 1rem;
           }
 


### PR DESCRIPTION
<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.
-->

<!--
  API CHANGES:
  If this PR includes changes to anything in the `/build` directory, make
  sure to note that in the PR. API changes have a different build and
  testing command than regular PRs.
-->

## Description

Fixes issue https://github.com/COVID19Tracking/website/issues/870, which was introduced recently by pull request https://github.com/COVID19Tracking/website/pull/863

Since we have added a negative margin on the containing element, we need to account for this with a margin on the items inside. I missed the media query in the initial work. 

I also changed the em unit of the negative margin to rem since we seem to use rem throughout. 

## Related Issues
Fixes https://github.com/COVID19Tracking/website/issues/870
Related to https://github.com/COVID19Tracking/website/issues/856
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

<!--
## Go-live time

  If this PR is for a feature that should not 
  be merged until a specific time, let us know!
-->


<!--
## Post-merge steps

  Outline things that need to be done once this is merged.
  This is usually work that has to be done in our CMS to change
  content or navigation.
-->
