### PR TITLE
Track state data page use with Fathom goals

### DIFF
--- a/src/__tests__/components/pages/data/__snapshots__/state-data.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-data.js.snap
@@ -305,6 +305,7 @@ Array [
     <li>
       <a
         href="https://twitter.com/@alpublichealth"
+        onClick={[Function]}
       >
         <span
           className="a11y-only"
@@ -321,6 +322,7 @@ Array [
     <li>
       <a
         href="https://alpublichealth.maps.arcgis.com/apps/opsdashboard/index.html#/6d2771faa9da4a2786a509d82c8cf0f7"
+        onClick={[Function]}
       >
         <span
           className="a11y-only"

--- a/src/__tests__/components/pages/data/__snapshots__/state-list.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-list.js.snap
@@ -308,6 +308,7 @@ exports[`Components : Pages : Data : State data renders correctly 1`] = `
     <li>
       <a
         href="https://twitter.com/@alpublichealth"
+        onClick={[Function]}
       >
         <span
           className="a11y-only"
@@ -324,6 +325,7 @@ exports[`Components : Pages : Data : State data renders correctly 1`] = `
     <li>
       <a
         href="https://alpublichealth.maps.arcgis.com/apps/opsdashboard/index.html#/6d2771faa9da4a2786a509d82c8cf0f7"
+        onClick={[Function]}
       >
         <span
           className="a11y-only"

--- a/src/__tests__/components/pages/state/__snapshots__/state-links.js.snap
+++ b/src/__tests__/components/pages/state/__snapshots__/state-links.js.snap
@@ -7,6 +7,7 @@ exports[`Components : Pages : State : State links renders correctly 1`] = `
   <li>
     <a
       href="https://twitter.com/california-covid"
+      onClick={[Function]}
     >
       <span
         className="a11y-only"
@@ -23,6 +24,7 @@ exports[`Components : Pages : State : State links renders correctly 1`] = `
   <li>
     <a
       href="https://example.com"
+      onClick={[Function]}
     >
       <span
         className="a11y-only"
@@ -39,6 +41,7 @@ exports[`Components : Pages : State : State links renders correctly 1`] = `
   <li>
     <a
       href="https://example.com2"
+      onClick={[Function]}
     >
       Secondary Data Source
       <span
@@ -60,6 +63,7 @@ exports[`Components : Pages : State : State links renders correctly 2`] = `
   <li>
     <a
       href="https://twitter.com/california-covid"
+      onClick={[Function]}
     >
       <span
         className="a11y-only"
@@ -76,6 +80,7 @@ exports[`Components : Pages : State : State links renders correctly 2`] = `
   <li>
     <a
       href="https://example.com"
+      onClick={[Function]}
     >
       <span
         className="a11y-only"
@@ -92,6 +97,7 @@ exports[`Components : Pages : State : State links renders correctly 2`] = `
   <li>
     <a
       href="https://example.com2"
+      onClick={[Function]}
     >
       Secondary Data Source
       <span

--- a/src/components/common/state-nav.js
+++ b/src/components/common/state-nav.js
@@ -17,6 +17,9 @@ export const getStateId = (stateList, selectedItem) =>
   })
 
 export const setWindowLocation = str => {
+  if (typeof window.fathom !== 'undefined') {
+    window.fathom.trackGoal('U4EOIB2V', 0)
+  }
   window.location.hash = str
 }
 

