### PR TITLE
chore: Remove page-associated links from navigation

### DIFF
--- a/src/components/layout/header/index.js
+++ b/src/components/layout/header/index.js
@@ -50,14 +50,8 @@ const Header = withSearch(
           nodes {
             slug
             pages {
-              ... on ContentfulPage {
-                title
-                link: slug
-              }
-              ... on ContentfulNavigationLink {
-                title
-                link: url
-              }
+              title
+              link: url
             }
           }
         }

--- a/src/pages/about-data/visualization-guide/index.js
+++ b/src/pages/about-data/visualization-guide/index.js
@@ -262,14 +262,8 @@ export const query = graphql`
   query {
     contentfulNavigationGroup(slug: { eq: "about-data" }) {
       pages {
-        ... on ContentfulPage {
-          title
-          link: slug
-        }
-        ... on ContentfulNavigationLink {
-          title
-          link: url
-        }
+        title
+        link: url
       }
     }
     file(relativePath: { regex: "/cdc-comparison-chart.png/" }) {

--- a/src/pages/about-project/index.js
+++ b/src/pages/about-project/index.js
@@ -60,14 +60,8 @@ export const query = graphql`
     }
     contentfulNavigationGroup(slug: { eq: "about-project" }) {
       pages {
-        ... on ContentfulPage {
-          title
-          link: slug
-        }
-        ... on ContentfulNavigationLink {
-          title
-          link: url
-        }
+        title
+        link: url
       }
     }
   }

--- a/src/pages/api.js
+++ b/src/pages/api.js
@@ -36,14 +36,8 @@ export const query = graphql`
     }
     contentfulNavigationGroup(slug: { eq: "data" }) {
       pages {
-        ... on ContentfulPage {
-          title
-          link: slug
-        }
-        ... on ContentfulNavigationLink {
-          title
-          link: url
-        }
+        title
+        link: url
       }
     }
   }

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -118,14 +118,8 @@ export const query = graphql`
     }
     contentfulNavigationGroup(slug: { eq: "data" }) {
       pages {
-        ... on ContentfulPage {
-          title
-          link: slug
-        }
-        ... on ContentfulNavigationLink {
-          title
-          link: url
-        }
+        title
+        link: url
       }
     }
   }

--- a/src/pages/data/us-daily.js
+++ b/src/pages/data/us-daily.js
@@ -106,14 +106,8 @@ export const query = graphql`
     }
     contentfulNavigationGroup(slug: { eq: "data" }) {
       pages {
-        ... on ContentfulPage {
-          title
-          link: slug
-        }
-        ... on ContentfulNavigationLink {
-          title
-          link: url
-        }
+        title
+        link: url
       }
     }
   }

--- a/src/templates/content.js
+++ b/src/templates/content.js
@@ -57,14 +57,8 @@ export const query = graphql`
       }
       navigationGroup {
         pages {
-          ... on ContentfulPage {
-            title
-            link: slug
-          }
-          ... on ContentfulNavigationLink {
-            title
-            link: url
-          }
+          title
+          link: url
         }
       }
     }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Removes references to pages in Navigation Groups, and only uses Navigation Links
- Fixes #1094 