### PR TITLE
fix(design): Add link back to blog on blog category pages

### DIFF
--- a/src/templates/blog-category.js
+++ b/src/templates/blog-category.js
@@ -6,6 +6,8 @@ import BlogTeaserList from '~components/pages/blog/blog-teaser-list'
 export default ({ data, path }) => (
   <Layout
     title={`Blog: ${data.contentfulBlogCategory.name}`}
+    returnLink="/blog"
+    returnLinkTitle="All posts"
     path={path}
     narrow
   >


### PR DESCRIPTION
Fixes issue #1126 by adding a return link to the blog in the blog category layout.

Screenshot:
![Screen Shot 2020-06-28 at 12 17 59 AM](https://user-images.githubusercontent.com/2343221/85940990-d4bdaf80-b8d4-11ea-9c91-013bea3015e9.png)


