### PR TITLE
chore(docs): Add type sizes to storybook

### DIFF
--- a/src/stories/2-components/01-Layout.stories.js
+++ b/src/stories/2-components/01-Layout.stories.js
@@ -51,6 +51,17 @@ Object.keys(spacers).forEach(spacer => {
 
 export const spacing = () => (
   <>
+    <p>
+      Instead of using absolute sizes for margins and paddings, use our standard
+      spacers. For example:
+    </p>
+    <code>
+      <pre>
+        {`.my-class {
+  margin: spacer(16);
+}`}
+      </pre>
+    </code>
     {spacerItems.map(spacer => (
       <div className={spacers.key} key={spacer.size}>
         <div className={spacers.wrap}>

--- a/src/stories/2-components/02-Typography.stories.js
+++ b/src/stories/2-components/02-Typography.stories.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { OrderedList, UnstyledList } from '~components/common/lists'
 import { FormatDate, FormatNumber } from '~components/utils/format'
+import typeSize from './type-size.module.scss'
 
 const sampleText = `Testing is a crucial part of any public health response,
 and sharing test data is essential to understanding this outbreak. The CDC is
@@ -40,31 +41,49 @@ export const linkInText = () => (
   </p>
 )
 
+const typeSizes = []
+Object.keys(typeSize).forEach(typeSizeName => {
+  if (typeSizeName.search('regular-type-') > -1) {
+    typeSizes.push({
+      class: typeSize[typeSizeName],
+      size: typeSizeName.replace('regular-type-', ''),
+    })
+  }
+})
+
+const boldTypeSizes = []
+Object.keys(typeSize).forEach(typeSizeName => {
+  if (typeSizeName.search('bold-type-') > -1) {
+    boldTypeSizes.push({
+      class: typeSize[typeSizeName],
+      size: typeSizeName.replace('bold-type-', ''),
+    })
+  }
+})
+
 export const fontSizes = () => (
-  <p>
-    We use a set of font sizes that are defined in{' '}
-    <code>~scss/type.module.scss</code>. <br />
-    <ul>
-      <li>
-        These sizes range from 100 to 700. 100 is the smallest size and 700 is
-        the largest
-      </li>
-      <li>
-        These can be used with Sass <code>@include</code>
-      </li>
-      <li>
-        All of the sizes come in:
-        <ul>
-          <li>
-            Bold: <code>bold-type-size($size)</code>
-          </li>
-          <li>
-            Regular: <code>type-size($size)</code>
-          </li>
-        </ul>
-      </li>
-    </ul>
-  </p>
+  <>
+    <p>
+      We use a set of font sizes that range from 100 to 700. 100 is the smallest
+      size and 700 is the largest. These can be used with Sass{' '}
+      <code>@include</code>:
+      <ul>
+        <li>
+          Bold: <code>bold-type-size($size)</code>
+        </li>
+        <li>
+          Regular: <code>type-size($size)</code>
+        </li>
+      </ul>
+    </p>
+    {typeSizes.map(size => (
+      <p className={size.class}>Sample text regular size {size.size}</p>
+    ))}
+
+    {boldTypeSizes.map(size => (
+      <p className={size.class}>Sample text bold size {size.size}</p>
+    ))}
+  </>
 )
 
 export const headers = () => (

--- a/src/stories/2-components/type-size.module.scss
+++ b/src/stories/2-components/type-size.module.scss
@@ -1,0 +1,11 @@
+@for $i from 1 through 7 {
+  .regular-type-#{$i}00 {
+    @include type-size($i * 100);
+  }
+}
+
+@for $i from 1 through 7 {
+  .bold-type-#{$i}00 {
+    @include bold-type-size($i * 100);
+  }
+}


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds actual type size samples to storybook
- Put a preamble to the spacer page to let users know how to use the mixin.