### PR TITLE
chore(nav): center get involved button on small viewports

### DIFF
--- a/src/components/layout/header/header.module.scss
+++ b/src/components/layout/header/header.module.scss
@@ -24,7 +24,9 @@
 
 .get-involved {
   display: inline-block;
-  line-height: 1.75;
+  @media (min-width: $viewport-lg) {
+    line-height: 1.75;
+  }
   padding: 0.4rem 0.5rem; // ignore-style-rule
   transition: all 0.2s;
   height: 35px; // match the search box height

--- a/src/components/layout/header/header.module.scss
+++ b/src/components/layout/header/header.module.scss
@@ -26,10 +26,10 @@
   display: inline-block;
   @media (min-width: $viewport-lg) {
     line-height: 1.75;
+    height: 35px; // match the search box height
   }
   padding: 0.4rem 0.5rem; // ignore-style-rule
   transition: all 0.2s;
-  height: 35px; // match the search box height
 
   font-weight: bold;
   background: $color-honey-300;


### PR DESCRIPTION
The text inside the "Get Involved" button is not vertically centered at smaller viewports.

Currently, it looks like this:
![image](https://user-images.githubusercontent.com/18607205/85880844-ed757a80-b799-11ea-87ce-c7bc46af162f.png)

This PR centers the text:
![image](https://user-images.githubusercontent.com/18607205/85880887-fd8d5a00-b799-11ea-8862-6f97ee968b43.png)
