### PR TITLE
fix: Remove center from header unless on blog post

### DIFF
--- a/src/__tests__/components/layout/__snapshots__/header.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/header.js.snap
@@ -2015,3 +2015,506 @@ exports[`Components : Layout : Header renders correctly 4`] = `
   </div>
 </header>
 `;
+
+exports[`Components : Layout : Header renders correctly 5`] = `
+<header
+  className="site-header siteHeader  "
+>
+  <div
+    className="container container "
+  >
+    <div
+      className=""
+      style={
+        Object {
+          "height": 0,
+          "opacity": 0,
+          "overflow": "hidden",
+          "transition": "height 500ms ease-in-out,opacity 500ms ease-in-out,background 500ms ease-in-out",
+        }
+      }
+    >
+      <div
+        className="mobileMenu"
+        style={
+          Object {
+            "minHeight": "0px",
+          }
+        }
+      >
+        <div
+          className="mobileSearchContainer"
+        >
+          <div
+            className="search"
+            onBlur={[Function]}
+          >
+            <div
+              data-reach-combobox=""
+            >
+              <input
+                aria-autocomplete="both"
+                aria-controls="listbox--14"
+                aria-expanded={false}
+                aria-haspopup="listbox"
+                autoComplete="off"
+                className="searchInput"
+                data-reach-combobox-input=""
+                id="header-search-autocomplete-mobile"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                role="combobox"
+                tabIndex="-1"
+                value=""
+              />
+              <label
+                className="searchLabel"
+                htmlFor="header-search-autocomplete-mobile"
+              >
+                Search
+              </label>
+            </div>
+            <button
+              aria-label="Submit search"
+              className="searchSubmit"
+              onClick={[Function]}
+              type="button"
+            >
+              <img
+                alt=""
+                aria-hidden="true"
+                src="test-file-stub"
+              />
+            </button>
+          </div>
+        </div>
+        <nav
+          className="js-disabled-block"
+          role="navigation"
+        >
+          <ul
+            className="mobile"
+            role="menubar"
+          >
+            <li
+              className="menuItem"
+            >
+              <div
+                className="navLabel"
+              >
+                <a
+                  href="/test-a"
+                >
+                  Test A
+                </a>
+                <button
+                  aria-controls="menu--32"
+                  aria-haspopup={true}
+                  className="caret"
+                  data-reach-menu-button=""
+                  id="menu-button--menu--32"
+                  onKeyDown={[Function]}
+                  onMouseDown={[Function]}
+                  type="button"
+                >
+                  <svg
+                    aria-hidden={true}
+                    fill="none"
+                    height="7"
+                    viewBox="0 0 12 7"
+                    width="12"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M5.59523 6.56387C5.7446 6.71053 5.91203 6.7381 6.0001 6.7381C6.09838 6.7381 6.25421 6.71136 6.40443 6.56387L10.9015 1.76778C11.1074 1.5483 11.093 1.20669 10.8695 1.00471C10.6459 0.802637 10.298 0.817297 10.0924 1.03625L5.99993 5.40006L1.90754 1.03625C1.70151 0.816664 1.35357 0.802742 1.13034 1.00471C0.906907 1.20669 0.892512 1.5483 1.09823 1.76778L5.59523 6.56387Z"
+                    />
+                  </svg>
+                  <span
+                    className="a11y-only"
+                  >
+                    show menu for 
+                    Test A
+                  </span>
+                </button>
+              </div>
+              <div
+                data-reach-menu=""
+                data-reach-menu-popover=""
+                hidden={true}
+              >
+                <div
+                  aria-labelledby="menu-button--menu--32"
+                  className="subMenu"
+                  data-reach-menu-items=""
+                  data-reach-menu-list=""
+                  id="menu--32"
+                  onKeyDown={[Function]}
+                  tabIndex={-1}
+                >
+                  <div
+                    role="none"
+                    tabIndex={-1}
+                  >
+                    <a
+                      className="menuLink"
+                      data-reach-menu-item=""
+                      data-reach-menu-link=""
+                      data-selected=""
+                      data-valuetext=""
+                      href="/contentful-a"
+                      onClick={[Function]}
+                      onDragStart={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseUp={[Function]}
+                      role="menuitem"
+                      tabIndex={-1}
+                    >
+                      Contentful a
+                    </a>
+                  </div>
+                  <div
+                    role="none"
+                    tabIndex={-1}
+                  >
+                    <a
+                      className="menuLink"
+                      data-reach-menu-item=""
+                      data-reach-menu-link=""
+                      data-selected=""
+                      data-valuetext=""
+                      href="/contentful-b"
+                      onClick={[Function]}
+                      onDragStart={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseMove={[Function]}
+                      onMouseUp={[Function]}
+                      role="menuitem"
+                      tabIndex={-1}
+                    >
+                      Contentful B
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </li>
+            <li
+              className="menuItem"
+            >
+              <div
+                className="navLabel"
+              >
+                <a
+                  href="/test-b"
+                >
+                  Test B
+                </a>
+              </div>
+            </li>
+          </ul>
+        </nav>
+        <a
+          className="getInvolved"
+          href="/about-project/help"
+        >
+          Get Involved
+        </a>
+        <div
+          className="mobilePointer"
+        />
+      </div>
+    </div>
+    <div
+      className=""
+      style={
+        Object {
+          "background": "colorPlum800",
+          "height": "auto",
+          "opacity": 1,
+          "overflow": "unset",
+          "transition": "height 500ms ease-in-out,opacity 500ms ease-in-out,background 500ms ease-in-out",
+        }
+      }
+    >
+      <div
+        className="banner"
+      >
+        <span
+          className="new"
+        >
+          New
+        </span>
+         
+        <a
+          href="/race"
+        >
+          We just launched the COVID Racial Data Tracker
+        </a>
+      </div>
+    </div>
+    <div
+      className="wrapper"
+    >
+      <div
+        className="siteTitleContainer"
+      >
+        <div
+          className="siteTitleInner"
+        >
+          <a
+            className="projectLogo"
+            href="/"
+          >
+            <img
+              alt="The COVID Tracking Project"
+              src="test-file-stub"
+              width="176px"
+            />
+          </a>
+        </div>
+        <div
+          className="navContainer"
+        >
+          <button
+            aria-expanded={false}
+            className="mobileToggle"
+            onClick={[Function]}
+            type="button"
+          >
+            Menu
+          </button>
+          <nav
+            className="js-disabled-block"
+            role="navigation"
+          >
+            <ul
+              className=""
+              role="menubar"
+            >
+              <li
+                className="menuItem"
+              >
+                <div
+                  className="navLabel"
+                >
+                  <a
+                    href="/test-a"
+                  >
+                    Test A
+                  </a>
+                  <button
+                    aria-controls="menu--34"
+                    aria-haspopup={true}
+                    className="caret"
+                    data-reach-menu-button=""
+                    id="menu-button--menu--34"
+                    onKeyDown={[Function]}
+                    onMouseDown={[Function]}
+                    type="button"
+                  >
+                    <svg
+                      aria-hidden={true}
+                      fill="none"
+                      height="7"
+                      viewBox="0 0 12 7"
+                      width="12"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M5.59523 6.56387C5.7446 6.71053 5.91203 6.7381 6.0001 6.7381C6.09838 6.7381 6.25421 6.71136 6.40443 6.56387L10.9015 1.76778C11.1074 1.5483 11.093 1.20669 10.8695 1.00471C10.6459 0.802637 10.298 0.817297 10.0924 1.03625L5.99993 5.40006L1.90754 1.03625C1.70151 0.816664 1.35357 0.802742 1.13034 1.00471C0.906907 1.20669 0.892512 1.5483 1.09823 1.76778L5.59523 6.56387Z"
+                      />
+                    </svg>
+                    <span
+                      className="a11y-only"
+                    >
+                      show menu for 
+                      Test A
+                    </span>
+                  </button>
+                </div>
+                <div
+                  data-reach-menu=""
+                  data-reach-menu-popover=""
+                  hidden={true}
+                >
+                  <div
+                    aria-labelledby="menu-button--menu--34"
+                    className="subMenu"
+                    data-reach-menu-items=""
+                    data-reach-menu-list=""
+                    id="menu--34"
+                    onKeyDown={[Function]}
+                    tabIndex={-1}
+                  >
+                    <div
+                      role="none"
+                      tabIndex={-1}
+                    >
+                      <a
+                        className="menuLink"
+                        data-reach-menu-item=""
+                        data-reach-menu-link=""
+                        data-selected=""
+                        data-valuetext=""
+                        href="/contentful-a"
+                        onClick={[Function]}
+                        onDragStart={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseMove={[Function]}
+                        onMouseUp={[Function]}
+                        role="menuitem"
+                        tabIndex={-1}
+                      >
+                        Contentful a
+                      </a>
+                    </div>
+                    <div
+                      role="none"
+                      tabIndex={-1}
+                    >
+                      <a
+                        className="menuLink"
+                        data-reach-menu-item=""
+                        data-reach-menu-link=""
+                        data-selected=""
+                        data-valuetext=""
+                        href="/contentful-b"
+                        onClick={[Function]}
+                        onDragStart={[Function]}
+                        onMouseDown={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseMove={[Function]}
+                        onMouseUp={[Function]}
+                        role="menuitem"
+                        tabIndex={-1}
+                      >
+                        Contentful B
+                      </a>
+                    </div>
+                  </div>
+                </div>
+              </li>
+              <li
+                className="menuItem"
+              >
+                <div
+                  className="navLabel"
+                >
+                  <a
+                    href="/test-b"
+                  >
+                    Test B
+                  </a>
+                </div>
+              </li>
+            </ul>
+          </nav>
+        </div>
+        <div
+          className="tools"
+        >
+          <div
+            className="searchContainer"
+          >
+            <div
+              className="search"
+              onBlur={[Function]}
+            >
+              <div
+                data-reach-combobox=""
+              >
+                <input
+                  aria-autocomplete="both"
+                  aria-controls="listbox--15"
+                  aria-expanded={false}
+                  aria-haspopup="listbox"
+                  autoComplete="off"
+                  className="searchInput"
+                  data-reach-combobox-input=""
+                  id="header-search-autocomplete"
+                  onBlur={[Function]}
+                  onChange={[Function]}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  role="combobox"
+                  tabIndex="-1"
+                  value=""
+                />
+                <label
+                  className="searchLabel"
+                  htmlFor="header-search-autocomplete"
+                >
+                  Search
+                </label>
+              </div>
+              <button
+                aria-label="Submit search"
+                className="searchSubmit"
+                onClick={[Function]}
+                type="button"
+              >
+                <img
+                  alt=""
+                  aria-hidden="true"
+                  src="test-file-stub"
+                />
+              </button>
+            </div>
+          </div>
+          <a
+            className="getInvolved"
+            href="/get-involved"
+          >
+            Get involved
+          </a>
+        </div>
+      </div>
+      <div
+        className="atlanticBanner"
+      >
+        <span>
+          At
+        </span>
+         
+        <img
+          alt="The Atlantic"
+          src="test-file-stub"
+        />
+        <div />
+      </div>
+    </div>
+    <div
+      className="container container"
+    >
+      <div
+        className="centered narrow"
+      >
+        <div
+          className="titleSubnavContainer "
+        >
+          <div
+            className="title"
+          >
+            <h1
+              className="page-title pageTitle"
+            >
+              Sample title
+            </h1>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</header>
+`;