--- a/src/components/pages/data/state-data.js
+++ b/src/components/pages/data/state-data.js
@@ -27,6 +27,7 @@ const State = ({ state }) => (
       covid19SiteSecondary={state.covid19SiteSecondary}
       stateName={state.name}
       historicalSlug={state.name}
+      fathomGoal="2YKBL0ZP"
     />
     {state.notes && <MarkdownContent html={smartypants(marked(state.notes))} />}
     <a

--- a/src/components/pages/data/state-list.js
+++ b/src/components/pages/data/state-list.js
@@ -16,7 +16,7 @@ export default ({ states, stateData }) => {
 
   return stateList.map(state => (
     <div
-      key={state}
+      key={`state-list-${state.state}`}
       id={`state-list-${state.state}`}
       className={stateListStyles.item}
     >

--- a/src/components/pages/state/state-links.js
+++ b/src/components/pages/state/state-links.js
@@ -9,42 +9,55 @@ export default ({
   covid19SiteSecondary,
   stateName,
   historicalSlug,
-}) => (
-  <ul className={stateLinksStyle.list}>
-    {twitter && (
-      <li>
-        <a href={`https://twitter.com/${twitter}`}>
-          <span className="a11y-only">{stateName}&apos;s </span>
-          Official Twitter
-        </a>
-        {covid19Site || covid19SiteSecondary ? <span>{'\u2022'}</span> : ''}
-      </li>
-    )}
-    {covid19Site && (
-      <li>
-        <a href={covid19Site}>
-          <span className="a11y-only">{stateName}&apos;s </span>
-          Best Current Data Source
-        </a>
-        {covid19SiteSecondary || historicalSlug ? <span>{'\u2022'}</span> : ''}
-      </li>
-    )}
-    {covid19SiteSecondary && (
-      <li>
-        <a href={covid19SiteSecondary}>
-          Secondary Data Source
-          <span className="a11y-only"> for {stateName}</span>
-        </a>
-        {historicalSlug ? <span>{'\u2022'}</span> : ''}
-      </li>
-    )}
-    {historicalSlug && (
-      <li>
-        <Link to={`/data/state/${slug(historicalSlug)}#historical`}>
-          Historical Data
-          <span className="a11y-only">for {stateName}</span>
-        </Link>
-      </li>
-    )}
-  </ul>
-)
+  fathomGoal,
+}) => {
+  const trackClick = () => {
+    if (!fathomGoal || typeof window.fathom === 'undefined') {
+      return
+    }
+    window.fathom.trackGoal(fathomGoal, 0)
+  }
+  return (
+    <ul className={stateLinksStyle.list}>
+      {twitter && (
+        <li>
+          <a href={`https://twitter.com/${twitter}`} onClick={trackClick}>
+            <span className="a11y-only">{stateName}&apos;s </span>
+            Official Twitter
+          </a>
+          {covid19Site || covid19SiteSecondary ? <span>{'\u2022'}</span> : ''}
+        </li>
+      )}
+      {covid19Site && (
+        <li>
+          <a href={covid19Site} onClick={trackClick}>
+            <span className="a11y-only">{stateName}&apos;s </span>
+            Best Current Data Source
+          </a>
+          {covid19SiteSecondary || historicalSlug ? (
+            <span>{'\u2022'}</span>
+          ) : (
+            ''
+          )}
+        </li>
+      )}
+      {covid19SiteSecondary && (
+        <li>
+          <a href={covid19SiteSecondary} onClick={trackClick}>
+            Secondary Data Source
+            <span className="a11y-only"> for {stateName}</span>
+          </a>
+          {historicalSlug ? <span>{'\u2022'}</span> : ''}
+        </li>
+      )}
+      {historicalSlug && (
+        <li>
+          <Link to={`/data/state/${slug(historicalSlug)}#historical`}>
+            Historical Data
+            <span className="a11y-only">for {stateName}</span>
+          </Link>
+        </li>
+      )}
+    </ul>
+  )
+}

--- a/src/templates/state.js
+++ b/src/templates/state.js
@@ -20,6 +20,7 @@ const StatePage = ({ pageContext, data, path }) => {
         covid19Site={state.covid19Site}
         covid19SiteSecondary={state.covid19SiteSecondary}
         stateName={state.name}
+        fathomGoal="DNRI0GQP"
       />
       <StateGrade letterGrade={covidState.dataQualityGrade} />
       {state.notes && (


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Tracks anonymous [goals with fathom](https://usefathom.com/support/goals) for:
- Click on state twitter or info pages from data page
- Click on state twitter or info pages from state pages
- Use of state nav on data page