### PR TITLE
fix: Absolute bar width on charts

### DIFF
--- a/src/components/pages/race/charts/county-chart.module.scss
+++ b/src/components/pages/race/charts/county-chart.module.scss
@@ -24,10 +24,6 @@
   width: 100%;
 }
 
-.bar {
-  width: toRem(10);
-}
-
 .tick {
   overflow: visible !important;
 }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Removed absolute width breaking the charts on the CRDT homepage.