### PR TITLE
chore: Add return link to data from download page

### DIFF
--- a/src/pages/data/download.js
+++ b/src/pages/data/download.js
@@ -10,7 +10,8 @@ export default ({ data }) => (
   <Layout
     title="Data Download"
     path="/data/download"
-    navigation={data.contentfulNavigationGroup.pages}
+    returnLink="/data"
+    returnLinkTitle="Our data"
   >
     <ContentfulContent
       content={
@@ -56,18 +57,6 @@ export const query = graphql`
       childContentfulSnippetContentTextNode {
         childMarkdownRemark {
           html
-        }
-      }
-    }
-    contentfulNavigationGroup(slug: { eq: "data" }) {
-      pages {
-        ... on ContentfulPage {
-          title
-          link: slug
-        }
-        ... on ContentfulNavigationLink {
-          title
-          link: url
         }
       }
     }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Adds a return link for the new download page introduced in #1033 