### PR TITLE
fix(logic): added language for death rate ratio cases

### DIFF
--- a/src/components/pages/race/multiplier-highlight.js
+++ b/src/components/pages/race/multiplier-highlight.js
@@ -2,13 +2,53 @@ import React from 'react'
 import Container from '~components/common/container'
 import multiplierHighlightStyle from './multiplier-highlight.module.scss'
 
+function range(multiplier) {
+  if (multiplier >= 136 && multiplier <= 149) {
+    return 'nearly 1.5 times'
+  }
+  if (multiplier > 149 && multiplier < 151) {
+    return '1.5 times'
+  }
+  if (multiplier >= 151 && multiplier <= 185) {
+    return 'more than 1.5 times'
+  }
+  if (multiplier > 185 && multiplier <= 199) {
+    return 'nearly 2 times'
+  }
+  if (multiplier > 199 && multiplier < 201) {
+    return '2 times'
+  }
+  if (multiplier >= 201 && multiplier <= 235) {
+    return 'more than 2 times'
+  }
+  if (multiplier > 236 && multiplier <= 249) {
+    return 'nearly 2.5 times'
+  }
+  if (multiplier > 249 && multiplier < 251) {
+    return '2.5 times'
+  }
+  if (multiplier >= 251 && multiplier <= 285) {
+    return 'more than 2.5 times'
+  }
+  if (multiplier > 285 && multiplier <= 299) {
+    return 'nearly 3 times'
+  }
+  if (multiplier > 299 && multiplier < 301) {
+    return '3 times'
+  }
+  if (multiplier >= 301 && multiplier <= 335) {
+    return 'more than 3 times'
+  }
+  return 'much'
+}
+
 export default ({ multiplier }) => (
   <div className={multiplierHighlightStyle.highlight}>
     <Container>
       <p>
         That&apos;s a black death rate{' '}
         <span className={multiplierHighlightStyle.number}>
-          {Math.round(multiplier * 100) / 100}x higher
+          {range(Math.round(multiplier * 100))} higher
         </span>{' '}
         than the Black share of the population.
       </p>

--- a/src/pages/race/index.js
+++ b/src/pages/race/index.js
@@ -64,9 +64,11 @@ export default () => {
               lives to COVID-19 to date.
             </LargeHeader>
             <NationalChart />
-            <RaceMultiplierHighlight
-              multiplier={blackLivesExpectedMultiplier}
-            />
+            {Number(blackLivesExpectedMultiplier) > 1.36 && (
+              <RaceMultiplierHighlight
+                multiplier={blackLivesExpectedMultiplier}
+              />
+            )}
           </LandingPageContainer>
         </LandingPageSection>
         <LandingPageSection noMargin>
@@ -102,7 +104,7 @@ export default () => {
           <Charts />
         </LandingPageSection>
 
-        <LandingPageSection noBottomBorder noMargin>
+        <LandingPageSection noMargin>
           <LandingPageContainer>
             <LargeHeader>
               Learn more from media outlets across the country about how

--- a/src/pages/race/index.js
+++ b/src/pages/race/index.js
@@ -104,7 +104,7 @@ export default () => {
           <Charts />
         </LandingPageSection>
 
-        <LandingPageSection noMargin>
+        <LandingPageSection noBottomBorder noMargin>
           <LandingPageContainer>
             <LargeHeader>
               Learn more from media outlets across the country about how


### PR DESCRIPTION

## Description

[Added cases](https://github.com/COVID19Tracking/website/projects/10#card-38544863) for the deaths / percent of the population ratio, so that we get standard language instead of a specific number

![image](https://user-images.githubusercontent.com/3722037/82446713-215fd080-9a75-11ea-8269-b65427ced1fd.png)


* For deaths / population < 1.36, the sentence does not show up at all

* currently, the cases account for up to deaths / population of 3.35, for anything higher I included 'much higher'