### PR TITLE
chore: Fix keyboard trap in search box

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4558,77 +4558,87 @@
       }
     },
     "@reach/menu-button": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@reach/menu-button/-/menu-button-0.10.3.tgz",
-      "integrity": "sha512-50C5nl7JJG9YcKqngmwTLVft+ZF2MMieto1GSCC7qEU8ykUNz0p69Ipup+Eqjk7KRHpSIYPlYIfAOS75dDuiZQ==",
+      "version": "0.10.5",
+      "resolved": "https://registry.npmjs.org/@reach/menu-button/-/menu-button-0.10.5.tgz",
+      "integrity": "sha512-PQzFzexk9K7Q5qTGmXcg3qYp+F36H0MaeyzybR5t4lB1e56nAh1u/C2bocwpHssIoy25xOR8Nu+LVMVf6k6cUw==",
       "requires": {
-        "@reach/auto-id": "^0.10.3",
-        "@reach/descendants": "^0.10.3",
-        "@reach/popover": "^0.10.3",
-        "@reach/utils": "^0.10.3",
+        "@reach/auto-id": "0.10.5",
+        "@reach/descendants": "0.10.5",
+        "@reach/popover": "0.10.5",
+        "@reach/utils": "0.10.5",
         "prop-types": "^15.7.2",
-        "tslib": "^1.11.2"
+        "tslib": "^2.0.0"
       },
       "dependencies": {
         "@reach/auto-id": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.10.3.tgz",
-          "integrity": "sha512-LK3qIsurXnga+gUbjl6t6msrZ+F3aZMY+k2go5Xcns9b85bNRyF/LwlUtcGSqmhgqbVYvMcnLeEdSQLZRxCGnQ==",
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/@reach/auto-id/-/auto-id-0.10.5.tgz",
+          "integrity": "sha512-we4/bwjFxJ3F+2eaddQ1HltbKvJ7AB8clkN719El7Zugpn/vOjfPMOVUiBqTmPGLUvkYrq4tpuFwLvk2HyOVHg==",
           "requires": {
-            "@reach/utils": "^0.10.3",
-            "tslib": "^1.11.2"
+            "@reach/utils": "0.10.5",
+            "tslib": "^2.0.0"
           }
         },
         "@reach/descendants": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.10.3.tgz",
-          "integrity": "sha512-1uwe2w49xSMF0ei1KedydB30sEWfyksk5axI3nEanwUDO7Sd1kCyt2GHZHoP2ESr6VQx2a9ETzMw8gKHsoy79g==",
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/@reach/descendants/-/descendants-0.10.5.tgz",
+          "integrity": "sha512-8HhN4DwS/HsPQ+Ym/Ft/XJ1spXBYdE8hqpnbYR9UcU7Nx3oDbTIdhjA6JXXt23t5avYIx2jRa8YHCtVKSHuiwA==",
           "requires": {
-            "@reach/utils": "^0.10.3",
-            "tslib": "^1.11.2"
+            "@reach/utils": "0.10.5",
+            "tslib": "^2.0.0"
           }
         },
+        "@reach/observe-rect": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/@reach/observe-rect/-/observe-rect-1.2.0.tgz",
+          "integrity": "sha512-Ba7HmkFgfQxZqqaeIWWkNK0rEhpxVQHIoVyW1YDSkGsGIXzcaW4deC8B0pZrNSSyLTdIk7y+5olKt5+g0GmFIQ=="
+        },
         "@reach/popover": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.10.3.tgz",
-          "integrity": "sha512-41iNfdjd9/5HtYuhezTc9z9WGkloYFVB8wBmPX3QOTuBP4qYd0La5sXClrfyiVqPn/uj1gGzehrZKuh8oSkorw==",
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/@reach/popover/-/popover-0.10.5.tgz",
+          "integrity": "sha512-S+qWIsjrN1yMpHjgELhjpdGc4Q3q1plJtXBGGQRxUAjmCUA/5OY7t5w5C8iqMNAEBwCvYXKvK/pLcXFxxLykSw==",
           "requires": {
-            "@reach/portal": "^0.10.3",
-            "@reach/rect": "^0.10.3",
-            "@reach/utils": "^0.10.3",
+            "@reach/portal": "0.10.5",
+            "@reach/rect": "0.10.5",
+            "@reach/utils": "0.10.5",
             "tabbable": "^4.0.0",
-            "tslib": "^1.11.2"
+            "tslib": "^2.0.0"
           }
         },
         "@reach/portal": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.10.3.tgz",
