### PR TITLE
Responsive tables for blog posts

### DIFF
--- a/src/components/pages/blog/table-content-block.js
+++ b/src/components/pages/blog/table-content-block.js
@@ -20,7 +20,6 @@ const parseMarkdownTable = table => {
     const rowData = row.split('|')
     let isDivider = true
     rowData.forEach(item => {
-      console.log(item)
       if (item.search(/[^-]/) > -1) {
         isDivider = false
       }

--- a/src/components/pages/blog/table-content-block.js
+++ b/src/components/pages/blog/table-content-block.js
@@ -1,13 +1,69 @@
+/* eslint-disable react/no-array-index-key,jsx-a11y/control-has-associated-label */
 import React from 'react'
 import marked from 'marked'
-import tableStyle from '~components/common/table.module.scss'
-import tableContentBlockStyle from './table-content-block.module.scss'
+import { Table, Th, Td } from '~components/common/table'
+import tableStyle from './table-content-block.module.scss'
 
-export default ({ table }) => (
-  <div
-    className={`${tableStyle.table} ${tableContentBlockStyle.table}`}
-    dangerouslySetInnerHTML={{
-      __html: marked(table),
-    }}
-  />
-)
+const renderCell = cell =>
+  marked(cell)
+    .replace(/<(\/)?p>/g, '')
+    .trim()
+
+const parseMarkdownTable = table => {
+  const rows = []
+  const tableData = table.split(/\n/)
+  const headers = tableData[0]
+    .split('|')
+    .map(item => renderCell(item.trim().replace(/_/g, '')))
+  tableData.shift()
+  tableData.forEach(row => {
+    const rowData = row.split('|')
+    let isDivider = true
+    rowData.forEach(item => {
+      console.log(item)
+      if (item.search(/[^-]/) > -1) {
+        isDivider = false
+      }
+    })
+    if (isDivider) {
+      return
+    }
+    rows.push(rowData.map(item => renderCell(item)))
+  })
+  return {
+    headers,
+    rows,
+  }
+}
+
+export default ({ table }) => {
+  const { headers, rows } = parseMarkdownTable(table)
+  return (
+    <Table>
+      <thead>
+        <tr className={tableStyle.header}>
+          {headers.map(item => (
+            <Th key={`header-${item}`}>
+              <span dangerouslySetInnerHTML={{ __html: item }} />
+            </Th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, index) => (
+          <tr key={`row-${index}`} className={tableStyle.row}>
+            {row.map((item, itemIndex) => (
+              <Td key={`row-${index}-${item}`} alignLeft>
+                <span
+                  className={tableStyle.cellLabel}
+                  dangerouslySetInnerHTML={{ __html: headers[itemIndex] }}
+                />
+                <span dangerouslySetInnerHTML={{ __html: item }} />
+              </Td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </Table>
+  )
+}

--- a/src/components/pages/blog/table-content-block.module.scss
+++ b/src/components/pages/blog/table-content-block.module.scss
@@ -1,11 +1,37 @@
 @import '~scss/colors.module.scss';
+@import '~scss/breakpoints.module.scss';
 
-.table {
-  width: 100%;
-  tr,
-  td,
-  th {
-    border-bottom: 1px solid $color-slate-200;
-    text-align: left;
+.cell-label {
+  display: block;
+  font-weight: bold;
+  font-size: 1rem;
+  margin: 0.75rem 0;
+  @media (min-width: $viewport-lg) {
+    display: none;
+  }
+}
+
+.header {
+  display: none;
+  @media (min-width: $viewport-lg) {
+    display: table-row;
+  }
+}
+
+.row {
+  display: block;
+  @media (max-width: $viewport-lg) {
+    border-top: 1px solid $color-slate-700;
+    border-bottom: 1px solid $color-slate-700;
+  }
+  td {
+    display: block;
+    padding: 1rem 0;
+    @media (min-width: $viewport-lg) {
+      display: table-cell;
+    }
+  }
+  @media (min-width: $viewport-lg) {
+    display: table-row;
   }
 }

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -30,6 +30,8 @@ const options = {
         node.data.target.sys.contentType.sys.contentful_id ===
         'contentBlockTable'
       ) {
+        console.log(node.data.target.fields.table['en-US'])
+
         return (
           <TableContentBlock table={node.data.target.fields.table['en-US']} />
         )


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Parses markdown tables in blog posts
- Uses our existing `Table` components as much as possible
- Adds utility classes to make the table responsive
Fixes #990 
