### PR TITLE
chore: Add staging endpoint

### DIFF
--- a/functions/api-build/api-build-test.js
+++ b/functions/api-build/api-build-test.js
@@ -1,0 +1,29 @@
+const fetch = require('node-fetch')
+
+exports.handler = async (event, context) => {
+  if (
+    event.queryStringParameters.key !== process.env.CTP_GITHUB_API_BUILD_KEY
+  ) {
+    return { statusCode: 403, body: 'Access denied' }
+  }
+  try {
+    await fetch(
+      'https://api.github.com/repos/COVID19Tracking/covid-public-api-build/dispatches',
+      {
+        method: 'post',
+        body: JSON.stringify({
+          event_type: 'api-build-staging',
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `token ${process.env.CTP_GITHUB_API_BUILD_TOKEN}`,
+        },
+      },
+    ).then(response => {
+      return response.text()
+    })
+    return { statusCode: 200, body: 'Done' }
+  } catch (err) {
+    return { statusCode: 500, body: err.toString() }
+  }
+}


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Add Netlify function to do a staging webhook for the API