--- a/src/__tests__/components/layout/__snapshots__/header.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/header.js.snap
@@ -482,7 +482,7 @@ exports[`Components : Layout : Header renders correctly 1`] = `
       className="container container"
     >
       <div
-        className="centered narrow"
+        className="full"
       >
         <div
           className="titleSubnavContainer "
@@ -985,7 +985,7 @@ exports[`Components : Layout : Header renders correctly 2`] = `
       className="container container"
     >
       <div
-        className="centered narrow"
+        className="full"
       >
         <div
           className="titleSubnavContainer "
@@ -1488,7 +1488,7 @@ exports[`Components : Layout : Header renders correctly 3`] = `
       className="container container"
     >
       <div
-        className="centered narrow"
+        className="full"
       >
         <div
           className="titleSubnavContainer "
@@ -1995,7 +1995,7 @@ exports[`Components : Layout : Header renders correctly 4`] = `
       className="container container"
     >
       <div
-        className="centered narrow"
+        className="full"
       >
         <div
           className="titleSubnavContainer "

--- a/src/__tests__/components/layout/__snapshots__/index.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/index.js.snap
@@ -490,7 +490,7 @@ Array [
         className="container container"
       >
         <div
-          className="centered narrow"
+          className="full"
         >
           <div
             className="titleSubnavContainer "
@@ -1147,7 +1147,7 @@ Array [
         className="container container"
       >
         <div
-          className="centered narrow"
+          className="full"
         >
           <div
             className="titleSubnavContainer "

--- a/src/__tests__/components/layout/header.js
+++ b/src/__tests__/components/layout/header.js
@@ -88,5 +88,12 @@ describe('Components : Layout : Header', () => {
       .create(<Header title="Sample title" navigation={mockNavigation} />)
       .toJSON()
     expect(navigationTree).toMatchSnapshot()
+
+    const navigationCenter = renderer
+      .create(
+        <Header title="Sample title" navigation={mockNavigation} centerTitle />,
+      )
+      .toJSON()
+    expect(navigationCenter).toMatchSnapshot()
   })
 })

