### PR TITLE
Fix copyright link color

### DIFF
--- a/src/components/layout/footer.module.scss
+++ b/src/components/layout/footer.module.scss
@@ -86,4 +86,14 @@
   padding: 1.5rem 2rem 0.5rem;
   text-align: center;
   font-size: 1rem;
+
+  a {
+    color: white;
+    &:hover {
+      @include link-hover-dark-bg;
+    }
+    &:focus {
+      @include link-focus-dark-bg;
+    }
+  }
 }

--- a/src/scss/colors.module.scss
+++ b/src/scss/colors.module.scss
@@ -69,16 +69,13 @@ $color-infobox-alert-dark: #802509;
 $color-error-light: #f9ded9;
 $color-error-dark: #e35942;
 
-
 // Qualitative Six Color Palette, Colorblind Safe
-$qualitative-color-palette-100: #B5E3DB;
-$qualitative-color-palette-200: #CCCC00;
-$qualitative-color-palette-300: #A19BCA;
-$qualitative-color-palette-400: #F4A071;
-$qualitative-color-palette-500: #2F6488;
+$qualitative-color-palette-100: #b5e3db;
+$qualitative-color-palette-200: #cccc00;
+$qualitative-color-palette-300: #a19bca;
+$qualitative-color-palette-400: #f4a071;
+$qualitative-color-palette-500: #2f6488;
 $qualitative-color-palette-600: #527740;
-
-
 
 :export {
   text: $text;


### PR DESCRIPTION
<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.

  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->

## Description
The copyright link was black on purple, now it's white on purple