-          "integrity": "sha512-t8c+jtDxMLSPRGg93sQd2s6dDNilh5/qdrwmx88ki7l9h8oIXqMxPP3kSkOqZ9cbVR0b2A68PfMhCDOwMGvkoQ==",
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/@reach/portal/-/portal-0.10.5.tgz",
+          "integrity": "sha512-K5K8gW99yqDPDCWQjEfSNZAbGOQWSx5AN2lpuR1gDVoz4xyWpTJ0k0LbetYJTDVvLP/InEcR7AU42JaDYDCXQw==",
           "requires": {
-            "@reach/utils": "^0.10.3",
-            "tslib": "^1.11.2"
+            "@reach/utils": "0.10.5",
+            "tslib": "^2.0.0"
           }
         },
         "@reach/rect": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.10.3.tgz",
-          "integrity": "sha512-OmnGfG+MdumviJXK5oPcrw2Nd4EgMPKLMCs03GrbkmZJwtXIQJNhQrVg60PQT6HKAKI0+0LobHKxHFT+7Ri7kw==",
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/@reach/rect/-/rect-0.10.5.tgz",
+          "integrity": "sha512-JBKs2HniYecq5zLO6UFReX28SUBPM3n0aizdNgHuvwZmDcTfNV4jsuJYQLqJ+FbCQsrSHkBxKZqWpfGXY9bUEg==",
           "requires": {
-            "@reach/observe-rect": "^1.1.0",
-            "@reach/utils": "^0.10.3",
+            "@reach/observe-rect": "1.2.0",
+            "@reach/utils": "0.10.5",
             "prop-types": "^15.7.2",
-            "tslib": "^1.11.2"
+            "tslib": "^2.0.0"
           }
         },
         "@reach/utils": {
-          "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.10.3.tgz",
-          "integrity": "sha512-LoIZSfVAJMA+DnzAMCMfc/wAM39iKT8BQQ9gI1FODpxd8nPFP4cKisMuRXImh2/iVtG2Z6NzzCNgceJSrywqFQ==",
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/@reach/utils/-/utils-0.10.5.tgz",
+          "integrity": "sha512-5E/xxQnUbmpI/LrufBAOXjunl96DnqX6B4zC2MO2KH/dRzLug5gM5VuOwV26egsp0jvsSPxojwciOhS43px3qw==",
           "requires": {
             "@types/warning": "^3.0.0",
-            "tslib": "^1.11.2",
+            "tslib": "^2.0.0",
             "warning": "^4.0.3"
           }
+        },
+        "tslib": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.0.tgz",
+          "integrity": "sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@reach/alert": "^0.9.1",
     "@reach/combobox": "^0.9.1",
     "@reach/disclosure": "^0.10.2",
-    "@reach/menu-button": "^0.10.2",
+    "@reach/menu-button": "^0.10.5",
     "@reach/router": "^1.3.3",
     "@reach/skip-nav": "^0.9.0",
     "@reach/visually-hidden": "^0.9.0",

--- a/src/__tests__/components/layout/__snapshots__/footer.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/footer.js.snap
@@ -120,7 +120,8 @@ exports[`Components : Layout : Footer renders correctly 1`] = `
         Back to top
       </span>
       <img
-        alt="Back to top"
+        alt=""
+        aria-hidden={true}
         src="test-file-stub"
       />
     </a>

--- a/src/__tests__/components/layout/__snapshots__/header.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/header.js.snap
@@ -51,6 +51,7 @@ exports[`Components : Layout : Header renders correctly 1`] = `
                 onFocus={[Function]}
                 onKeyDown={[Function]}
                 role="combobox"
+                tabIndex="-1"
                 value=""
               />
               <label
@@ -433,6 +434,7 @@ exports[`Components : Layout : Header renders correctly 1`] = `
                   onFocus={[Function]}
                   onKeyDown={[Function]}
                   role="combobox"
+                  tabIndex="-1"
                   value=""
                 />
                 <label
@@ -554,6 +556,7 @@ exports[`Components : Layout : Header renders correctly 2`] = `
                 onFocus={[Function]}
                 onKeyDown={[Function]}
                 role="combobox"
