### PR TITLE
Enable gatsby incremental builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   "scripts": {
     "build": "run-s setup:api-repo build:gatsby build:test",
     "build-preview": "run-s setup build:gatsby build:test",
-    "build:gatsby": "gatsby build",
+    "build:gatsby": "GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true gatsby build",
     "build:test": "jest --verbose --config=\"{}\" -- src/__tests__/build/index.js",
     "clean": "run-p clean:*",
     "clean:gatsby": "gatsby clean",

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
   "scripts": {
     "build": "run-s setup:api-repo build:gatsby build:test",
     "build-preview": "run-s setup build:gatsby build:test",
-    "build:gatsby": "GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true gatsby build",
+    "build:gatsby": "GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true gatsby build --log-pages",
     "build:test": "jest --verbose --config=\"{}\" -- src/__tests__/build/index.js",
     "clean": "run-p clean:*",
     "clean:gatsby": "gatsby clean",


### PR DESCRIPTION
<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.

  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->

## Description
Enables [incremental builds](https://www.netlify.com/blog/2020/04/23/enable-gatsby-incremental-builds-on-netlify/).
