### PR TITLE
fix(summary-table): last updated times

### DIFF
--- a/src/__tests__/components/common/__snapshots__/summary-table.js.snap
+++ b/src/__tests__/components/common/__snapshots__/summary-table.js.snap
@@ -257,7 +257,7 @@ exports[`Components : Common: Publication: Summary table renders correctly 1`] =
     className="detail-text detailText"
   >
     Last updated: 
-    Wed Apr 1 2020 12:00 am
+    Wed Apr 1 2020 4:00 am
      
     <abbr
       aria-label="Eastern Time"
@@ -406,7 +406,7 @@ exports[`Components : Common: Publication: Summary table renders correctly 2`] =
     className="detail-text detailText"
   >
     Last updated: 
-    Wed Apr 1 2020 12:00 am
+    Wed Apr 1 2020 4:00 am
      
     <abbr
       aria-label="Eastern Time"

--- a/src/__tests__/components/pages/data/__snapshots__/state-data.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-data.js.snap
@@ -289,7 +289,7 @@ Array [
       className="detail-text detailText"
     >
       Last updated: 
-      Fri Apr 17 2020 12:00 am
+      Fri Apr 17 2020 4:00 am
        
       <abbr
         aria-label="Eastern Time"

--- a/src/__tests__/components/pages/data/__snapshots__/state-list.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-list.js.snap
@@ -292,7 +292,7 @@ exports[`Components : Pages : Data : State data renders correctly 1`] = `
       className="detail-text detailText"
     >
       Last updated: 
-      Fri Apr 17 2020 12:00 am
+      Fri Apr 17 2020 4:00 am
        
       <abbr
         aria-label="Eastern Time"

--- a/src/components/common/summary-table.js
+++ b/src/components/common/summary-table.js
@@ -143,7 +143,7 @@ export default ({
       tableLabel={
         lastUpdated && (
           <>
-            Last updated: <FormatDate date={lastUpdated} /> <Timezone />
+            Last updated: <FormatDate date={lastUpdated} inEt /> <Timezone />
           </>
         )
       }

--- a/src/components/utils/format.js
+++ b/src/components/utils/format.js
@@ -5,13 +5,16 @@ function lowercaseMeridiem(dateString) {
   return dateString.replace('AM', 'am').replace('PM', 'pm')
 }
 
-function formatDateToString(date, format = 'ccc LLL d yyyy h:mm a') {
+function formatDateToString(date, format = 'ccc LLL d yyyy h:mm a', inEt) {
   if (typeof date === 'undefined') {
     return null
   }
+  // using UTC here since the time is *already* on New York time, and
+  // setting UTC simply preserves that value
+  const timeZone = inEt ? 'UTC' : 'America/New_York'
   return lowercaseMeridiem(
     DateTime.fromISO(date)
-      .setZone('America/New_York')
+      .setZone(timeZone)
       .toFormat(format),
   )
 }
@@ -20,15 +23,17 @@ const FormatDate = ({
   date,
   format = 'ccc LLL d yyyy h:mm a',
   timezone = true,
-}) => {
-  return (
-    <>
-      {timezone
-        ? formatDateToString(date, format)
-        : DateTime.fromISO(date).toFormat(format)}
-    </>
-  )
-}
+  // inEt means this date *appears* to be in UTC, but actually shows the
+  // current time in Eastern Time i.e. if a date time appears like:
+  // 2020-06-19T18:00:00Z, but actually means 6:00 pm *EST*, not 6:00 pm UTC
+  inEt = false,
+}) => (
+  <>
+    {timezone
+      ? formatDateToString(date, format, inEt)
+      : DateTime.fromISO(date).toFormat(format)}
+  </>
+)
 
 const FormatNumber = ({ number }) => (
   <>{number || number === 0 ? number.toLocaleString() : 'N/A'}</>


### PR DESCRIPTION
This fixes the time offset on the summary tables, identified in #1075.

The issue is that the API returns datetimes that are _already in Eastern Time_, yet have a UTC timezone.

This solution is admittedly hack-y...we should probably fix this upstream (i.e. in the API build) so that our API customers also don't have this problem

Closes #1075.