### PR TITLE
chore: Shorten PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,45 +4,10 @@
 
   Testing!
   Make sure that running `npm run test` works locally before opening a PR.
--->
 
-<!--
-  API CHANGES:
-  If this PR includes changes to anything in the `/build` directory, make
-  sure to note that in the PR. API changes have a different build and
-  testing command than regular PRs.
+  Link to the issue that is fixed by this PR (if there is one)
+  e.g. Fixes #1234
 -->
 
 ## Description
 
-<!-- Write a brief description of what this PR is for -->
-
-
-## Related Issues
-
-<!--
-  Link to the issue that is fixed by this PR (if there is one)
-  e.g. Fixes #1234
-
-  Link to an issue that is partially addressed by this PR (if there are any)
-  e.g. Addresses #1234
-
-  Link to related issues (if there are any)
-  e.g. Related to #1234
--->
-
-<!--
-## Go-live time
-
-  If this PR is for a feature that should not 
-  be merged until a specific time, let us know!
--->
-
-
-<!--
-## Post-merge steps
-
-  Outline things that need to be done once this is merged.
-  This is usually work that has to be done in our CMS to change
-  content or navigation.
--->


### PR DESCRIPTION
This shortens the PR template to include just one preamble comment about docs and testing. It removes the stubbed-out go-live and post-merge steps.