### PR TITLE
fix(state-combo): Workaround to prevent chrome from autofilling

### DIFF
--- a/src/__tests__/components/pages/data/__snapshots__/state-nav.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-nav.js.snap
@@ -25,9 +25,11 @@ exports[`Components : Pages : Data : Navigation with JS enabled renders correctl
         >
           Jump to state or territory
         </label>
-        <input
-          type="text"
-        />
+        <form>
+          <input
+            type="text"
+          />
+        </form>
         <div>
           <ul>
             <li />

--- a/src/components/common/state-nav.js
+++ b/src/components/common/state-nav.js
@@ -89,16 +89,19 @@ export default ({ title, stateList }) => {
             <label htmlFor="jump-to-state" className="a11y-only">
               Jump to state or territory
             </label>
-            <ComboboxInput
-              id="jump-to-state"
-              placeholder="State or territory"
-              autoComplete="false"
-              ref={inputRef}
-              onKeyDown={event => selectFirstItemOnKeyDown(event, results)}
-              onChange={event => {
-                setSearchTerm(event.target.value)
-              }}
-            />
+            {/* form wrapper is to ensure chrome doesn't try to autofill the input */}
+            <form>
+              <ComboboxInput
+                id="jump-to-state"
+                placeholder="State or territory"
+                autoComplete="off"
+                ref={inputRef}
+                onKeyDown={event => selectFirstItemOnKeyDown(event, results)}
+                onChange={event => {
+                  setSearchTerm(event.target.value)
+                }}
+              />
+            </form>
             {results ? (
               <ComboboxPopover
                 className={stateNavStyles.popover}


### PR DESCRIPTION
closes #1088

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
