### PR TITLE
chore(blog): wrap author byline on small devices

### DIFF
--- a/src/__tests__/components/pages/blog/__snapshots__/blog-lede.js.snap
+++ b/src/__tests__/components/pages/blog/__snapshots__/blog-lede.js.snap
@@ -15,30 +15,22 @@ exports[`Components : Pages : Blog : Lede renders correctly 1`] = `
   <div
     className="byline"
   >
-    <p
-      className="bylineText"
+    <span
+      className="author"
     >
-      <span
-        className="spacer"
+      By 
+      <a
+        className="authorInner"
+        href="https://twitter.com/test"
       >
-        By 
-      </span>
-      <span
-        className="author"
-      >
-        <a
-          className="authorInner"
-          href="https://twitter.com/test"
-        >
-          test name
-        </a>
-      </span>
-      <span
-        className="date"
-      >
-        Aug 1 2020
-      </span>
-    </p>
+        test name
+      </a>
+    </span>
+    <span
+      className="date"
+    >
+      Aug 1 2020
+    </span>
   </div>
   <hr />
 </div>

--- a/src/__tests__/components/pages/blog/__snapshots__/blog-teaser-list.js.snap
+++ b/src/__tests__/components/pages/blog/__snapshots__/blog-teaser-list.js.snap
@@ -26,39 +26,31 @@ Array [
         src="//images.ctfassets.net/aspecificfile"
       />
     </div>
-    <p
-      className="bylineText"
+    <span
+      className="author"
     >
-      <span
-        className="spacer"
+      By 
+      <a
+        className="authorInner"
+        href="https://twitter.com/test"
       >
-        By 
-      </span>
-      <span
-        className="author"
+        test name
+      </a>
+       
+      &
+       
+      <a
+        className="authorInner"
+        href="https://twitter.com/testii"
       >
-        <a
-          className="authorInner"
-          href="https://twitter.com/test"
-        >
-          test name
-        </a>
-         
-        &
-         
-        <a
-          className="authorInner"
-          href="https://twitter.com/testii"
-        >
-          test name II
-        </a>
-      </span>
-      <span
-        className="date"
-      >
-        Aug 1 2020
-      </span>
-    </p>
+        test name II
+      </a>
+    </span>
+    <span
+      className="date"
+    >
+      Aug 1 2020
+    </span>
   </div>,
   <p
     className="lede"
@@ -89,39 +81,31 @@ Array [
         src="//images.ctfassets.net/aspecificfile"
       />
     </div>
-    <p
-      className="bylineText"
+    <span
+      className="author"
     >
-      <span
-        className="spacer"
+      By 
+      <a
+        className="authorInner"
+        href="https://twitter.com/test"
       >
-        By 
-      </span>
-      <span
-        className="author"
+        test name
+      </a>
+       
+      &
+       
+      <a
+        className="authorInner"
+        href="https://twitter.com/testii"
       >
-        <a
-          className="authorInner"
-          href="https://twitter.com/test"
-        >
-          test name
-        </a>
-         
-        &
-         
-        <a
-          className="authorInner"
-          href="https://twitter.com/testii"
-        >
-          test name II
-        </a>
-      </span>
-      <span
-        className="date"
-      >
-        Apr 15 2020
-      </span>
-    </p>
+        test name II
+      </a>
+    </span>
+    <span
+      className="date"
+    >
+      Apr 15 2020
+    </span>
   </div>,
   <p
     className="lede"

--- a/src/__tests__/components/pages/blog/__snapshots__/byline.js.snap
+++ b/src/__tests__/components/pages/blog/__snapshots__/byline.js.snap
@@ -12,30 +12,22 @@ exports[`Components : Pages : Blog : Byline renders correctly 1`] = `
       src="//images.ctfassets.net/arandomfile"
     />
   </div>
-  <p
-    className="bylineText"
+  <span
+    className="author"
   >
-    <span
-      className="spacer"
+    By 
+    <a
+      className="authorInner"
+      href="https://twitter.com/test"
     >
-      By 
-    </span>
-    <span
-      className="author"
-    >
-      <a
-        className="authorInner"
-        href="https://twitter.com/test"
-      >
-        test name
-      </a>
-    </span>
-    <span
-      className="date"
-    >
-      Aug 1 2020
-    </span>
-  </p>
+      test name
+    </a>
+  </span>
+  <span
+    className="date"
+  >
+    Aug 1 2020
+  </span>
 </div>
 `;
 
@@ -43,28 +35,20 @@ exports[`Components : Pages : Blog : Byline renders correctly 2`] = `
 <div
   className="byline"
 >
-  <p
-    className="bylineText"
+  <span
+    className="author"
   >
+    By 
     <span
-      className="spacer"
+      className="authorInner"
     >
-      By 
+      test name
     </span>
