### PR TITLE
chore: Cleanup list elements

### DIFF
--- a/src/components/common/press-list.module.scss
+++ b/src/components/common/press-list.module.scss
@@ -2,6 +2,7 @@
   list-style-type: none;
   margin: 0;
   line-height: 1.3;
+  padding-left: 0;
 
   li {
     margin-bottom: spacer(24);

--- a/src/components/common/volunteers-list.module.scss
+++ b/src/components/common/volunteers-list.module.scss
@@ -1,9 +1,9 @@
 .list {
   column-count: 2;
-  line-height: 1.3;
   list-style-type: none;
   margin-top: spacer(24);
   margin-left: 0;
+  padding-left: 0;
   @media (max-width: $viewport-md) {
     column-count: 1;
   }

--- a/src/components/pages/state/state-links.module.scss
+++ b/src/components/pages/state/state-links.module.scss
@@ -1,6 +1,7 @@
 .list {
   list-style-type: none;
   margin: 0;
+  padding-left: 0;
   span {
     color: $color-slate-200;
     @include type-size(100);

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -22,13 +22,6 @@ img {
   max-width: 100%;
 }
 
-ol[class],
-ul[class] {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
 li > :first-child {
   margin-top: 0;
 }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Removes global ul/ol stlyes
- Makes the one component that depended on those styles declare the styles explicitly