### PR TITLE
Codywall/cleanup state data page links 1026

### DIFF
--- a/src/__tests__/components/pages/data/__snapshots__/state-data.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-data.js.snap
@@ -300,7 +300,7 @@ Array [
     </div>
   </div>,
   <ul
-    className="list-unstyled listUnstyled"
+    className="list"
   >
     <li>
       <a

--- a/src/__tests__/components/pages/data/__snapshots__/state-data.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-data.js.snap
@@ -311,7 +311,7 @@ Array [
           className="a11y-only"
         >
           Alabama
-          's
+          's 
         </span>
         Official Twitter
       </a>
@@ -327,9 +327,9 @@ Array [
           className="a11y-only"
         >
           Alabama
-          's
+          's 
         </span>
-        Official Data Source
+        Best Current Data Source
       </a>
       <span>
         •
@@ -340,6 +340,12 @@ Array [
         href="/data/state/alabama#historical"
       >
         Historical Data
+        <span
+          className="a11y-only"
+        >
+          for 
+          Alabama
+        </span>
       </a>
     </li>
   </ul>,

--- a/src/__tests__/components/pages/data/__snapshots__/state-data.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-data.js.snap
@@ -307,24 +307,27 @@ Array [
       <a
         href="https://twitter.com/@alpublichealth"
       >
-        Alabama
-         on Twitter
+        Official Twitter
       </a>
+      <span>
+        •
+      </span>
     </li>
     <li>
       <a
         href="https://alpublichealth.maps.arcgis.com/apps/opsdashboard/index.html#/6d2771faa9da4a2786a509d82c8cf0f7"
       >
-        Best current data source for 
-        Alabama
+        Official Data Source
       </a>
+      <span>
+        •
+      </span>
     </li>
     <li>
       <a
         href="/data/state/alabama#historical"
       >
-        Historical data for 
-        Alabama
+        Historical Data
       </a>
     </li>
   </ul>,

--- a/src/__tests__/components/pages/data/__snapshots__/state-data.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-data.js.snap
@@ -307,6 +307,12 @@ Array [
       <a
         href="https://twitter.com/@alpublichealth"
       >
+        <span
+          className="a11y-only"
+        >
+          Alabama
+          's
+        </span>
         Official Twitter
       </a>
       <span>
@@ -317,6 +323,12 @@ Array [
       <a
         href="https://alpublichealth.maps.arcgis.com/apps/opsdashboard/index.html#/6d2771faa9da4a2786a509d82c8cf0f7"
       >
+        <span
+          className="a11y-only"
+        >
+          Alabama
+          's
+        </span>
         Official Data Source
       </a>
       <span>

--- a/src/__tests__/components/pages/data/__snapshots__/state-list.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-list.js.snap
@@ -310,6 +310,12 @@ exports[`Components : Pages : Data : State data renders correctly 1`] = `
       <a
         href="https://twitter.com/@alpublichealth"
       >
+        <span
+          className="a11y-only"
+        >
+          Alabama
+          's
+        </span>
         Official Twitter
       </a>
       <span>
@@ -320,6 +326,12 @@ exports[`Components : Pages : Data : State data renders correctly 1`] = `
       <a
         href="https://alpublichealth.maps.arcgis.com/apps/opsdashboard/index.html#/6d2771faa9da4a2786a509d82c8cf0f7"
       >
+        <span
+          className="a11y-only"
+        >
+          Alabama
+          's
+        </span>
         Official Data Source
       </a>
       <span>

--- a/src/__tests__/components/pages/data/__snapshots__/state-list.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-list.js.snap
@@ -303,7 +303,7 @@ exports[`Components : Pages : Data : State data renders correctly 1`] = `
     </div>
   </div>
   <ul
-    className="list-unstyled listUnstyled"
+    className="list"
   >
     <li>
       <a

--- a/src/__tests__/components/pages/data/__snapshots__/state-list.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-list.js.snap
@@ -314,7 +314,7 @@ exports[`Components : Pages : Data : State data renders correctly 1`] = `
           className="a11y-only"
         >
           Alabama
-          's
+          's 
         </span>
         Official Twitter
       </a>
@@ -330,9 +330,9 @@ exports[`Components : Pages : Data : State data renders correctly 1`] = `
           className="a11y-only"
         >
           Alabama
-          's
+          's 
         </span>
-        Official Data Source
+        Best Current Data Source
       </a>
       <span>
         •
@@ -343,6 +343,12 @@ exports[`Components : Pages : Data : State data renders correctly 1`] = `
         href="/data/state/alabama#historical"
       >
         Historical Data
+        <span
+          className="a11y-only"
+        >
+          for 
+          Alabama
+        </span>
       </a>
     </li>
   </ul>

--- a/src/__tests__/components/pages/data/__snapshots__/state-list.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-list.js.snap
@@ -310,24 +310,27 @@ exports[`Components : Pages : Data : State data renders correctly 1`] = `
       <a
         href="https://twitter.com/@alpublichealth"
       >
-        Alabama
-         on Twitter
+        Official Twitter
       </a>
+      <span>
+        •
+      </span>
     </li>
     <li>
       <a
         href="https://alpublichealth.maps.arcgis.com/apps/opsdashboard/index.html#/6d2771faa9da4a2786a509d82c8cf0f7"
       >
-        Best current data source for 
-        Alabama
+        Official Data Source
       </a>
+      <span>
+        •
+      </span>
     </li>
     <li>
       <a
         href="/data/state/alabama#historical"
       >
-        Historical data for 
-        Alabama
+        Historical Data
       </a>
     </li>
   </ul>

--- a/src/__tests__/components/pages/state/__snapshots__/state-links.js.snap
+++ b/src/__tests__/components/pages/state/__snapshots__/state-links.js.snap
@@ -8,15 +8,17 @@ exports[`Components : Pages : State : State links renders correctly 1`] = `
     <a
       href="https://twitter.com/california-covid"
     >
-      California
-       on Twitter
+      Official Twitter
     </a>
+    <span>
+      •
+    </span>
   </li>
   <li>
     <a
       href="https://example.com"
     >
-      Data source
+      Data Source
     </a>
   </li>
 </ul>
@@ -30,22 +32,27 @@ exports[`Components : Pages : State : State links renders correctly 2`] = `
     <a
       href="https://twitter.com/california-covid"
     >
-      California
-       on Twitter
+      Official Twitter
     </a>
+    <span>
+      •
+    </span>
   </li>
   <li>
     <a
       href="https://example.com"
     >
-      Best current data source
+      Best Current Data Source
     </a>
+    <span>
+      •
+    </span>
   </li>
   <li>
     <a
       href="https://example.com"
     >
-      Data source
+      Data Source
     </a>
   </li>
 </ul>

--- a/src/__tests__/components/pages/state/__snapshots__/state-links.js.snap
+++ b/src/__tests__/components/pages/state/__snapshots__/state-links.js.snap
@@ -8,6 +8,11 @@ exports[`Components : Pages : State : State links renders correctly 1`] = `
     <a
       href="https://twitter.com/california-covid"
     >
+      <span
+        className="a11y-only"
+      >
+        's 
+      </span>
       Official Twitter
     </a>
     <span>
@@ -19,6 +24,11 @@ exports[`Components : Pages : State : State links renders correctly 1`] = `
       href="https://example.com"
     >
       Data Source
+      <span
+        className="a11y-only"
+      >
+         for 
+      </span>
     </a>
   </li>
 </ul>
@@ -32,6 +42,11 @@ exports[`Components : Pages : State : State links renders correctly 2`] = `
     <a
       href="https://twitter.com/california-covid"
     >
+      <span
+        className="a11y-only"
+      >
+        's 
+      </span>
       Official Twitter
     </a>
     <span>
@@ -42,6 +57,11 @@ exports[`Components : Pages : State : State links renders correctly 2`] = `
     <a
       href="https://example.com"
     >
+      <span
+        className="a11y-only"
+      >
+        's 
+      </span>
       Best Current Data Source
     </a>
     <span>
@@ -53,6 +73,11 @@ exports[`Components : Pages : State : State links renders correctly 2`] = `
       href="https://example.com"
     >
       Data Source
+      <span
+        className="a11y-only"
+      >
+         for 
+      </span>
     </a>
   </li>
 </ul>

--- a/src/__tests__/components/pages/state/__snapshots__/state-links.js.snap
+++ b/src/__tests__/components/pages/state/__snapshots__/state-links.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Components : Pages : State : State links renders correctly 1`] = `
 <ul
-  className="list-unstyled listUnstyled"
+  className="list"
 >
   <li>
     <a
@@ -11,40 +11,7 @@ exports[`Components : Pages : State : State links renders correctly 1`] = `
       <span
         className="a11y-only"
       >
-        's 
-      </span>
-      Official Twitter
-    </a>
-    <span>
-      •
-    </span>
-  </li>
-  <li>
-    <a
-      href="https://example.com"
-    >
-      Data Source
-      <span
-        className="a11y-only"
-      >
-         for 
-      </span>
-    </a>
-  </li>
-</ul>
-`;
-
-exports[`Components : Pages : State : State links renders correctly 2`] = `
-<ul
-  className="list-unstyled listUnstyled"
->
-  <li>
-    <a
-      href="https://twitter.com/california-covid"
-    >
-      <span
-        className="a11y-only"
-      >
+        California
         's 
       </span>
       Official Twitter
@@ -60,6 +27,7 @@ exports[`Components : Pages : State : State links renders correctly 2`] = `
       <span
         className="a11y-only"
       >
+        California
         's 
       </span>
       Best Current Data Source
@@ -70,15 +38,70 @@ exports[`Components : Pages : State : State links renders correctly 2`] = `
   </li>
   <li>
     <a
-      href="https://example.com"
+      href="https://example.com2"
     >
-      Data Source
+      Secondary Data Source
       <span
         className="a11y-only"
       >
          for 
+        California
       </span>
     </a>
+    
+  </li>
+</ul>
+`;
+
+exports[`Components : Pages : State : State links renders correctly 2`] = `
+<ul
+  className="list"
+>
+  <li>
+    <a
+      href="https://twitter.com/california-covid"
+    >
+      <span
+        className="a11y-only"
+      >
+        California
+        's 
+      </span>
+      Official Twitter
+    </a>
+    <span>
+      •
+    </span>
+  </li>
+  <li>
+    <a
+      href="https://example.com"
+    >
+      <span
+        className="a11y-only"
+      >
+        California
+        's 
+      </span>
+      Best Current Data Source
+    </a>
+    <span>
+      •
+    </span>
+  </li>
+  <li>
+    <a
+      href="https://example.com2"
+    >
+      Secondary Data Source
+      <span
+        className="a11y-only"
+      >
+         for 
+        California
+      </span>
+    </a>
+    
   </li>
 </ul>
 `;

--- a/src/__tests__/components/pages/state/state-links.js
+++ b/src/__tests__/components/pages/state/state-links.js
@@ -7,9 +7,10 @@ describe('Components : Pages : State : State links', () => {
     const tree = renderer
       .create(
         <StateLinks
-          name="California"
+          stateName="California"
           twitter="california-covid"
-          dataSource="https://example.com"
+          covid19Site="https://example.com"
+          covid19SiteSecondary="https://example.com2"
         />,
       )
       .toJSON()
@@ -18,10 +19,10 @@ describe('Components : Pages : State : State links', () => {
     const covid19SiteTree = renderer
       .create(
         <StateLinks
-          name="California"
+          stateName="California"
           twitter="california-covid"
           covid19Site="https://example.com"
-          dataSource="https://example.com"
+          covid19SiteSecondary="https://example.com2"
         />,
       )
       .toJSON()

--- a/src/components/common/lists.module.scss
+++ b/src/components/common/lists.module.scss
@@ -1,24 +1,7 @@
-@import '~scss/colors.module.scss';
-@import '~scss/breakpoints.module.scss';
-
 .list-unstyled {
   list-style-type: none;
   margin: 0;
-  span {
-    color: $color-slate-200;
-    font-size: .75em;
-    padding: 0 1em;
-  }
   li {
-    display: inline;
     margin: 0;
-  }
-  @media (max-width: $viewport-sm) {
-    li {
-      display: block;
-    }
-    span {
-      display: none;
-    }
   }
 }

--- a/src/components/common/lists.module.scss
+++ b/src/components/common/lists.module.scss
@@ -1,7 +1,24 @@
+@import '~scss/colors.module.scss';
+@import '~scss/breakpoints.module.scss';
+
 .list-unstyled {
   list-style-type: none;
   margin: 0;
+  span {
+    color: $color-slate-200;
+    font-size: .75em;
+    padding: 0 1em;
+  }
   li {
+    display: inline;
     margin: 0;
+  }
+  @media (max-width: $viewport-sm) {
+    li {
+      display: block;
+    }
+    span {
+      display: none;
+    }
   }
 }

--- a/src/components/pages/data/state-data.js
+++ b/src/components/pages/data/state-data.js
@@ -23,21 +23,21 @@ const State = ({ state }) => (
     <UnstyledList>
       {state.twitter && (
         <li>
-          <a href={`https://twitter.com/${state.twitter}`}>
-            {state.name} on Twitter
-          </a>
+          <a href={`https://twitter.com/${state.twitter}`}>Official Twitter</a>
+          <span>{'\u2022'}</span>
         </li>
       )}
       {state.covid19Site && (
-        <li>
-          <a href={state.covid19Site}>
-            Best current data source for {state.name}
-          </a>
-        </li>
+        <>
+          <li>
+            <a href={state.covid19Site}>Official Data Source</a>
+            <span>{'\u2022'}</span>
+          </li>
+        </>
       )}
       <li>
         <Link to={`/data/state/${slug(state.name)}#historical`}>
-          Historical data for {state.name}
+          Historical Data
         </Link>
       </li>
     </UnstyledList>

--- a/src/components/pages/data/state-data.js
+++ b/src/components/pages/data/state-data.js
@@ -3,7 +3,7 @@ import marked from 'marked'
 import smartypants from 'smartypants'
 import { Link } from 'gatsby'
 import slug from '~utilities/slug'
-import { UnstyledList } from '~components/common/lists'
+import StateLinks from '~components/pages/state/state-links'
 import StateGrade from '~components/pages/state/state-grade'
 import SummaryTable from '~components/common/summary-table'
 import stateDataStyles from './state-data.module.scss'
@@ -20,33 +20,12 @@ const State = ({ state }) => (
       data={state.stateData}
       lastUpdated={state.stateData.dateModified}
     />
-    <UnstyledList>
-      {state.twitter && (
-        <li>
-          <a href={`https://twitter.com/${state.twitter}`}>
-            <span className="a11y-only">{state.name}&apos;s</span>
-            Official Twitter
-          </a>
-          <span>{'\u2022'}</span>
-        </li>
-      )}
-      {state.covid19Site && (
-        <>
-          <li>
-            <a href={state.covid19Site}>
-              <span className="a11y-only">{state.name}&apos;s</span>
-              Official Data Source
-            </a>
-            <span>{'\u2022'}</span>
-          </li>
-        </>
-      )}
-      <li>
-        <Link to={`/data/state/${slug(state.name)}#historical`}>
-          Historical Data
-        </Link>
-      </li>
-    </UnstyledList>
+    <StateLinks
+      twitter={state.twitter}
+      covid19Site={state.covid19Site}
+      stateName={state.name}
+      historicalSlug={state.name}
+    />
     {state.notes && (
       <div
         className={`module-content ${stateDataStyles.notes}`}

--- a/src/components/pages/data/state-data.js
+++ b/src/components/pages/data/state-data.js
@@ -23,6 +23,7 @@ const State = ({ state }) => (
     <StateLinks
       twitter={state.twitter}
       covid19Site={state.covid19Site}
+      covid19SiteSecondary={state.covid19SiteSecondary}
       stateName={state.name}
       historicalSlug={state.name}
     />

--- a/src/components/pages/data/state-data.js
+++ b/src/components/pages/data/state-data.js
@@ -23,14 +23,20 @@ const State = ({ state }) => (
     <UnstyledList>
       {state.twitter && (
         <li>
-          <a href={`https://twitter.com/${state.twitter}`}>Official Twitter</a>
+          <a href={`https://twitter.com/${state.twitter}`}>
+            <span className="a11y-only">{state.name}&apos;s</span>
+            Official Twitter
+          </a>
           <span>{'\u2022'}</span>
         </li>
       )}
       {state.covid19Site && (
         <>
           <li>
-            <a href={state.covid19Site}>Official Data Source</a>
+            <a href={state.covid19Site}>
+              <span className="a11y-only">{state.name}&apos;s</span>
+              Official Data Source
+            </a>
             <span>{'\u2022'}</span>
           </li>
         </>

--- a/src/components/pages/state/state-links.js
+++ b/src/components/pages/state/state-links.js
@@ -1,16 +1,18 @@
 import React from 'react'
 import { UnstyledList } from '~components/common/lists'
 
-export default ({ name, twitter, covid19Site, dataSource }) => (
+export default ({ twitter, covid19Site, dataSource }) => (
   <UnstyledList>
     {twitter && (
       <li>
-        <a href={`https://twitter.com/${twitter}`}>{name} on Twitter</a>
+        <a href={`https://twitter.com/${twitter}`}>Official Twitter</a>
+        {covid19Site || dataSource ? <span>{'\u2022'}</span> : ''}
       </li>
     )}
     {covid19Site && (
       <li>
         <a href={covid19Site}>Best current data source</a>
+        {dataSource ? <span>{'\u2022'}</span> : ''}
       </li>
     )}
     {dataSource && (

--- a/src/components/pages/state/state-links.js
+++ b/src/components/pages/state/state-links.js
@@ -1,23 +1,23 @@
 import React from 'react'
 import { Link } from 'gatsby'
 import slug from '~utilities/slug'
-import { UnstyledList } from '~components/common/lists'
+import stateLinksStyle from './state-links.module.scss'
 
 export default ({
   twitter,
   covid19Site,
-  dataSource,
+  covid19SiteSecondary,
   stateName,
   historicalSlug,
 }) => (
-  <UnstyledList>
+  <ul className={stateLinksStyle.list}>
     {twitter && (
       <li>
         <a href={`https://twitter.com/${twitter}`}>
           <span className="a11y-only">{stateName}&apos;s </span>
           Official Twitter
         </a>
-        {covid19Site || dataSource ? <span>{'\u2022'}</span> : ''}
+        {covid19Site || covid19SiteSecondary ? <span>{'\u2022'}</span> : ''}
       </li>
     )}
     {covid19Site && (
@@ -26,15 +26,16 @@ export default ({
           <span className="a11y-only">{stateName}&apos;s </span>
           Best Current Data Source
         </a>
-        {dataSource || historicalSlug ? <span>{'\u2022'}</span> : ''}
+        {covid19SiteSecondary || historicalSlug ? <span>{'\u2022'}</span> : ''}
       </li>
     )}
-    {dataSource && (
+    {covid19SiteSecondary && (
       <li>
-        <a href={dataSource}>
-          Data Source
+        <a href={covid19SiteSecondary}>
+          Secondary Data Source
           <span className="a11y-only"> for {stateName}</span>
         </a>
+        {historicalSlug ? <span>{'\u2022'}</span> : ''}
       </li>
     )}
     {historicalSlug && (
@@ -45,5 +46,5 @@ export default ({
         </Link>
       </li>
     )}
-  </UnstyledList>
+  </ul>
 )

--- a/src/components/pages/state/state-links.js
+++ b/src/components/pages/state/state-links.js
@@ -1,23 +1,48 @@
 import React from 'react'
+import { Link } from 'gatsby'
+import slug from '~utilities/slug'
 import { UnstyledList } from '~components/common/lists'
 
-export default ({ twitter, covid19Site, dataSource }) => (
+export default ({
+  twitter,
+  covid19Site,
+  dataSource,
+  stateName,
+  historicalSlug,
+}) => (
   <UnstyledList>
     {twitter && (
       <li>
-        <a href={`https://twitter.com/${twitter}`}>Official Twitter</a>
+        <a href={`https://twitter.com/${twitter}`}>
+          <span className="a11y-only">{stateName}&apos;s </span>
+          Official Twitter
+        </a>
         {covid19Site || dataSource ? <span>{'\u2022'}</span> : ''}
       </li>
     )}
     {covid19Site && (
       <li>
-        <a href={covid19Site}>Best Current Data Source</a>
-        {dataSource ? <span>{'\u2022'}</span> : ''}
+        <a href={covid19Site}>
+          <span className="a11y-only">{stateName}&apos;s </span>
+          Best Current Data Source
+        </a>
+        {dataSource || historicalSlug ? <span>{'\u2022'}</span> : ''}
       </li>
     )}
     {dataSource && (
       <li>
-        <a href={dataSource}>Data Source</a>
+        <a href={dataSource}>
+          Data Source
+          <span className="a11y-only"> for {stateName}</span>
+        </a>
+      </li>
+    )}
+    {historicalSlug && (
+      <li>
+        <Link to={`/data/state/${slug(historicalSlug)}#historical`}>
+          Historical Data
+          <span className="a11y-only">for {stateName}</span>
+        </Link>
       </li>
     )}
   </UnstyledList>

--- a/src/components/pages/state/state-links.js
+++ b/src/components/pages/state/state-links.js
@@ -11,13 +11,13 @@ export default ({ twitter, covid19Site, dataSource }) => (
     )}
     {covid19Site && (
       <li>
-        <a href={covid19Site}>Best current data source</a>
+        <a href={covid19Site}>Best Current Data Source</a>
         {dataSource ? <span>{'\u2022'}</span> : ''}
       </li>
     )}
     {dataSource && (
       <li>
-        <a href={dataSource}>Data source</a>
+        <a href={dataSource}>Data Source</a>
       </li>
     )}
   </UnstyledList>

--- a/src/components/pages/state/state-links.module.scss
+++ b/src/components/pages/state/state-links.module.scss
@@ -1,0 +1,21 @@
+.list {
+  list-style-type: none;
+  margin: 0;
+  span {
+    color: $color-slate-200;
+    @include type-size(100);
+    padding: 0 spacer(8);
+  }
+  li {
+    display: inline;
+    margin: 0;
+  }
+  @media (max-width: $viewport-sm) {
+    li {
+      display: block;
+    }
+    span {
+      display: none;
+    }
+  }
+}

--- a/src/templates/state.js
+++ b/src/templates/state.js
@@ -14,7 +14,12 @@ const StatePage = ({ pageContext, data, path }) => {
   const { covidState, allCovidStateDaily, allCovidScreenshot } = data
   return (
     <Layout title={state.name} returnLink="/data" path={path}>
-      <StateLinks {...state} />
+      <StateLinks
+        twitter={state.twitter}
+        covid19Site={state.covid19Site}
+        covid19SiteSecondary={state.covid19SiteSecondary}
+        stateName={state.name}
+      />
       <StateGrade letterGrade={covidState.dataQualityGrade} />
       {state.notes && (
         <div


### PR DESCRIPTION
### Description
Fixes #1026 

- Cleans up state data page link language
- Updated links to be inline and added bullet points between-except on mobile. Font size would need to be decreased on mobile to make all links fit inline, reducing readability.
