### PR TITLE
fix(design): Increase spacing to authors in homepage blog

### DIFF
--- a/src/components/pages/homepage/blog-list.module.scss
+++ b/src/components/pages/homepage/blog-list.module.scss
@@ -28,5 +28,6 @@
     font-size: 16px;
     font-size: 1rem;
     line-height: 1.5;
+    margin-bottom: 8px;
   }
 }


### PR DESCRIPTION
I added half a line of spacing so the authors are still visually linked to the text. Let me know if that works.

![image](https://user-images.githubusercontent.com/41039/84273237-d03b7d80-ab04-11ea-9482-ce75ca6fce51.png)

Closes #1013 