+                tabIndex="-1"
                 value=""
               />
               <label
@@ -936,6 +939,7 @@ exports[`Components : Layout : Header renders correctly 2`] = `
                   onFocus={[Function]}
                   onKeyDown={[Function]}
                   role="combobox"
+                  tabIndex="-1"
                   value=""
                 />
                 <label
@@ -1057,6 +1061,7 @@ exports[`Components : Layout : Header renders correctly 3`] = `
                 onFocus={[Function]}
                 onKeyDown={[Function]}
                 role="combobox"
+                tabIndex="-1"
                 value=""
               />
               <label
@@ -1439,6 +1444,7 @@ exports[`Components : Layout : Header renders correctly 3`] = `
                   onFocus={[Function]}
                   onKeyDown={[Function]}
                   role="combobox"
+                  tabIndex="-1"
                   value=""
                 />
                 <label
@@ -1564,6 +1570,7 @@ exports[`Components : Layout : Header renders correctly 4`] = `
                 onFocus={[Function]}
                 onKeyDown={[Function]}
                 role="combobox"
+                tabIndex="-1"
                 value=""
               />
               <label
@@ -1946,6 +1953,7 @@ exports[`Components : Layout : Header renders correctly 4`] = `
                   onFocus={[Function]}
                   onKeyDown={[Function]}
                   role="combobox"
+                  tabIndex="-1"
                   value=""
                 />
                 <label

--- a/src/__tests__/components/layout/__snapshots__/header.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/header.js.snap
@@ -96,9 +96,9 @@ exports[`Components : Layout : Header renders correctly 1`] = `
                 </a>
                 <button
                   aria-controls="menu--1"
-                  aria-expanded="false"
-                  aria-haspopup="true"
+                  aria-haspopup={true}
                   className="caret"
+                  data-reach-menu-button=""
                   id="menu-button--menu"
                   onKeyDown={[Function]}
                   onMouseDown={[Function]}
@@ -296,9 +296,9 @@ exports[`Components : Layout : Header renders correctly 1`] = `
                   </a>
                   <button
                     aria-controls="menu--3"
-                    aria-expanded="false"
-                    aria-haspopup="true"
+                    aria-haspopup={true}
                     className="caret"
+                    data-reach-menu-button=""
                     id="menu-button--menu"
                     onKeyDown={[Function]}
                     onMouseDown={[Function]}
@@ -601,9 +601,9 @@ exports[`Components : Layout : Header renders correctly 2`] = `
                 </a>
                 <button
                   aria-controls="menu--9"
-                  aria-expanded="false"
-                  aria-haspopup="true"
+                  aria-haspopup={true}
                   className="caret"
+                  data-reach-menu-button=""
                   id="menu-button--menu--9"
                   onKeyDown={[Function]}
                   onMouseDown={[Function]}
@@ -801,9 +801,9 @@ exports[`Components : Layout : Header renders correctly 2`] = `
                   </a>
                   <button
                     aria-controls="menu--11"
-                    aria-expanded="false"
-                    aria-haspopup="true"
+                    aria-haspopup={true}
                     className="caret"
+                    data-reach-menu-button=""
                     id="menu-button--menu--11"
                     onKeyDown={[Function]}
                     onMouseDown={[Function]}
@@ -1106,9 +1106,9 @@ exports[`Components : Layout : Header renders correctly 3`] = `
                 </a>
                 <button
                   aria-controls="menu--18"
-                  aria-expanded="false"
-                  aria-haspopup="true"
+                  aria-haspopup={true}
                   className="caret"
+                  data-reach-menu-button=""
                   id="menu-button--menu--18"
                   onKeyDown={[Function]}
                   onMouseDown={[Function]}
@@ -1306,9 +1306,9 @@ exports[`Components : Layout : Header renders correctly 3`] = `
                   </a>
                   <button
                     aria-controls="menu--20"
-                    aria-expanded="false"
-                    aria-haspopup="true"
+                    aria-haspopup={true}
                     className="caret"
+                    data-reach-menu-button=""
                     id="menu-button--menu--20"
                     onKeyDown={[Function]}
                     onMouseDown={[Function]}
@@ -1615,9 +1615,9 @@ exports[`Components : Layout : Header renders correctly 4`] = `
                 </a>
                 <button
                   aria-controls="menu--25"
