### PR TITLE
feat: Add API post-build testing

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -9,7 +9,7 @@ jobs:
         uses: JakePartusch/wait-for-netlify-action@v1.2
         id: preview
         with:
-          site_name: "focused-tereshkova-0e2f4b"
+          site_name: "upbeat-lovelace-3e9fff"
           max_timeout: 600
 
       - uses: actions/checkout@v1

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Run
         env:
           JEST_COVID_API_HOST: ${{ steps.preview.outputs.url }}
-        run: jest ./src/__tests__/api/index.js --no-color 2>/tmp/api-output.txt
+        run: npm run test:api-header-test
 
       - name: Comment
         uses: marocchino/sticky-pull-request-comment@v1

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -14,6 +14,9 @@ jobs:
 
       - uses: actions/checkout@v1
 
+      - name: Install
+        run: npm install
+
       - name: Run
         env:
           JEST_COVID_API_HOST: ${{ steps.preview.outputs.url }}

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -13,8 +13,6 @@ jobs:
           max_timeout: 600
 
       - uses: actions/checkout@v1
-        with:
-          path: ./
 
       - name: Install
         run: npm install
@@ -22,7 +20,7 @@ jobs:
       - name: Run
         env:
           JEST_COVID_API_HOST: ${{ steps.preview.outputs.url }}
-        run: npm run test:api-header-test
+        run: ls && npm run test:api-header-test
 
       - name: Comment
         uses: marocchino/sticky-pull-request-comment@v1

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -17,25 +17,7 @@ jobs:
       - name: Install
         run: npm install
 
-      - name: Run
+      - name: Test
         env:
           JEST_COVID_API_HOST: ${{ steps.preview.outputs.url }}
         run: npm run test:api-header-test
-      
-      - name: Read output
-        id: readoutput
-        env:
-          JEST_COVID_API_HOST: ${{ steps.preview.outputs.url }}
-        run: |
-          OUTPUT=$(less /tmp/api-output.txt)
-          echo "::set-output name=result::$OUTPUT"
-
-      - name: Comment
-        uses: marocchino/sticky-pull-request-comment@v1.4.0
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          message: |
-            API CORS test results
-            ```
-            ${{ steps.readoutput.outputs.result }}
-            ```

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -13,6 +13,8 @@ jobs:
           max_timeout: 600
 
       - uses: actions/checkout@v1
+        with:
+          path: ./
 
       - name: Install
         run: npm install

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -1,0 +1,25 @@
+name: API output test
+on: [pull_request]
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for Netlify
+        uses: JakePartusch/wait-for-netlify-action@v1.2
+        id: preview
+        with:
+          site_name: "focused-tereshkova-0e2f4b"
+
+      - uses: actions/checkout@v1
+
+      - name: Run
+        env:
+          JEST_COVID_API_HOST: ${{ steps.preview.outputs.url }}
+        run: jest ./src/__tests__/api/index.js --no-color 2>/tmp/api-output.txt
+
+      - name: Comment
+        uses: marocchino/sticky-pull-request-comment@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          path: /tmp/api-output.txt

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -10,6 +10,7 @@ jobs:
         id: preview
         with:
           site_name: "focused-tereshkova-0e2f4b"
+          max_timeout: 600
 
       - uses: actions/checkout@v1
 

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -1,8 +1,8 @@
-name: API output test
+name: Test deployed API
 on: [pull_request]
 
 jobs:
-  trigger:
+  test:
     runs-on: ubuntu-latest
     steps:
       - name: Wait for Netlify

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -23,7 +23,7 @@ jobs:
         run: ls && npm run test:api-header-test
 
       - name: Comment
-        uses: marocchino/sticky-pull-request-comment@latest
+        uses: marocchino/sticky-pull-request-comment@v1.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           path: /tmp/api-output.txt

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -18,11 +18,16 @@ jobs:
         run: npm install
 
       - name: Run
-        id: apitest
+        env:
+          JEST_COVID_API_HOST: ${{ steps.preview.outputs.url }}
+        run: npm run test:api-header-test
+      
+      - name: Read output
+        id: readoutput
         env:
           JEST_COVID_API_HOST: ${{ steps.preview.outputs.url }}
         run: |
-          OUTPUT=$(npm run test:api-header-test)
+          OUTPUT=$(less /tmp/api-output.txt)
           echo "::set-output name=result::$OUTPUT"
 
       - name: Comment
@@ -32,5 +37,5 @@ jobs:
           message: |
             API CORS test results
             ```
-            ${{ steps.apitest.outputs.result }}
+            ${{ steps.readoutput.outputs.result }}
             ```

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -23,7 +23,7 @@ jobs:
         run: ls && npm run test:api-header-test
 
       - name: Comment
