### PR TITLE
feat: Set headers for CORS preflight requests

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -14,5 +14,5 @@
   for = "/api/*"
   [headers.values]
     Access-Control-Allow-Origin = "*"
-    Access-Control-Allow-Methods: POST
-    Access-Control-Allow-Headers: Content-Type
+    Access-Control-Allow-Methods = "POST"
+    Access-Control-Allow-Headers = "Content-Type"

--- a/netlify.toml
+++ b/netlify.toml
@@ -14,3 +14,5 @@
   for = "/api/*"
   [headers.values]
     Access-Control-Allow-Origin = "*"
+    Access-Control-Allow-Methods: POST
+    Access-Control-Allow-Headers: Content-Type


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Hard-sets preflight headers for API folks using jQuery's CORS requests:

```
Access-Control-Allow-Methods: POST
Access-Control-Allow-Headers: Content-Type
```