-                  aria-expanded="false"
-                  aria-haspopup="true"
+                  aria-haspopup={true}
                   className="caret"
+                  data-reach-menu-button=""
                   id="menu-button--menu--25"
                   onKeyDown={[Function]}
                   onMouseDown={[Function]}
@@ -1815,9 +1815,9 @@ exports[`Components : Layout : Header renders correctly 4`] = `
                   </a>
                   <button
                     aria-controls="menu--27"
-                    aria-expanded="false"
-                    aria-haspopup="true"
+                    aria-haspopup={true}
                     className="caret"
+                    data-reach-menu-button=""
                     id="menu-button--menu--27"
                     onKeyDown={[Function]}
                     onMouseDown={[Function]}

--- a/src/__tests__/components/layout/__snapshots__/header.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/header.js.snap
@@ -136,7 +136,6 @@ exports[`Components : Layout : Header renders correctly 1`] = `
                   data-reach-menu-list=""
                   id="menu--1"
                   onKeyDown={[Function]}
-                  role={false}
                   tabIndex={-1}
                 >
                   <div
@@ -336,7 +335,6 @@ exports[`Components : Layout : Header renders correctly 1`] = `
                     data-reach-menu-list=""
                     id="menu--3"
                     onKeyDown={[Function]}
-                    role={false}
                     tabIndex={-1}
                   >
                     <div
@@ -641,7 +639,6 @@ exports[`Components : Layout : Header renders correctly 2`] = `
                   data-reach-menu-list=""
                   id="menu--9"
                   onKeyDown={[Function]}
-                  role={false}
                   tabIndex={-1}
                 >
                   <div
@@ -841,7 +838,6 @@ exports[`Components : Layout : Header renders correctly 2`] = `
                     data-reach-menu-list=""
                     id="menu--11"
                     onKeyDown={[Function]}
-                    role={false}
                     tabIndex={-1}
                   >
                     <div
@@ -1146,7 +1142,6 @@ exports[`Components : Layout : Header renders correctly 3`] = `
                   data-reach-menu-list=""
                   id="menu--18"
                   onKeyDown={[Function]}
-                  role={false}
                   tabIndex={-1}
                 >
                   <div
@@ -1346,7 +1341,6 @@ exports[`Components : Layout : Header renders correctly 3`] = `
                     data-reach-menu-list=""
                     id="menu--20"
                     onKeyDown={[Function]}
-                    role={false}
                     tabIndex={-1}
                   >
                     <div
@@ -1655,7 +1649,6 @@ exports[`Components : Layout : Header renders correctly 4`] = `
                   data-reach-menu-list=""
                   id="menu--25"
                   onKeyDown={[Function]}
-                  role={false}
                   tabIndex={-1}
                 >
                   <div
