### PR TITLE
chore: Add categories to the bottom of a chart

### DIFF
--- a/src/components/pages/data/charts/chart-list.js
+++ b/src/components/pages/data/charts/chart-list.js
@@ -1,23 +1,43 @@
 import React from 'react'
-import { Link } from 'gatsby'
+import { Link, useStaticQuery, graphql } from 'gatsby'
 import { Row, Col } from '~components/common/grid'
 import chartListStyles from './chart-list.module.scss'
 
-export default ({ chartCategories }) => (
-  <Row className={chartListStyles.charts}>
-    {chartCategories.map(({ name, charts }) => (
-      <Col width={[4, 3, 3]} paddingRight={[0, 8, 32]} paddingLeft={[0, 0, 0]}>
-        <h2>{name}</h2>
-        {charts && charts.length > 0 && (
-          <ul className={chartListStyles.list}>
-            {charts.map(item => (
-              <li>
-                <Link to={`/data/charts/${item.slug}`}>{item.title}</Link>
-              </li>
-            ))}
-          </ul>
-        )}
-      </Col>
-    ))}
-  </Row>
-)
+export default () => {
+  const data = useStaticQuery(graphql`
+    query {
+      allContentfulChartCategory(sort: { fields: [order], order: ASC }) {
+        nodes {
+          name
+          slug
+          charts {
+            title
+            slug
+          }
+        }
+      }
+    }
+  `)
+  return (
+    <Row className={chartListStyles.charts}>
+      {data.allContentfulChartCategory.nodes.map(({ name, charts }) => (
+        <Col
+          width={[4, 3, 3]}
+          paddingRight={[0, 8, 32]}
+          paddingLeft={[0, 0, 0]}
+        >
+          <h2>{name}</h2>
+          {charts && charts.length > 0 && (
+            <ul className={chartListStyles.list}>
+              {charts.map(item => (
+                <li>
+                  <Link to={`/data/charts/${item.slug}`}>{item.title}</Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </Col>
+      ))}
+    </Row>
+  )
+}

--- a/src/pages/data/charts.js
+++ b/src/pages/data/charts.js
@@ -8,7 +8,7 @@ import ChartList from '~components/pages/data/charts/chart-list'
 
 export default ({ data }) => (
   <Layout title="Charts" returnLink="/data" returnLinkTitle="Our Data">
-    <ChartList chartCategories={data.allContentfulChartCategory.nodes} />
+    <ChartList />
 
     <Container centered>
       <LongContent>
@@ -26,16 +26,6 @@ export default ({ data }) => (
 
 export const query = graphql`
   query {
-    allContentfulChartCategory(sort: { fields: [order], order: ASC }) {
-      nodes {
-        name
-        slug
-        charts {
-          title
-          slug
-        }
-      }
-    }
     contentfulSnippet(slug: { eq: "chart-page-content" }) {
       contentful_id
       childContentfulSnippetContentTextNode {

--- a/src/templates/chart.js
+++ b/src/templates/chart.js
@@ -3,6 +3,7 @@ import { graphql } from 'gatsby'
 import Container from '~components/common/container'
 import LongContent from '~components/common/long-content'
 import TableauChart from '~components/charts/tableau'
+import ChartList from '~components/pages/data/charts/chart-list'
 import Layout from '../components/layout'
 
 const ChartPage = ({ data, path }) => {
@@ -34,6 +35,7 @@ const ChartPage = ({ data, path }) => {
             viewUrl={chart.tableauViewUrl}
           />
         )}
+        <ChartList />
       </Container>
     </Layout>
   )


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Adds the chart categories on the bottom of every chart page.