--- a/src/components/layout/header/index.js
+++ b/src/components/layout/header/index.js
@@ -37,6 +37,7 @@ const Header = withSearch(
     returnLink,
     returnLinkTitle,
     hero,
+    centerTitle,
   }) => {
     const data = useStaticQuery(graphql`
       query {
@@ -218,7 +219,7 @@ const Header = withSearch(
                 <div />
               </div>
             </div>
-            <Container centered>
+            <Container centered={centerTitle}>
               {title && !hero && (
                 <div
                   className={`${headerStyle.titleSubnavContainer} ${

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -24,6 +24,7 @@ const Layout = ({
   centered,
   socialCard,
   hero,
+  centerTitle,
 }) => {
   const data = useStaticQuery(graphql`
     query SiteTitleQuery {
@@ -50,6 +51,7 @@ const Layout = ({
         returnLink={returnLink}
         returnLinkTitle={returnLinkTitle}
         hero={hero}
+        centerTitle={centerTitle}
       />
       <main id="main">
         <SkipNavContent />

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -33,6 +33,7 @@ export default ({ data, path }) => {
       returnLinkTitle="All posts"
       path={path}
       hero={hero}
+      centerTitle
     >
       {blogPost.featuredImage && (
         <FeaturedImage image={blogPost.featuredImage} />


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Makes the header title and subnavigation not in a centered container
- Adds a `centerTitle` prop for blog posts
