### PR TITLE
fix: Blur current element for mobile

### DIFF
--- a/src/components/common/state-nav.js
+++ b/src/components/common/state-nav.js
@@ -17,6 +17,7 @@ export const getStateId = (stateList, selectedItem) =>
   })
 
 export const setWindowLocation = str => {
+  document.activeElement.blur()
   window.location.hash = str
 }
 


### PR DESCRIPTION
<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.

  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->

## Description
Blurs state nav before changing the hash in the data by state page.

fixes #944 
