### PR TITLE
chore: check for content type before checking if content is an image

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -116,6 +116,7 @@ exports.createPages = async ({ graphql, actions }) => {
       .filter(
         block =>
           block.nodeType === 'embedded-entry-block' &&
+          block.data.target.sys.contentType &&
           block.data.target.sys.contentType.sys.id === 'contentBlockImage',
       )
       .forEach(image => {


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
