### PR TITLE
chore: Add parent items to sub navigation

### DIFF
--- a/src/__tests__/components/layout/__snapshots__/header.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/header.js.snap
@@ -139,6 +139,30 @@ exports[`Components : Layout : Header renders correctly 1`] = `
                       data-reach-menu-link=""
                       data-selected=""
                       data-valuetext=""
+                      href="/test-a"
+                      onClick={[Function]}
+                      onDragStart={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseUp={[Function]}
+                      role="menuitem"
+                      tabIndex={-1}
+                    >
+                      Test A
+                    </a>
+                  </div>
+                  <div
+                    role="none"
+                    tabIndex={-1}
+                  >
+                    <a
+                      className="menuLink"
+                      data-reach-menu-item=""
+                      data-reach-menu-link=""
+                      data-selected=""
+                      data-valuetext=""
                       href="/contentful-a"
                       onClick={[Function]}
                       onDragStart={[Function]}
@@ -394,6 +418,30 @@ exports[`Components : Layout : Header renders correctly 1`] = `
                             data-reach-menu-link=""
                             data-selected=""
                             data-valuetext=""
+                            href="/test-a"
+                            onClick={[Function]}
+                            onDragStart={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseMove={[Function]}
+                            onMouseUp={[Function]}
+                            role="menuitem"
+                            tabIndex={-1}
+                          >
+                            Test A
+                          </a>
+                        </div>
+                        <div
+                          role="none"
+                          tabIndex={-1}
+                        >
+                          <a
+                            className="menuLink"
+                            data-reach-menu-item=""
+                            data-reach-menu-link=""
+                            data-selected=""
+                            data-valuetext=""
                             href="/contentful-a"
                             onClick={[Function]}
                             onDragStart={[Function]}
@@ -610,6 +658,30 @@ exports[`Components : Layout : Header renders correctly 2`] = `
                   role={false}
                   tabIndex={-1}
                 >
+                  <div
+                    role="none"
+                    tabIndex={-1}
+                  >
+                    <a
+                      className="menuLink"
+                      data-reach-menu-item=""
+                      data-reach-menu-link=""
+                      data-selected=""
+                      data-valuetext=""
+                      href="/test-a"
+                      onClick={[Function]}
+                      onDragStart={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseUp={[Function]}
+                      role="menuitem"
+                      tabIndex={-1}
+                    >
+                      Test A
+                    </a>
+                  </div>
                   <div
                     role="none"
                     tabIndex={-1}
@@ -875,6 +947,30 @@ exports[`Components : Layout : Header renders correctly 2`] = `
                             data-reach-menu-link=""
                             data-selected=""
                             data-valuetext=""
+                            href="/test-a"
+                            onClick={[Function]}
+                            onDragStart={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseMove={[Function]}
+                            onMouseUp={[Function]}
+                            role="menuitem"
+                            tabIndex={-1}
+                          >
+                            Test A
+                          </a>
+                        </div>
+                        <div
+                          role="none"
+                          tabIndex={-1}
+                        >
+                          <a
+                            className="menuLink"
+                            data-reach-menu-item=""
+                            data-reach-menu-link=""
+                            data-selected=""
+                            data-valuetext=""
                             href="/contentful-a"
                             onClick={[Function]}
                             onDragStart={[Function]}
@@ -1091,6 +1187,30 @@ exports[`Components : Layout : Header renders correctly 3`] = `
                   role={false}
                   tabIndex={-1}
                 >
+                  <div
+                    role="none"
+                    tabIndex={-1}
+                  >
+                    <a
+                      className="menuLink"
+                      data-reach-menu-item=""
+                      data-reach-menu-link=""
+                      data-selected=""
+                      data-valuetext=""
+                      href="/test-a"
+                      onClick={[Function]}
+                      onDragStart={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseUp={[Function]}
+                      role="menuitem"
+                      tabIndex={-1}
+                    >
+                      Test A
+                    </a>
+                  </div>
                   <div
                     role="none"
                     tabIndex={-1}
@@ -1356,6 +1476,30 @@ exports[`Components : Layout : Header renders correctly 3`] = `
                             data-reach-menu-link=""
                             data-selected=""
                             data-valuetext=""
+                            href="/test-a"
+                            onClick={[Function]}
+                            onDragStart={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseMove={[Function]}
+                            onMouseUp={[Function]}
+                            role="menuitem"
+                            tabIndex={-1}
+                          >
+                            Test A
+                          </a>
+                        </div>
+                        <div
+                          role="none"
+                          tabIndex={-1}
+                        >
+                          <a
+                            className="menuLink"
+                            data-reach-menu-item=""
+                            data-reach-menu-link=""
+                            data-selected=""
+                            data-valuetext=""
                             href="/contentful-a"
                             onClick={[Function]}
                             onDragStart={[Function]}
@@ -1576,6 +1720,30 @@ exports[`Components : Layout : Header renders correctly 4`] = `
                   role={false}
                   tabIndex={-1}
                 >
+                  <div
+                    role="none"
+                    tabIndex={-1}
+                  >
+                    <a
+                      className="menuLink"
+                      data-reach-menu-item=""
+                      data-reach-menu-link=""
+                      data-selected=""
+                      data-valuetext=""
+                      href="/test-a"
+                      onClick={[Function]}
+                      onDragStart={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseUp={[Function]}
+                      role="menuitem"
+                      tabIndex={-1}
+                    >
+                      Test A
+                    </a>
+                  </div>
                   <div
                     role="none"
                     tabIndex={-1}
@@ -1831,6 +1999,30 @@ exports[`Components : Layout : Header renders correctly 4`] = `
                         role={false}
                         tabIndex={-1}
                       >
+                        <div
+                          role="none"
+                          tabIndex={-1}
+                        >
+                          <a
+                            className="menuLink"
+                            data-reach-menu-item=""
+                            data-reach-menu-link=""
+                            data-selected=""
+                            data-valuetext=""
+                            href="/test-a"
+                            onClick={[Function]}
+                            onDragStart={[Function]}
+                            onMouseDown={[Function]}
+                            onMouseEnter={[Function]}
+                            onMouseLeave={[Function]}
+                            onMouseMove={[Function]}
+                            onMouseUp={[Function]}
+                            role="menuitem"
+                            tabIndex={-1}
+                          >
+                            Test A
+                          </a>
+                        </div>
                         <div
                           role="none"
                           tabIndex={-1}

--- a/src/__tests__/components/layout/__snapshots__/index.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/index.js.snap
@@ -147,6 +147,30 @@ Array [
                         data-reach-menu-link=""
                         data-selected=""
                         data-valuetext=""
+                        href="/test-a"
+                        onClick={[Function]}
+                        onDragStart={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseMove={[Function]}
+                        onMouseUp={[Function]}
+                        role="menuitem"
+                        tabIndex={-1}
+                      >
+                        Test A
+                      </a>
+                    </div>
+                    <div
+                      role="none"
+                      tabIndex={-1}
+                    >
+                      <a
+                        className="menuLink"
+                        data-reach-menu-item=""
+                        data-reach-menu-link=""
+                        data-selected=""
+                        data-valuetext=""
                         href="/contentful-a"
                         onClick={[Function]}
                         onDragStart={[Function]}
@@ -392,6 +416,30 @@ Array [
                           role={false}
                           tabIndex={-1}
                         >
+                          <div
+                            role="none"
+                            tabIndex={-1}
+                          >
+                            <a
+                              className="menuLink"
+                              data-reach-menu-item=""
+                              data-reach-menu-link=""
+                              data-selected=""
+                              data-valuetext=""
+                              href="/test-a"
+                              onClick={[Function]}
+                              onDragStart={[Function]}
+                              onMouseDown={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              onMouseMove={[Function]}
+                              onMouseUp={[Function]}
+                              role="menuitem"
+                              tabIndex={-1}
+                            >
+                              Test A
+                            </a>
+                          </div>
                           <div
                             role="none"
                             tabIndex={-1}
@@ -763,6 +811,30 @@ Array [
                         data-reach-menu-link=""
                         data-selected=""
                         data-valuetext=""
+                        href="/test-a"
+                        onClick={[Function]}
+                        onDragStart={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseMove={[Function]}
+                        onMouseUp={[Function]}
+                        role="menuitem"
+                        tabIndex={-1}
+                      >
+                        Test A
+                      </a>
+                    </div>
+                    <div
+                      role="none"
+                      tabIndex={-1}
+                    >
+                      <a
+                        className="menuLink"
+                        data-reach-menu-item=""
+                        data-reach-menu-link=""
+                        data-selected=""
+                        data-valuetext=""
                         href="/contentful-a"
                         onClick={[Function]}
                         onDragStart={[Function]}
@@ -1008,6 +1080,30 @@ Array [
                           role={false}
                           tabIndex={-1}
                         >
+                          <div
+                            role="none"
+                            tabIndex={-1}
+                          >
+                            <a
+                              className="menuLink"
+                              data-reach-menu-item=""
+                              data-reach-menu-link=""
+                              data-selected=""
+                              data-valuetext=""
+                              href="/test-a"
+                              onClick={[Function]}
+                              onDragStart={[Function]}
+                              onMouseDown={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              onMouseMove={[Function]}
+                              onMouseUp={[Function]}
+                              role="menuitem"
+                              tabIndex={-1}
+                            >
+                              Test A
+                            </a>
+                          </div>
                           <div
                             role="none"
                             tabIndex={-1}
@@ -1379,6 +1475,30 @@ Array [
                         data-reach-menu-link=""
                         data-selected=""
                         data-valuetext=""
+                        href="/test-a"
+                        onClick={[Function]}
+                        onDragStart={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseMove={[Function]}
+                        onMouseUp={[Function]}
+                        role="menuitem"
+                        tabIndex={-1}
+                      >
+                        Test A
+                      </a>
+                    </div>
+                    <div
+                      role="none"
+                      tabIndex={-1}
+                    >
+                      <a
+                        className="menuLink"
+                        data-reach-menu-item=""
+                        data-reach-menu-link=""
+                        data-selected=""
+                        data-valuetext=""
                         href="/contentful-a"
                         onClick={[Function]}
                         onDragStart={[Function]}
@@ -1624,6 +1744,30 @@ Array [
                           role={false}
                           tabIndex={-1}
                         >
+                          <div
+                            role="none"
+                            tabIndex={-1}
+                          >
+                            <a
+                              className="menuLink"
+                              data-reach-menu-item=""
+                              data-reach-menu-link=""
+                              data-selected=""
+                              data-valuetext=""
+                              href="/test-a"
+                              onClick={[Function]}
+                              onDragStart={[Function]}
+                              onMouseDown={[Function]}
+                              onMouseEnter={[Function]}
+                              onMouseLeave={[Function]}
+                              onMouseMove={[Function]}
+                              onMouseUp={[Function]}
+                              role="menuitem"
+                              tabIndex={-1}
+                            >
+                              Test A
+                            </a>
+                          </div>
                           <div
                             role="none"
                             tabIndex={-1}

--- a/src/components/layout/header/navigation.js
+++ b/src/components/layout/header/navigation.js
@@ -71,6 +71,13 @@ export default ({ topNavigation, subNavigation, isMobile }) => (
                   }}
                   portal={false}
                 >
+                  <MenuLink
+                    className={headerNavigationStyles.menuLink}
+                    to={internalLink(item.link)}
+                    as={Link}
+                  >
+                    {item.title}
+                  </MenuLink>
                   {subNavigation[item.subNavigation].map(subItem => (
                     <MenuLink
                       key={subItem.link}


### PR DESCRIPTION
<!--
  Have any questions? 
  Check out the docs at https://covid19tracking.github.io/website-docs first.

  Testing!
  Make sure that running `npm run test` works locally before opening a PR.

  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->

## Description
- Fixes #1008
- Adds the parent navigation item to the top of the sub navigation
