### PR TITLE
feat: include state codes in state search

### DIFF
--- a/src/__tests__/components/pages/data/state-nav.js
+++ b/src/__tests__/components/pages/data/state-nav.js
@@ -33,13 +33,27 @@ describe('Components : Pages : Data : Navigation with JS enabled', () => {
     const tree = renderer.create(<StateNav stateList={stateList} />).toJSON()
     expect(tree).toMatchSnapshot()
   })
-  it('can filter on user input', () => {
+
+  it('can filter on user input for state name', () => {
     const wrapper = shallow(
       <StateNav title="Test title" stateList={stateList} />,
     )
 
     const input = wrapper.find('#jump-to-state')
     input.simulate('change', { target: { value: 'ala' } })
+    expect(wrapper.exists('#state-nav-results-popover')).toBe(true)
+
+    input.simulate('change', { target: { value: '' } })
+    expect(wrapper.exists('#state-nav-results-popover')).toBe(false)
+  })
+
+  it('can filter on user input for state code', () => {
+    const wrapper = shallow(
+      <StateNav title="Test title" stateList={stateList} />,
+    )
+
+    const input = wrapper.find('#jump-to-state')
+    input.simulate('change', { target: { value: 'ak' } })
     expect(wrapper.exists('#state-nav-results-popover')).toBe(true)
 
     input.simulate('change', { target: { value: '' } })

--- a/src/components/common/state-nav.js
+++ b/src/components/common/state-nav.js
@@ -45,7 +45,10 @@ export default ({ title, stateList }) => {
     }
     const results = []
     stateList.forEach(node => {
-      if (node.name.toLowerCase().search(term.toLowerCase().trim()) === 0) {
+      if (
+        node.name.toLowerCase().search(term.toLowerCase().trim()) === 0 ||
+        node.state.toLowerCase().search(term.toLowerCase().trim()) === 0
+      ) {
         results.push(node)
       }
     })


### PR DESCRIPTION
My first instinct for searching a state was to type the two character state code which showed no results, since it seems we only search on strict state / territory name.

This updates to also strictly search on the `state` property which is the expected state code (and `DC` for District of Colombia and `PR` for Puerto Rico).

![state code](https://user-images.githubusercontent.com/4138357/85637338-8ac09980-b648-11ea-8520-9446d0053b8f.gif)
