### PR TITLE
Changes contact form autoreply address

### DIFF
--- a/src/pages/contact/index.js
+++ b/src/pages/contact/index.js
@@ -107,7 +107,7 @@ export default ({ data }) => {
         <input
           type="hidden"
           name="autoreply-from"
-          value="support@covidtracking.com"
+          value="contact@covidtracking.com"
         />
         <input
           type="hidden"


### PR DESCRIPTION
In Front it turns out that when emails come from support@covidtracking.com they automatically get copied to the General Support inbox no matter what rules I set, so I've set up a Google Group with the address contact@covidtracking.com with me as the owner and only member to serve as the From address for autoreplies to Contact form submissions

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
