### PR TITLE
fix: Hot reload ownerDocument error, Gatsby links

### DIFF
--- a/src/__tests__/components/pages/homepage/__snapshots__/press.js.snap
+++ b/src/__tests__/components/pages/homepage/__snapshots__/press.js.snap
@@ -92,7 +92,7 @@ exports[`Components : Pages : Homepage : Press renders correctly 1`] = `
     </div>
     <a
       className="cta centered "
-      href="about-project/in-the-press"
+      href="/about-project/in-the-press"
     >
       See what else our data powers
       <span

--- a/src/components/layout/header/navigation.js
+++ b/src/components/layout/header/navigation.js
@@ -1,30 +1,36 @@
-/* eslint-disable jsx-a11y/aria-role */
+/* eslint-disable jsx-a11y/aria-role,react/prefer-stateless-function */
 import React from 'react'
 import { Link } from 'gatsby'
 import { Menu, MenuList, MenuButton, MenuLink } from '@reach/menu-button'
+import internalLink from '~components/utils/internal-link'
 import headerNavigationStyles from './navigation.module.scss'
 
-const MenuCaret = ({
-  children,
-  id,
-  onKeyDown,
-  onMouseDown,
-  'aria-controls': ariaControls,
-  'aria-expanded': ariaExpanded,
-}) => (
-  <button
-    type="button"
-    onKeyDown={onKeyDown}
-    onMouseDown={onMouseDown}
-    className={headerNavigationStyles.caret}
-    aria-controls={ariaControls}
-    aria-haspopup="true"
-    id={id}
-    aria-expanded={ariaExpanded ? 'true' : 'false'}
-  >
-    {children}
-  </button>
-)
+class MenuCaret extends React.Component {
+  render() {
+    const {
+      children,
+      id,
+      onKeyDown,
+      onMouseDown,
+      'aria-controls': ariaControls,
+      'aria-expanded': ariaExpanded,
+    } = this.props
+    return (
+      <button
+        type="button"
+        onKeyDown={onKeyDown}
+        onMouseDown={onMouseDown}
+        className={headerNavigationStyles.caret}
+        aria-controls={ariaControls}
+        aria-haspopup="true"
+        id={id}
+        aria-expanded={ariaExpanded ? 'true' : 'false'}
+      >
+        {children}
+      </button>
+    )
+  }
+}
 
 export default ({ topNavigation, subNavigation, isMobile }) => (
   <nav className="js-disabled-block" role="navigation">
@@ -34,7 +40,7 @@ export default ({ topNavigation, subNavigation, isMobile }) => (
     >
       {topNavigation.map(item => (
         <li key={item.link} className={headerNavigationStyles.menuItem}>
-          <Link to={item.link}>{item.title}</Link>
+          <Link to={internalLink(item.link)}>{item.title}</Link>
           {item.subNavigation &&
             typeof subNavigation[item.subNavigation] !== 'undefined' && (
               <Menu>
@@ -69,7 +75,7 @@ export default ({ topNavigation, subNavigation, isMobile }) => (
                     <MenuLink
                       key={subItem.link}
                       className={headerNavigationStyles.menuLink}
-                      to={subItem.link}
+                      to={internalLink(subItem.link)}
                       as={Link}
                     >
                       {subItem.title}

--- a/src/components/pages/homepage/press.js
+++ b/src/components/pages/homepage/press.js
@@ -14,7 +14,7 @@ export default () => (
       <div className={pressStyles.logos}>
         <PressLogos onlyFeatured />
       </div>
-      <CtaLink to="about-project/in-the-press" centered>
+      <CtaLink to="/about-project/in-the-press" centered>
         See what else our data powers
       </CtaLink>
     </div>

--- a/src/components/utils/internal-link.js
+++ b/src/components/utils/internal-link.js
@@ -1,0 +1,6 @@
+export default link => {
+  if (link.substr(0, 1) === '/' || link.search('://') > -1) {
+    return link
+  }
+  return `/${link}`
+}


### PR DESCRIPTION
<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.
-->

<!--
  API CHANGES:
  If this PR includes changes to anything in the `/build` directory, make
  sure to note that in the PR. API changes have a different build and
  testing command than regular PRs.
-->

## Description
- Fixes hot-reload issue created by non-class component in MenuList
- Fixed a few non-base-relative Link components
<!-- Write a brief description of what this PR is for -->


## Related Issues
Fixes #925 
<!--
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234

  Link to an issue that is partially addressed by this PR (if there are any)
  e.g. Addresses #1234

  Link to related issues (if there are any)
  e.g. Related to #1234
-->

<!--
## Go-live time

  If this PR is for a feature that should not 
  be merged until a specific time, let us know!
-->


<!--
## Post-merge steps

  Outline things that need to be done once this is merged.
  This is usually work that has to be done in our CMS to change
  content or navigation.
-->