-    <span
-      className="author"
-    >
-      <span
-        className="authorInner"
-      >
-        test name
-      </span>
-    </span>
-    <span
-      className="date"
-    >
-      Aug 1 2020
-    </span>
-  </p>
+  </span>
+  <span
+    className="date"
+  >
+    Aug 1 2020
+  </span>
 </div>
 `;

--- a/src/__tests__/components/pages/homepage/__snapshots__/blog-list.js.snap
+++ b/src/__tests__/components/pages/homepage/__snapshots__/blog-list.js.snap
@@ -36,37 +36,29 @@ exports[`Components : Pages : Homepage : Blog list renders correctly 1`] = `
           <div
             className="bylineSmallMargin"
           >
-            <p
-              className="bylineText"
+            <span
+              className="author"
             >
+              By 
               <span
-                className="spacer"
+                className="authorInner"
               >
-                By 
+                Prajakta Ranade
               </span>
+               
+              &
+               
               <span
-                className="author"
+                className="authorInner"
               >
-                <span
-                  className="authorInner"
-                >
-                  Prajakta Ranade
-                </span>
-                 
-                &
-                 
-                <span
-                  className="authorInner"
-                >
-                  Harrison Frank
-                </span>
+                Harrison Frank
               </span>
-              <span
-                className="date"
-              >
-                April 23, 2020
-              </span>
-            </p>
+            </span>
+            <span
+              className="date"
+            >
+              April 23, 2020
+            </span>
           </div>
         </li>
         <li
@@ -95,30 +87,22 @@ exports[`Components : Pages : Homepage : Blog list renders correctly 1`] = `
                 src="//images.ctfassets.net/o2ll9t4ee8tq/3vW1aeLjPFSMAZOqHv9TQS/b4ffb03526cf67724c6732c6e11a6cef/original.png?w=100&fl=progressive&q=50"
               />
             </div>
-            <p
-              className="bylineText"
+            <span
+              className="author"
             >
-              <span
-                className="spacer"
+              By 
+              <a
+                className="authorInner"
+                href="https://www.theatlantic.com/author/alexis-madrigal"
               >
-                By 
-              </span>
-              <span
-                className="author"
-              >
-                <a
-                  className="authorInner"
-                  href="https://www.theatlantic.com/author/alexis-madrigal"
-                >
-                  Alexis Madrigal
-                </a>
-              </span>
-              <span
-                className="date"
-              >
-                April 15, 2020
-              </span>
-            </p>
+                Alexis Madrigal
+              </a>
+            </span>
+            <span
+              className="date"
+            >
+              April 15, 2020
+            </span>
           </div>
         </li>
       </ul>

--- a/src/components/pages/blog/byline.js
+++ b/src/components/pages/blog/byline.js
@@ -65,13 +65,10 @@ const Byline = ({ authors, date, smallmargin = false }) => {
           ))}
         </div>
       )}
-      <p className={bylineStyles.bylineText}>
-        <span className={bylineStyles.spacer}>By </span>
-        <span className={bylineStyles.author}>
-          <AuthorsText authors={authors} />
-        </span>
-        <span className={bylineStyles.date}>{date}</span>
-      </p>
+      <span className={bylineStyles.author}>
+        By <AuthorsText authors={authors} />
+      </span>
+      <span className={bylineStyles.date}>{date}</span>
     </div>
   )
 }

--- a/src/components/pages/blog/byline.module.scss
+++ b/src/components/pages/blog/byline.module.scss
@@ -1,5 +1,9 @@
 .byline-base {
-  display: flex;
+  @media (min-width: $viewport-ms) {
+    display: flex;
+  }
+  display: inline-grid;
+  grid-template-columns: 1fr 4fr;
   align-items: center;
   @include type-size(400);
   line-height: 1.5;
@@ -15,12 +19,11 @@
       margin-right: -5px;
     }
   }
-  .spacer {
-    white-space: pre;
-  }
-  .author::after {
-    content: '  |  ';
-    white-space: pre;
+  @media (min-width: $viewport-ms) {
+    .author::after {
+      content: '  |  ';
+      white-space: pre;
+    }
   }
   * {
     margin: spacer(8) 0;
@@ -33,6 +36,10 @@
   }
   .date {
     color: $color-slate-700;
+    @media (max-width: $viewport-ms) {
+      margin-top: 0;
+    }
+    grid-column-start: span 2;
   }
 }
 


### PR DESCRIPTION
:new: 
![image](https://user-images.githubusercontent.com/18607205/85883114-b739fa00-b79d-11ea-8a8a-4b11de5faf2d.png)

These bylines currently don't wrap the date to a new line, like this:
![image](https://user-images.githubusercontent.com/18607205/85883266-efd9d380-b79d-11ea-83a0-b4733b55de47.png)

@tealtan the date looks a little lonely on it's own. Do you have any suggestions for that? Maybe we could darken the color or prefix it with "Published on" :thinking:...