### PR TITLE
chore: Fix hidden label

### DIFF
--- a/src/components/layout/header/search/search-autocomplete.module.scss
+++ b/src/components/layout/header/search/search-autocomplete.module.scss
@@ -17,7 +17,7 @@
   }
 
   @media (min-width: $viewport-lg) {
-    @include a11y-only();
+    display: none;
   }
 }
 


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
The display `none` on the search label is ok from an a11y perspective because it's displayed on focus.