### PR TITLE
fix(crdt): nav-bar overlaps states popover

### DIFF
--- a/src/components/common/state-nav.module.scss
+++ b/src/components/common/state-nav.module.scss
@@ -72,4 +72,5 @@
   [data-suggested-value] {
     font-weight: normal;
   }
+  z-index: 1;
 }


### PR DESCRIPTION
closes #1041

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
