### PR TITLE
chore(docs): Change fail message in plugin

### DIFF
--- a/plugins/gatsby-source-covid-tracking-api/gatsby-node.js
+++ b/plugins/gatsby-source-covid-tracking-api/gatsby-node.js
@@ -12,9 +12,9 @@ exports.sourceNodes = async (
     fs.statSync(configOptions.file)
   } catch {
     reporter.error(
-      `There is no file ${configOptions.file} directory. 
+      `There is no file ${configOptions.file}. 
     
-If you are developing on your local computer, be sure to download the latest data archive here: http://covidtracking.com/api/archive.tar.gz. Then expand it to the directory "_data".`,
+Make sure to run "npm run setup" to clone the most recent version of the COVID API files.`,
     )
     return
   }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->

- Changes the error message that is displayed if a user tries to run gatsby without the API files downloaded
- Fixes #1042 