### PR TITLE
chore: Reorder press and blog sections

### DIFF
--- a/src/__tests__/components/pages/homepage/__snapshots__/press.js.snap
+++ b/src/__tests__/components/pages/homepage/__snapshots__/press.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Components : Pages : Homepage : Press renders correctly 1`] = `
-<section>
+<section
+  className="section"
+>
   <h3
     className="header"
   >

--- a/src/components/pages/homepage/blog-list.module.scss
+++ b/src/components/pages/homepage/blog-list.module.scss
@@ -1,6 +1,6 @@
 .wrapper {
   border-top: 1px solid $color-slate-200;
-  // padding-top: 1.75rem;
+  border-bottom: 1px solid $color-slate-200;
   @include padding(24, top);
 }
 

--- a/src/components/pages/homepage/press.js
+++ b/src/components/pages/homepage/press.js
@@ -6,7 +6,7 @@ import { CtaLink } from '~components/common/landing-page/call-to-action'
 import pressStyles from './press.module.scss'
 
 export default () => (
-  <section>
+  <section className={pressStyles.section}>
     <h3 className={pressStyles.header}>Who&#8217;s using our data</h3>
     <div className={pressStyles.press}>
       <Row>

--- a/src/components/pages/homepage/press.module.scss
+++ b/src/components/pages/homepage/press.module.scss
@@ -9,3 +9,7 @@
     @include type-size(400);
   }
 }
+
+.section {
+  @include margin(80, top);
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -30,9 +30,11 @@ export default () => (
       <Container>
         <LargeDataset />
         <Datasets />
-        <Press />
       </Container>
       <BlogList />
+      <Container>
+        <Press />
+      </Container>
     </main>
     <Footer />
   </>


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->

- Fixes #1134
- Switches order of press and blog sections on the homepage