-        uses: marocchino/sticky-pull-request-comment@v1
+        uses: marocchino/sticky-pull-request-comment@latest
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           path: /tmp/api-output.txt

--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -18,12 +18,19 @@ jobs:
         run: npm install
 
       - name: Run
+        id: apitest
         env:
           JEST_COVID_API_HOST: ${{ steps.preview.outputs.url }}
-        run: ls && npm run test:api-header-test
+        run: |
+          OUTPUT=$(npm run test:api-header-test)
+          echo "::set-output name=result::$OUTPUT"
 
       - name: Comment
         uses: marocchino/sticky-pull-request-comment@v1.4.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          path: /tmp/api-output.txt
+          message: |
+            API CORS test results
+            ```
+            ${{ steps.apitest.outputs.result }}
+            ```

--- a/jest.config.js
+++ b/jest.config.js
@@ -24,9 +24,7 @@ module.exports = {
     `\\.cache`,
     `<rootDir>.*/public`,
     './src/__tests__/build/index.js',
-    './build/__tests__/post-build/',
-    './build/__tests__/utilities/',
-    './build/test.js',
+    './src/__tests__/api/index.js',
   ],
   transformIgnorePatterns: [`node_modules/(?!(gatsby)/)`],
   globals: {

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "test:coverage": "jest --coverage --maxWorkers 1",
     "test:lint": "eslint ./src",
     "test:dev": "run-s test:lint test",
+    "test:api-header-test": "jest ./src/__tests__/api/index.js --no-color 2>/tmp/api-output.txt",
     "setup": "run-s setup:api-repo setup:env-vars",
     "setup:env-vars": "curl -L https://covidtracking.com/__developer/env-vars > .env",
     "setup:api-repo": "rm -rf _api || true && git clone --depth 1 https://github.com/COVID19Tracking/covid-public-api.git _api && rm -rf _api/.git"

--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "identity-obj-proxy": "^3.0.0",
     "jest": "^25.3.0",
     "jest-junit": "^10.0.0",
+    "node-fetch": "^2.6.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^1.19.1",
     "react-test-renderer": "^16.13.1",
@@ -134,7 +135,7 @@
     "test:coverage": "jest --coverage --maxWorkers 1",
     "test:lint": "eslint ./src",
     "test:dev": "run-s test:lint test",
-    "test:api-header-test": "jest --config='{}' ./src/__tests__/api/index.js --no-color 2>/tmp/api-output.txt",
+    "test:api-header-test": "jest --config='{}' ./src/__tests__/api/index.js",
     "setup": "run-s setup:api-repo setup:env-vars",
     "setup:env-vars": "curl -L https://covidtracking.com/__developer/env-vars > .env",
     "setup:api-repo": "rm -rf _api || true && git clone --depth 1 https://github.com/COVID19Tracking/covid-public-api.git _api && rm -rf _api/.git"

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "test:coverage": "jest --coverage --maxWorkers 1",
     "test:lint": "eslint ./src",
     "test:dev": "run-s test:lint test",
-    "test:api-header-test": "jest --config='{}' ./src/__tests__/api/index.js --no-color 2>/tmp/api-output.txt",
+    "test:api-header-test": "jest --config='{}' ./src/__tests__/api/index.js --no-color",
     "setup": "run-s setup:api-repo setup:env-vars",
     "setup:env-vars": "curl -L https://covidtracking.com/__developer/env-vars > .env",
     "setup:api-repo": "rm -rf _api || true && git clone --depth 1 https://github.com/COVID19Tracking/covid-public-api.git _api && rm -rf _api/.git"

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "test:coverage": "jest --coverage --maxWorkers 1",
     "test:lint": "eslint ./src",
     "test:dev": "run-s test:lint test",
-    "test:api-header-test": "jest ./src/__tests__/api/index.js --no-color 2>/tmp/api-output.txt",
+    "test:api-header-test": "jest --config='{}' ./src/__tests__/api/index.js --no-color 2>/tmp/api-output.txt",
     "setup": "run-s setup:api-repo setup:env-vars",
     "setup:env-vars": "curl -L https://covidtracking.com/__developer/env-vars > .env",
     "setup:api-repo": "rm -rf _api || true && git clone --depth 1 https://github.com/COVID19Tracking/covid-public-api.git _api && rm -rf _api/.git"

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "test:coverage": "jest --coverage --maxWorkers 1",
     "test:lint": "eslint ./src",
     "test:dev": "run-s test:lint test",
-    "test:api-header-test": "jest --config='{}' ./src/__tests__/api/index.js --no-color",
+    "test:api-header-test": "jest --config='{}' ./src/__tests__/api/index.js --no-color 2>/tmp/api-output.txt",
     "setup": "run-s setup:api-repo setup:env-vars",
     "setup:env-vars": "curl -L https://covidtracking.com/__developer/env-vars > .env",
     "setup:api-repo": "rm -rf _api || true && git clone --depth 1 https://github.com/COVID19Tracking/covid-public-api.git _api && rm -rf _api/.git"

--- a/src/__tests__/api/index.js
+++ b/src/__tests__/api/index.js
@@ -1,0 +1,132 @@
+const fetch = require('node-fetch')
+
+const host = process.env.JEST_COVID_API_HOST
+
+describe('Fetch API data', () => {
+  it('has status API', done => {
+    fetch(`${host}/api/v1/status.json`)
+      .then(response => {
+        expect(
+          Array.isArray(response.headers.raw()['access-control-allow-origin']),
+        ).toBe(true)
+        expect(response.headers.raw()['access-control-allow-origin'][0]).toBe(
+          '*',
+        )
+        return response.json()
+      })
+      .then(status => {
+        expect(status).toHaveProperty('runNumber')
+        expect(status).toHaveProperty('buildTime')
+        done()
+      })
+      .catch(error => {
+        expect(error).toBe(false)
+        done()
+      })
+  })
+
+  it('has states daily API', done => {
+    fetch(`${host}/api/v1/states/daily.json`)
+      .then(response => {
+        expect(
+          Array.isArray(response.headers.raw()['access-control-allow-origin']),
+        ).toBe(true)
+        expect(response.headers.raw()['access-control-allow-origin'][0]).toBe(
+          '*',
+        )
+        return response.json()
+      })
+      .then(data => {
+        expect(data.length).toBeGreaterThan(100)
+        done()
+      })
+      .catch(error => {
+        expect(error).toBe(false)
+        done()
+      })
+  })
+
+  it('has US daily API', done => {
+    fetch(`${host}/api/v1/us/daily.json`)
+      .then(response => {
+        expect(
+          Array.isArray(response.headers.raw()['access-control-allow-origin']),
+        ).toBe(true)
+        expect(response.headers.raw()['access-control-allow-origin'][0]).toBe(
+          '*',
+        )
+        return response.json()
+      })
+      .then(data => {
+        expect(data.length).toBeGreaterThan(40)
+        done()
+      })
+      .catch(error => {
+        expect(error).toBe(false)
+        done()
+      })
+  })
+
+  it('proxies old state URLs', done => {
+    fetch(`${host}/api/states.json`)
+      .then(response => {
+        expect(
+          Array.isArray(response.headers.raw()['access-control-allow-origin']),
+        ).toBe(true)
+        expect(response.headers.raw()['access-control-allow-origin'][0]).toBe(
+          '*',
+        )
+        return response.json()
+      })
+      .then(data => {
+        expect(data.length).toBeGreaterThan(40)
+        done()
+      })
+      .catch(error => {
+        expect(error).toBe(false)
+        done()
+      })
+  })
+
+  it('proxies old US date URLs with parameters', done => {
+    fetch(`${host}/api/us?date=20200501`)
+      .then(response => {
+        expect(
+          Array.isArray(response.headers.raw()['access-control-allow-origin']),
+        ).toBe(true)
+        expect(response.headers.raw()['access-control-allow-origin'][0]).toBe(
+          '*',
+        )
+        return response.json()
+      })
+      .then(data => {
+        expect(data.date).toBe(20200501)
+        done()
+      })
+      .catch(error => {
+        expect(error).toBe(false)
+        done()
+      })
+  })
+
+  it('proxies old state URLs with multiple parameters', done => {
+    fetch(`${host}/api/states/daily?state=ca&date=20200501`)
+      .then(response => {
+        expect(
+          Array.isArray(response.headers.raw()['access-control-allow-origin']),
+        ).toBe(true)
+        expect(response.headers.raw()['access-control-allow-origin'][0]).toBe(
+          '*',
+        )
+        return response.json()
+      })
+      .then(data => {
+        expect(data.date).toBe(20200501)
+        done()
+      })
+      .catch(error => {
+        expect(error).toBe(false)
+        done()
+      })
+  })
+})


### PR DESCRIPTION
<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.

  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->

## Description
This runs a github action that ensures all CORS headers and proxies for old API URLs are set. It leaves a comment on the PR with the output of a JEST test.
