### PR TITLE
Kevee/api type size

### DIFF
--- a/src/components/pages/data/api/explorer.module.scss
+++ b/src/components/pages/data/api/explorer.module.scss
@@ -13,7 +13,7 @@
 
 .toggle {
   display: inline-block;
-  margin-left: spacer(32);
+  margin-left: spacer(16);
 }
 
 .panel {

--- a/src/components/pages/data/api/explorer.module.scss
+++ b/src/components/pages/data/api/explorer.module.scss
@@ -6,6 +6,9 @@
   display: block;
   background: transparent;
   cursor: pointer;
+  h3 {
+    @include type-size(400);
+  }
 }
 
 .toggle {


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Shrinks the type size on the API page.