### PR TITLE
fix(chart): Corrected spelling

### DIFF
--- a/src/components/pages/race/charts/county-chart.js
+++ b/src/components/pages/race/charts/county-chart.js
@@ -66,7 +66,7 @@ export default ({ data, field }) => {
             ),
         )}
       </g>
-      <g transfrorm={`translate(0, ${heightOffset})`}>
+      <g transform={`translate(0, ${heightOffset})`}>
         {data.map((d, index) => (
           <g key={`${d.field}-${d.county}`}>
             <svg

--- a/src/components/pages/race/charts/county-chart.js
+++ b/src/components/pages/race/charts/county-chart.js
@@ -70,7 +70,7 @@ export default ({ data, field }) => {
         {data.map((d, index) => (
           <g key={`${d.field}-${d.county}`}>
             <svg
-              y={yScale(index) + 10 + heightOffset}
+              y={yScale(index) + 10}
               x={0}
               width={labelOffset}
               className={countyChartStyles.tick}

--- a/src/components/pages/race/charts/index.js
+++ b/src/components/pages/race/charts/index.js
@@ -109,10 +109,10 @@ export default () => {
           >
             This chart shows the 20 counties with the highest level of
             infections per capita, and the largest racial or ethnic group in
-            that county. White people represent the largest racial group in most
-            of these counties. This is in line with Census statistics, which
-            show that more than 60 percent of Americans are White, non-Hispanic
-            or Latino.
+            that county. Non-Hispanic White people represent the largest racial
+            group in most of these counties. This is in line with Census
+            statistics, which show that more than 60 percent of Americans are
+            White, non-Hispanic or Latino.
             <DisclosureButton className={chartsStyle.showChartData}>
               {isCasesOpen ? (
                 <>

--- a/src/components/pages/race/citation.js
+++ b/src/components/pages/race/citation.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default ({ children }) => {
+  return <cite>{children}</cite>
+}

--- a/src/components/pages/race/header-hero.js
+++ b/src/components/pages/race/header-hero.js
@@ -15,7 +15,7 @@ export default () => (
         The COVID Racial Data Tracker is a collaboration between the COVID
         Tracking Project and the Antiracist Research &amp; Policy Center.
         Together, we&apos;re gathering the most complete race and ethnicity data
-        on COVID-19 in the US anywhere.
+        on COVID-19 in the United States.
       </HeroText>
     </Container>
   </div>

--- a/src/pages/race/index.js
+++ b/src/pages/race/index.js
@@ -15,6 +15,7 @@ import CtaLinks from '~components/pages/race/cta-links'
 import Charts from '~components/pages/race/charts'
 import Totals from '~components/pages/race/totals'
 import Press from '~components/pages/race/press'
+import Publication from '~components/pages/race/citation'
 import { FormatNumber } from '~components/utils/format'
 
 export default () => {
@@ -87,9 +88,10 @@ export default () => {
               Race and ethnicity data for COVID cases isn&apos;t widely
               available at the county level, so we&apos;re using two numbers we
               do have: the latest infection and death rates for each county,
-              from a New York Times dataset, paired with the largest racial or
-              ethnic group in that county, based on the Census Bureau&apos;s
-              2018 ACS 5-Year estimates. The results are staggering.
+              from a <Publication>New York Times</Publication> dataset, paired
+              with the largest racial or ethnic group in that county, based on
+              the Census Bureau&apos;s 2018 ACS 5-Year estimates. The results
+              are staggering.
             </RacialDataParagraph>
           </LandingPageContainer>
           <Charts />

--- a/src/pages/race/index.js
+++ b/src/pages/race/index.js
@@ -98,8 +98,8 @@ export default () => {
         <LandingPageSection noBorder>
           <LandingPageContainer>
             <LargeHeader>
-              Learn more about how COVID-19 is impacting communities of color
-              from media outlets across the country.
+              Learn more from media outlets across the country about how
+              COVID-19 is impacting communities of color.
             </LargeHeader>
             <Press />
           </LandingPageContainer>

--- a/src/pages/race/index.js
+++ b/src/pages/race/index.js
@@ -87,9 +87,9 @@ export default () => {
               Race and ethnicity data for COVID cases isn&apos;t widely
               available at the county level, so we&apos;re using two numbers we
               do have: the latest infection and death rates for each county,
-              from a New York Times dataset, paired with the Census
-              Bureau&apos;s 2018 ACS 5-Year estimates for race and ethnicity
-              breakdowns in that county. The results are staggering.
+              from a New York Times dataset, paired with the largest racial or
+              ethnic group in that county, based on the Census Bureau&apos;s
+              2018 ACS 5-Year estimates. The results are staggering.
             </RacialDataParagraph>
           </LandingPageContainer>
           <Charts />

--- a/src/pages/race/index.js
+++ b/src/pages/race/index.js
@@ -86,10 +86,10 @@ export default () => {
             <RacialDataParagraph>
               Race and ethnicity data for COVID cases isn&apos;t widely
               available at the county level, so we&apos;re using two numbers we
-              do have: infection and death rates for each county, from a New
-              York Times dataset, paired with the Census Bureau&apos;s 2018 ACS
-              5-Year estimates for race and ethnicity breakdowns in that county.
-              The results are staggering.
+              do have: the latest infection and death rates for each county,
+              from a New York Times dataset, paired with the Census
+              Bureau&apos;s 2018 ACS 5-Year estimates for race and ethnicity
+              breakdowns in that county. The results are staggering.
             </RacialDataParagraph>
           </LandingPageContainer>
           <Charts />


### PR DESCRIPTION
## Description

Corrected spelling (_transfrorm_ to _transform_) and realigned labels to chart bars once the transform worked