@@ -1855,7 +1848,6 @@ exports[`Components : Layout : Header renders correctly 4`] = `
                     data-reach-menu-list=""
                     id="menu--27"
                     onKeyDown={[Function]}
-                    role={false}
                     tabIndex={-1}
                   >
                     <div

--- a/src/__tests__/components/layout/__snapshots__/index.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/index.js.snap
@@ -59,6 +59,7 @@ Array [
                   onFocus={[Function]}
                   onKeyDown={[Function]}
                   role="combobox"
+                  tabIndex="-1"
                   value=""
                 />
                 <label
@@ -441,6 +442,7 @@ Array [
                     onFocus={[Function]}
                     onKeyDown={[Function]}
                     role="combobox"
+                    tabIndex="-1"
                     value=""
                   />
                   <label
@@ -715,6 +717,7 @@ Array [
                   onFocus={[Function]}
                   onKeyDown={[Function]}
                   role="combobox"
+                  tabIndex="-1"
                   value=""
                 />
                 <label
@@ -1097,6 +1100,7 @@ Array [
                     onFocus={[Function]}
                     onKeyDown={[Function]}
                     role="combobox"
+                    tabIndex="-1"
                     value=""
                   />
                   <label

--- a/src/__tests__/components/layout/__snapshots__/index.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/index.js.snap
@@ -144,7 +144,6 @@ Array [
                     data-reach-menu-list=""
                     id="menu--1"
                     onKeyDown={[Function]}
-                    role={false}
                     tabIndex={-1}
                   >
                     <div
@@ -344,7 +343,6 @@ Array [
                       data-reach-menu-list=""
                       id="menu--3"
                       onKeyDown={[Function]}
-                      role={false}
                       tabIndex={-1}
                     >
                       <div
@@ -649,7 +647,8 @@ Array [
           Back to top
         </span>
         <img
-          alt="Back to top"
+          alt=""
+          aria-hidden={true}
           src="test-file-stub"
         />
       </a>
@@ -802,7 +801,6 @@ Array [
                     data-reach-menu-list=""
                     id="menu--9"
                     onKeyDown={[Function]}
-                    role={false}
                     tabIndex={-1}
                   >
                     <div
@@ -1002,7 +1000,6 @@ Array [
                       data-reach-menu-list=""
                       id="menu--11"
                       onKeyDown={[Function]}
-                      role={false}
                       tabIndex={-1}
                     >
                       <div
@@ -1307,7 +1304,8 @@ Array [
           Back to top
         </span>
         <img
-          alt="Back to top"
+          alt=""
+          aria-hidden={true}
           src="test-file-stub"
         />
       </a>

--- a/src/__tests__/components/layout/__snapshots__/index.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/index.js.snap
@@ -104,9 +104,9 @@ Array [
                   </a>
                   <button
                     aria-controls="menu--1"
-                    aria-expanded="false"
-                    aria-haspopup="true"
+                    aria-haspopup={true}
                     className="caret"
+                    data-reach-menu-button=""
                     id="menu-button--menu"
                     onKeyDown={[Function]}
                     onMouseDown={[Function]}
@@ -304,9 +304,9 @@ Array [
                     </a>
                     <button
                       aria-controls="menu--3"
-                      aria-expanded="false"
-                      aria-haspopup="true"
+                      aria-haspopup={true}
                       className="caret"
+                      data-reach-menu-button=""
                       id="menu-button--menu"
                       onKeyDown={[Function]}
                       onMouseDown={[Function]}
@@ -762,9 +762,9 @@ Array [
                   </a>
                   <button
                     aria-controls="menu--9"
-                    aria-expanded="false"
-                    aria-haspopup="true"
+                    aria-haspopup={true}
                     className="caret"
+                    data-reach-menu-button=""
                     id="menu-button--menu--9"
                     onKeyDown={[Function]}
                     onMouseDown={[Function]}
@@ -962,9 +962,9 @@ Array [
                     </a>
                     <button
                       aria-controls="menu--11"
-                      aria-expanded="false"
-                      aria-haspopup="true"
+                      aria-haspopup={true}
                       className="caret"
+                      data-reach-menu-button=""
                       id="menu-button--menu--11"
                       onKeyDown={[Function]}
                       onMouseDown={[Function]}

--- a/src/components/layout/footer.js
+++ b/src/components/layout/footer.js
@@ -64,7 +64,7 @@ const Footer = () => (
       </span>
       <a href="#reach-skip-nav" className={footerStyles.backToTop}>
         <span>Back to top</span>
-        <img src={upArrow} alt="Back to top" />
+        <img src={upArrow} alt="" aria-hidden />
       </a>
     </div>
   </footer>

--- a/src/components/layout/footer.module.scss
+++ b/src/components/layout/footer.module.scss
@@ -136,7 +136,7 @@ hr.divider {
       font-weight: normal;
 
       @media (max-width: $viewport-lg) {
-        display: none;
+        @include a11y-only();
       }
     }
   }

--- a/src/components/layout/header/navigation.js
+++ b/src/components/layout/header/navigation.js
@@ -5,33 +5,6 @@ import { Menu, MenuList, MenuButton, MenuLink } from '@reach/menu-button'
 import internalLink from '~components/utils/internal-link'
 import headerNavigationStyles from './navigation.module.scss'
 
-class MenuCaret extends React.Component {
-  render() {
-    const {
-      children,
-      id,
-      onKeyDown,
-      onMouseDown,
-      'aria-controls': ariaControls,
-      'aria-expanded': ariaExpanded,
-    } = this.props
-    return (
-      <button
-        type="button"
-        onKeyDown={onKeyDown}
-        onMouseDown={onMouseDown}
-        className={headerNavigationStyles.caret}
-        aria-controls={ariaControls}
-        aria-haspopup="true"
-        id={id}
-        aria-expanded={ariaExpanded ? 'true' : 'false'}
-      >
-        {children}
-      </button>
-    )
-  }
-}
-
 export default ({ topNavigation, subNavigation, isMobile }) => (
   <nav className="js-disabled-block" role="navigation">
     <ul
@@ -45,7 +18,7 @@ export default ({ topNavigation, subNavigation, isMobile }) => (
               <Link to={internalLink(item.link)}>{item.title}</Link>
               {item.subNavigation &&
                 typeof subNavigation[item.subNavigation] !== 'undefined' && (
-                  <MenuButton as={MenuCaret}>
+                  <MenuButton className={headerNavigationStyles.caret}>
                     <svg
                       width="12"
                       height="7"

--- a/src/components/layout/header/navigation.js
+++ b/src/components/layout/header/navigation.js
@@ -38,7 +38,7 @@ export default ({ topNavigation, subNavigation, isMobile }) => (
             {item.subNavigation &&
               typeof subNavigation[item.subNavigation] !== 'undefined' && (
                 <MenuList
-                  role={false}
+                  role={undefined}
                   className={headerNavigationStyles.subMenu}
                   onKeyDown={event => {
                     if (event.key === 'Tab') {

--- a/src/components/layout/header/search/index.js
+++ b/src/components/layout/header/search/index.js
@@ -56,6 +56,12 @@ export default ({ mobile, visible, popoverRef }) => {
         mobile={mobile}
         visible={visible}
         onClick={toggleFocusOrQuery}
+        hideAutocomplete={() => {
+          searchDispatch({
+            type: 'setAutocompleteFocus',
+            hasFocus: false,
+          })
+        }}
       />
 
       <SearchButton onClick={toggleFocusOrQuery} />

--- a/src/components/layout/header/search/search-autocomplete.js
+++ b/src/components/layout/header/search/search-autocomplete.js
@@ -19,145 +19,153 @@ import {
 } from '~context/search-context'
 import styles from './search-autocomplete.module.scss'
 
-export default forwardRef(({ mobile, visible, onClick }, popoverRef) => {
-  const [searchState, searchDispatch] = useSearch()
-  const [showResults, setShowResults] = useState(true)
-  const searchInputRef = useRef()
-  const { query, results, autocompleteHasFocus } = searchState
-  const id = `header-search-autocomplete${mobile ? '-mobile' : ''}`
+export default forwardRef(
+  ({ mobile, visible, onClick, hideAutocomplete }, popoverRef) => {
+    const [searchState, searchDispatch] = useSearch()
+    const [showResults, setShowResults] = useState(true)
+    const searchInputRef = useRef()
+    const { query, results, autocompleteHasFocus } = searchState
+    const id = `header-search-autocomplete${mobile ? '-mobile' : ''}`
 
-  function setQuery(value) {
-    if (!value) {
-      return searchDispatch({ type: 'clearQuery' })
+    function setQuery(value) {
+      if (!value) {
+        return searchDispatch({ type: 'clearQuery' })
+      }
+
+      return searchDispatch({ type: 'setQuery', payload: value })
     }
 
-    return searchDispatch({ type: 'setQuery', payload: value })
-  }
-
-  useEffect(() => {
-    if (mobile && searchInputRef.current !== null) {
-      searchInputRef.current.blur()
-    }
-  }, [visible])
-
-  useEffect(() => {
-    if (searchInputRef.current !== null) {
-      if (autocompleteHasFocus) {
-        searchInputRef.current.focus()
-      } else {
+    useEffect(() => {
+      if (mobile && searchInputRef.current !== null) {
         searchInputRef.current.blur()
       }
-    }
-  }, [autocompleteHasFocus])
+    }, [visible])
 
-  useEffect(() => {
-    if (query) {
-      querySearch(searchState, searchDispatch)
-    }
-  }, [query])
-
-  const totalHits =
-    results &&
-    (results[types.STATE].nbHits || 0) +
-      (results[types.BLOG_POST].nbHits || 0) +
-      (results[types.PAGE].nbHits || 0)
-
-  /**
-   * When a result is selected (here by pressing Enter),
-   * try to find a match in search results.
-   * Otherwise, the user is likely submitting the input value,
-   * so we navigate to the search page using value as the query.
-   *
-   * @param string currentValue.
-   *  Current value of the Combobox Input.
-   */
-  const goToResultOrSearch = currentValue => {
-    setShowResults(false)
-    const resultTypes = Object.values(types)
-
-    let match
-    resultTypes.forEach(type => {
-      const item = results[type].hits.find(result => {
-        return result.name === currentValue || result.title === currentValue
-      })
-      if (item) {
-        match = { item, type }
-      }
-    })
-    if (match) {
-      navigate(getSanitizedSlug(match.type, match.item))
-    } else {
-      navigate(`/search?q=${currentValue}`)
-    }
-  }
-
-  const onItemClick = item => navigate(getSanitizedSlug(item.type, item))
-
-  const { bestHits, otherHits } = partitionHitsByRelevance(results)
-
-  return (
-    <Combobox>
-      <ComboboxInput
-        id={id}
-        ref={searchInputRef}
-        className={classNames(styles.searchInput, {
-          [styles.searchInputFocused]: autocompleteHasFocus,
-        })}
-        autoComplete="off"
-        onChange={event => {
-          setQuery(event.currentTarget.value)
-        }}
-        onKeyDown={event =>
-          event.key === 'Enter' && goToResultOrSearch(event.target.value)
+    useEffect(() => {
+      if (searchInputRef.current !== null) {
+        if (autocompleteHasFocus) {
+          searchInputRef.current.focus()
+        } else {
+          searchInputRef.current.blur()
         }
-        onClick={!autocompleteHasFocus && onClick}
-      />
-      <label htmlFor={id} className={styles.searchLabel}>
-        Search
-      </label>
-      {totalHits && showResults ? (
-        <ComboboxPopover
-          ref={popoverRef}
-          portal={false}
-          id="search-results-popover"
-          className={styles.popover}
-        >
-          {totalHits > 0 ? (
-            <ComboboxList aria-label="Results">
-              {bestHits.length > 0 && (
-                <li tabIndex="-1" className={styles.popoverSeparator}>
-                  Best results
-                </li>
-              )}
-              {bestHits.slice(0, 5).map(item => (
-                <ComboboxOption
-                  key={`${item.slug}`}
-                  value={`${item.type === 'state' ? item.name : item.title}`}
-                  onMouseDown={() => onItemClick(item)}
-                />
-              ))}
-              {otherHits.length > 0 && (
-                <li tabIndex="-1" className={styles.popoverSeparator}>
-                  Other results
-                </li>
-              )}
-              {otherHits.slice(0, 5).map(item => (
-                <ComboboxOption
-                  key={`${item.slug}`}
-                  value={`${item.type === 'state' ? item.name : item.title}`}
-                  onMouseDown={() => onItemClick(item)}
-                />
-              ))}
-            </ComboboxList>
-          ) : (
-            <span style={{ display: 'block', marginTop: 5 }}>
-              No results found
-            </span>
-          )}
-        </ComboboxPopover>
-      ) : (
-        false
-      )}
-    </Combobox>
-  )
-})
+      }
+    }, [autocompleteHasFocus])
+
+    useEffect(() => {
+      if (query) {
+        querySearch(searchState, searchDispatch)
+      }
+    }, [query])
+
+    const totalHits =
+      results &&
+      (results[types.STATE].nbHits || 0) +
+        (results[types.BLOG_POST].nbHits || 0) +
+        (results[types.PAGE].nbHits || 0)
+
+    /**
+     * When a result is selected (here by pressing Enter),
+     * try to find a match in search results.
+     * Otherwise, the user is likely submitting the input value,
+     * so we navigate to the search page using value as the query.
+     *
+     * @param string currentValue.
+     *  Current value of the Combobox Input.
+     */
+    const goToResultOrSearch = currentValue => {
+      setShowResults(false)
+      const resultTypes = Object.values(types)
+
+      let match
+      resultTypes.forEach(type => {
+        const item = results[type].hits.find(result => {
+          return result.name === currentValue || result.title === currentValue
+        })
+        if (item) {
+          match = { item, type }
+        }
+      })
+      if (match) {
+        navigate(getSanitizedSlug(match.type, match.item))
+      } else {
+        navigate(`/search?q=${currentValue}`)
+      }
+    }
+
+    const onItemClick = item => navigate(getSanitizedSlug(item.type, item))
+
+    const { bestHits, otherHits } = partitionHitsByRelevance(results)
+
+    return (
+      <Combobox>
+        <ComboboxInput
+          id={id}
+          ref={searchInputRef}
+          tabIndex={autocompleteHasFocus ? '0' : '-1'}
+          className={classNames(styles.searchInput, {
+            [styles.searchInputFocused]: autocompleteHasFocus,
+          })}
+          autoComplete="off"
+          onChange={event => {
+            setQuery(event.currentTarget.value)
+          }}
+          onKeyDown={event => {
+            if (event.key === 'Enter') {
+              goToResultOrSearch(event.target.value)
+            }
+            if (event.key === 'Escape') {
+              hideAutocomplete()
+            }
+          }}
+          onClick={!autocompleteHasFocus && onClick}
+        />
+        <label htmlFor={id} className={styles.searchLabel}>
+          Search
+        </label>
+        {totalHits && showResults ? (
+          <ComboboxPopover
+            ref={popoverRef}
+            portal={false}
+            id="search-results-popover"
+            className={styles.popover}
+          >
+            {totalHits > 0 ? (
+              <ComboboxList aria-label="Results">
+                {bestHits.length > 0 && (
+                  <li tabIndex="-1" className={styles.popoverSeparator}>
+                    Best results
+                  </li>
+                )}
+                {bestHits.slice(0, 5).map(item => (
+                  <ComboboxOption
+                    key={`${item.slug}`}
+                    value={`${item.type === 'state' ? item.name : item.title}`}
+                    onMouseDown={() => onItemClick(item)}
+                  />
+                ))}
+                {otherHits.length > 0 && (
+                  <li tabIndex="-1" className={styles.popoverSeparator}>
+                    Other results
+                  </li>
+                )}
+                {otherHits.slice(0, 5).map(item => (
+                  <ComboboxOption
+                    key={`${item.slug}`}
+                    value={`${item.type === 'state' ? item.name : item.title}`}
+                    onMouseDown={() => onItemClick(item)}
+                  />
+                ))}
+              </ComboboxList>
+            ) : (
+              <span style={{ display: 'block', marginTop: 5 }}>
+                No results found
+              </span>
+            )}
+          </ComboboxPopover>
+        ) : (
+          false
+        )}
+      </Combobox>
+    )
+  },
+)

--- a/src/components/layout/header/search/search-autocomplete.module.scss
+++ b/src/components/layout/header/search/search-autocomplete.module.scss
@@ -17,7 +17,7 @@
   }
 
   @media (min-width: $viewport-lg) {
-    display: none;
+    @include a11y-only();
   }
 }
 

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -43,14 +43,7 @@ li > ul:last-child {
 }
 
 .a11y-only {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  margin: -1px;
-  overflow: hidden;
-  padding: 0;
-  position: absolute;
-  width: 1px;
+  @include a11y-only();
 }
 
 .a11y-only.focusable:active,

--- a/src/scss/helpers.module.scss
+++ b/src/scss/helpers.module.scss
@@ -58,3 +58,14 @@ $spacers: (
 @function toRem($pixel: 16) {
   @return ($pixel / 16) + rem;
 }
+
+@mixin a11y-only {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
+}

--- a/src/scss/helpers.module.scss
+++ b/src/scss/helpers.module.scss
@@ -63,7 +63,7 @@ $spacers: (
   border: 0;
   clip: rect(0 0 0 0);
   height: 1px;
-  margin: -1px;
+  margin: -1px; // ignore-style-rule
   overflow: hidden;
   padding: 0;
   position: absolute;


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Fixes #1078 
- Adds escape key handler to autocomplete that auto-blurs the search and closes it
- Removes tabindex on the autocomplete input so it's not tabbable when minimized
- Removes overridden `MenuButton` component so we have better native keyboard handling from Reach-UI
- Adds new `a11y-only()` mixin
- Used mixin on label for search box when hidden, and the "Back to the top" part of the footer when hidden
- Removed unused `role` from menu dropdowns.
