### PR TITLE
fix: Improve handling of blurring jump-to-state input

### DIFF
--- a/src/components/common/state-nav.js
+++ b/src/components/common/state-nav.js
@@ -1,6 +1,6 @@
 /* eslint jsx-a11y/label-has-associated-control: 0 */
 
-import React, { useState } from 'react'
+import React, { useState, useRef, useLayoutEffect } from 'react'
 import {
   Combobox,
   ComboboxInput,
@@ -51,6 +51,17 @@ export default ({ title, stateList }) => {
 
   const results = searchStates(searchTerm)
 
+  const inputRef = useRef()
+
+  useLayoutEffect(() => {
+    const handleHashChange = () => inputRef.current.blur()
+    window.addEventListener('hashchange', handleHashChange)
+
+    return () => {
+      window.removeEventListener('hashchange', handleHashChange)
+    }
+  })
+
   return (
     <div className={`state-nav-header ${stateNavStyles.stateNav}`}>
       <div className={stateNavStyles.stateNavInner}>
@@ -79,6 +90,7 @@ export default ({ title, stateList }) => {
               id="jump-to-state"
               placeholder="State or territory"
               autoComplete="false"
+              ref={inputRef}
               onKeyDown={event => selectFirstItemOnKeyDown(event, results)}
               onChange={event => {
                 setSearchTerm(event.target.value)


### PR DESCRIPTION
This is a new fix for #551. I have successfully tested on multiple Android and iOS devices using Browserstack, as well as multiple desktop browsers.  

Thanks to @pspeter3 for the recommended approach!

