### PR TITLE
Add autoreply fields to contact form

### DIFF
--- a/src/pages/contact/index.js
+++ b/src/pages/contact/index.js
@@ -119,6 +119,16 @@ export default ({ data }) => {
                   can route your message to the right team.
                 </AlertInfobox>
               )}
+              <input
+                type="hidden"
+                name="autoreply-from"
+                value="support@covidtracking.com"
+              />
+              <input
+                type="hidden"
+                name="autoreply-sender-name"
+                value="The COVID Tracking Project"
+              />
               <button
                 type="submit"
                 disabled={reason === defaultReason}


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Fixes #1080