### PR TITLE
feat: Add tableau charts to blog posts

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -184,6 +184,7 @@ const gatsbyConfig = {
       options: {
         spaceId: process.env.CONTENTFUL_SPACE,
         accessToken: process.env.CONTENTFUL_TOKEN,
+        environment: 'tableau-embed',
       },
     },
     {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -116,6 +116,7 @@ exports.createPages = async ({ graphql, actions }) => {
       .filter(
         block =>
           block.nodeType === 'embedded-entry-block' &&
+          typeof block.data.target.sys.contentType !== 'undefined' &&
           block.data.target.sys.contentType.sys.id === 'contentBlockImage',
       )
       .forEach(image => {

--- a/src/components/pages/blog/blog-content.js
+++ b/src/components/pages/blog/blog-content.js
@@ -2,22 +2,29 @@ import React from 'react'
 import { BLOCKS } from '@contentful/rich-text-types'
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer'
 import CleanSpacing from '~components/utils/clean-spacing'
+import Container from '~components/common/container'
 import TableContentBlock from './table-content-block'
 import ImageContentBlock from './image-content-block'
+import TableauContentBlock from './tableau-content-block'
 import blogContentStyles from './blog-content.module.scss'
 
 export default ({ content, images }) => {
   const options = {
     renderNode: {
       [BLOCKS.PARAGRAPH]: (node, children) => (
-        <p>
-          {children.map(child => (
-            <CleanSpacing>{child}</CleanSpacing>
-          ))}
-        </p>
+        <Container narrow>
+          <p>
+            {children.map(child => (
+              <CleanSpacing>{child}</CleanSpacing>
+            ))}
+          </p>
+        </Container>
       ),
       [BLOCKS.EMBEDDED_ENTRY]: node => {
-        if (typeof node.data.target.fields === 'undefined') {
+        if (
+          typeof node.data.target.fields === 'undefined' ||
+          typeof node.data.target.sys.contentType === 'undefined'
+        ) {
           return null
         }
         if (
@@ -30,14 +37,32 @@ export default ({ content, images }) => {
         }
         if (
           node.data.target.sys.contentType.sys.contentful_id ===
+          'contentBlockTableauChart'
+        ) {
+          return (
+            <TableauContentBlock
+              id={`chart-${node.data.target.sys.id}`}
+              server={node.data.target.fields.server['en-US']}
+              view={node.data.target.fields.view['en-US']}
+              embedCode={node.data.target.fields.embedCode['en-US']}
+              caption={node.data.target.fields.caption['en-US']}
+              height={node.data.target.fields.height['en-US']}
+              fallbackImage={node.data.target.fields.fallbackImage['en-US']}
+            />
+          )
+        }
+        if (
+          node.data.target.sys.contentType.sys.contentful_id ===
           'contentBlockImage'
         ) {
           const { caption } = node.data.target.fields
           return (
-            <ImageContentBlock
-              image={images[node.data.target.sys.contentful_id].image}
-              caption={caption}
-            />
+            <Container narrow>
+              <ImageContentBlock
+                image={images[node.data.target.sys.contentful_id].image}
+                caption={caption}
+              />
+            </Container>
           )
         }
         return null

--- a/src/components/pages/blog/image-content-block.js
+++ b/src/components/pages/blog/image-content-block.js
@@ -1,9 +1,10 @@
 import React from 'react'
 import Img from 'gatsby-image'
 import ImageCredit from '~components/common/image-credit'
+import imageContentSyle from './image-content-block.module.scss'
 
 export default ({ caption, image }) => (
-  <div>
+  <div className={imageContentSyle.image}>
     <Img fluid={image.fluid} alt={image.title} />
     {caption && <ImageCredit>{caption['en-US']}</ImageCredit>}
   </div>

--- a/src/components/pages/blog/image-content-block.module.scss
+++ b/src/components/pages/blog/image-content-block.module.scss
@@ -1,0 +1,4 @@
+.image {
+  margin-top: spacer(16);
+  margin-bottom: spacer(32);
+}

--- a/src/components/pages/blog/table-content-block.module.scss
+++ b/src/components/pages/blog/table-content-block.module.scss
@@ -1,6 +1,8 @@
 .table {
   width: 100%;
   border-collapse: collapse;
+  margin-top: spacer(16);
+  margin-bottom: spacer(32);
   tr,
   td,
   th {

--- a/src/components/pages/blog/tableau-content-block.js
+++ b/src/components/pages/blog/tableau-content-block.js
@@ -1,0 +1,42 @@
+/* eslint-disable no-new */
+import React, { useRef, useEffect } from 'react'
+import classnames from 'classnames'
+import DetailText from '~components/common/detail-text'
+import tableuContentBlockStyle from './tableau-content-block.module.scss'
+
+export default ({ id, height, embedCode, caption, fallbackImage }) => {
+  const chartRef = useRef(false)
+  const imageRef = useRef(false)
+  const objectTag = embedCode.replace(/\n/g, '').match('<object(.*)</object>')
+
+  useEffect(() => {
+    const visualizationElement = chartRef.current
+      .getElementsByTagName('object')
+      .item(0)
+    const scriptElement = document.createElement('script')
+    scriptElement.src = 'https://public.tableau.com/javascripts/api/viz_v1.js'
+    visualizationElement.parentNode.insertBefore(
+      scriptElement,
+      visualizationElement,
+    )
+    visualizationElement.style.height = `${height}px`
+    imageRef.current.style.display = 'none'
+  }, [])
+
+  return (
+    <>
+      <div
+        className={classnames(
+          tableuContentBlockStyle.chart,
+          'tableauPlaceholder',
+        )}
+        id={`chart-${id}`}
+        ref={chartRef}
+        dangerouslySetInnerHTML={{ __html: objectTag[0] }}
+      />
+      <img src={fallbackImage.fields.file['en-US'].url} alt="" ref={imageRef} />
+
+      {caption && <DetailText>{caption}</DetailText>}
+    </>
+  )
+}

--- a/src/components/pages/blog/tableau-content-block.module.scss
+++ b/src/components/pages/blog/tableau-content-block.module.scss
@@ -1,0 +1,12 @@
+.chart {
+  @include margin(32, top bottom);
+
+  iframe {
+    border: none;
+    width: 100%;
+    height: 500px;
+    @media (min-width: $viewport-lg) {
+      height: 702px;
+    }
+  }
+}

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -3,6 +3,7 @@ import { graphql } from 'gatsby'
 import AuthorFooter from '~components/pages/blog/author-footer'
 import Categories from '~components/pages/blog/categories'
 import Layout from '~components/layout'
+import Container from '~components/common/container'
 import Lede from '~components/pages/blog/blog-lede'
 import BlogPostContent from '~components/pages/blog/blog-content'
 
@@ -22,23 +23,25 @@ export default ({ data, path }) => {
       returnLinkTitle="All posts"
       path={path}
       textHeavy
-      narrow
     >
-      <Categories categories={blogPost.categories} />
-      <Lede
-        headline={blogPost.title}
-        authors={blogPost.authors}
-        date={blogPost.publishDate}
-        lede={blogPost.lede.lede}
-        featuredImage={blogPost.featuredImage}
-      />
+      <Container narrow>
+        <Categories categories={blogPost.categories} />
+        <Lede
+          headline={blogPost.title}
+          authors={blogPost.authors}
+          date={blogPost.publishDate}
+          lede={blogPost.lede.lede}
+          featuredImage={blogPost.featuredImage}
+        />
+      </Container>
       <BlogPostContent
         content={blogPost.childContentfulBlogPostBlogContentRichTextNode.json}
         images={blogImages}
       />
-
-      <hr />
-      <AuthorFooter authors={blogPost.authors} />
+      <Container narrow>
+        <hr />
+        <AuthorFooter authors={blogPost.authors} />
+      </Container>
     </Layout>
   )
 }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds support for a new Tableau-embed in blog posts

## Pre-merge steps:
- [x] Setup Content Block: Tableau in the master environment of Contentful
- [x] Change branch to use master environment
