### PR TITLE
Initial update national chart with bar graph and new data

### DIFF
--- a/src/__tests__/components/charts/__snapshots__/horizontal-bar-chart.js.snap
+++ b/src/__tests__/components/charts/__snapshots__/horizontal-bar-chart.js.snap
@@ -12,15 +12,15 @@ exports[`Components : Charts: Area chart renders correctly 1`] = `
     <g>
       <text
         className="label xTickLabel"
-        x={46.666666666666664}
+        x={0}
         y={170}
       >
-        500
+        0
       </text>
       <line
         className="gridLine"
-        x1={46.666666666666664}
-        x2={46.666666666666664}
+        x1={0}
+        x2={0}
         y1={0}
         y2={140}
       />
@@ -28,15 +28,31 @@ exports[`Components : Charts: Area chart renders correctly 1`] = `
     <g>
       <text
         className="label xTickLabel"
-        x={105}
+        x={76.92307692307693}
+        y={170}
+      >
+        500
+      </text>
+      <line
+        className="gridLine"
+        x1={76.92307692307693}
+        x2={76.92307692307693}
+        y1={0}
+        y2={140}
+      />
+    </g>
+    <g>
+      <text
+        className="label xTickLabel"
+        x={153.84615384615387}
         y={170}
       >
         1k
       </text>
       <line
         className="gridLine"
-        x1={105}
-        x2={105}
+        x1={153.84615384615387}
+        x2={153.84615384615387}
         y1={0}
         y2={140}
       />
@@ -96,28 +112,28 @@ exports[`Components : Charts: Area chart renders correctly 1`] = `
     <rect
       fill="#333"
       height={26.666666666666664}
-      width={132.29999999999998}
+      width={189.84615384615384}
       x={0}
       y={6.6666666666666785}
     />
     <rect
       fill="#333"
       height={26.666666666666664}
-      width={2.683333333333333}
+      width={18.923076923076923}
       x={0}
       y={40.00000000000001}
     />
     <rect
       fill="#333"
       height={26.666666666666664}
-      width={132.18333333333334}
+      width={189.69230769230768}
       x={0}
       y={73.33333333333334}
     />
     <rect
       fill="#333"
       height={26.666666666666664}
-      width={3.7333333333333334}
+      width={20.307692307692307}
       x={0}
       y={106.66666666666666}
     />
@@ -137,15 +153,15 @@ exports[`Components : Charts: Area chart renders correctly 2`] = `
     <g>
       <text
         className="label xTickLabel"
-        x={66.66666666666666}
+        x={0}
         y={200}
       >
-        500
+        0
       </text>
       <line
         className="gridLine"
-        x1={66.66666666666666}
-        x2={66.66666666666666}
+        x1={0}
+        x2={0}
         y1={0}
         y2={200}
       />
@@ -153,15 +169,31 @@ exports[`Components : Charts: Area chart renders correctly 2`] = `
     <g>
       <text
         className="label xTickLabel"
-        x={150}
+        x={76.92307692307693}
+        y={200}
+      >
+        500
+      </text>
+      <line
+        className="gridLine"
+        x1={76.92307692307693}
+        x2={76.92307692307693}
+        y1={0}
+        y2={200}
+      />
+    </g>
+    <g>
+      <text
+        className="label xTickLabel"
+        x={153.84615384615387}
         y={200}
       >
         1k
       </text>
       <line
         className="gridLine"
-        x1={150}
-        x2={150}
+        x1={153.84615384615387}
+        x2={153.84615384615387}
         y1={0}
         y2={200}
       />
@@ -221,28 +253,28 @@ exports[`Components : Charts: Area chart renders correctly 2`] = `
     <rect
       fill="#333"
       height={38.095238095238095}
-      width={189}
+      width={189.84615384615384}
       x={0}
       y={9.523809523809518}
     />
     <rect
       fill="#333"
       height={38.095238095238095}
-      width={3.833333333333333}
+      width={18.923076923076923}
       x={0}
       y={57.14285714285714}
     />
     <rect
       fill="#333"
       height={38.095238095238095}
-      width={188.83333333333334}
+      width={189.69230769230768}
       x={0}
       y={104.76190476190476}
     />
     <rect
       fill="#333"
       height={38.095238095238095}
-      width={5.333333333333334}
+      width={20.307692307692307}
       x={0}
       y={152.38095238095238}
     />

--- a/src/components/charts/horizontal-bar-chart.js
+++ b/src/components/charts/horizontal-bar-chart.js
@@ -9,16 +9,14 @@ import chartStyles from './charts.module.scss'
 export default function HorizontalBarChart({
   data,
   fill,
+  highlight = fill,
   height,
   marginBottom = 0,
   marginLeft = 0,
-  marginRight = 0,
   marginTop = 0,
   xTicks,
   width,
-  xMax = null,
 }) {
-  const totalXMargin = marginLeft + marginRight
   const totalYMargin = marginTop + marginBottom
   const yScale = scaleBand()
     .domain(data.map(d => d.name))
@@ -26,9 +24,9 @@ export default function HorizontalBarChart({
     .padding(0.2)
   const formatTick = format('~s')
   const xScale = scaleLinear()
-    .domain([120, xMax || max(data, d => d.value)])
+    .domain([0, max(data, d => d.value)])
     .nice()
-    .range([0, width - totalXMargin])
+    .range([0, width])
 
   return (
     <svg
@@ -79,7 +77,7 @@ export default function HorizontalBarChart({
             y={yScale(d.name)}
             height={yScale.bandwidth()}
             width={xScale(d.value)}
-            fill={fill}
+            fill={d.highlight ? highlight : fill}
           />
         ))}
       </g>

--- a/src/components/pages/race/national-chart.js
+++ b/src/components/pages/race/national-chart.js
@@ -1,80 +1,128 @@
-import React from 'react'
-import classnames from 'classnames'
-import { useStaticQuery, graphql } from 'gatsby'
+import React, { useState } from 'react'
+import {
+  Disclosure,
+  DisclosureButton,
+  DisclosurePanel,
+} from '@reach/disclosure'
 import nationalChartStyle from './national-chart.module.scss'
-
-const DonutChart = ({ value, children, mobileOnly, desktopOnly }) => (
-  <div
-    className={classnames(
-      nationalChartStyle.donutChart,
-      mobileOnly && nationalChartStyle.mobileOnly,
-      desktopOnly && nationalChartStyle.desktopOnly,
-    )}
-  >
-    <div
-      className={nationalChartStyle.slice}
-      style={{ transform: `rotate(${value * 360 + 90}deg)` }}
-    />
-    <div
-      className={nationalChartStyle.slice}
-      style={{ transform: 'rotate(-90deg)' }}
-    />
-    <div className={nationalChartStyle.center}>
-      <span>{children}</span>
-    </div>
-  </div>
-)
+import HorizontalBarChart from '~components/charts/horizontal-bar-chart'
+import { totalColor, lightColor } from '~utilities/visualization'
+import { FormatNumber } from '~components/utils/format'
 
 export default () => {
-  const data = useStaticQuery(graphql`
-    query {
-      covidRaceDataHomepage {
-        blackPercentOfPopulation
-        blackPercentOfDeath
-      }
-    }
-  `)
   const {
-    blackPercentOfPopulation,
-    blackPercentOfDeath,
-  } = data.covidRaceDataHomepage
+    blackMortalityRate,
+    aianMortalityRate,
+    nhpiMortalityRate,
+    twoMortalityRate,
+    whiteMortalityRate,
+    otherMortalityRate,
+    latinXMortalityRate,
+  } = {
+    // hardcoded for now
+    blackLivesLost: 26425,
+    blackPercentOfPopulation: 0.1267,
+    blackPercentOfDeath: 0.2332735988,
+    blackLivesExpectedMultiplier: 1.841149162,
+    statesReportingCases: 49,
+    statesReportingDeaths: 48,
+    blackMortalityRate: 64,
+    aianMortalityRate: 30,
+    nhpiMortalityRate: 20,
+    twoMortalityRate: 2,
+    whiteMortalityRate: 25,
+    otherMortalityRate: 24,
+    latinXMortalityRate: 29,
+    blackwhiteRateRatio: 2.5,
+  }
+  const data = [
+    {
+      name: 'Black',
+      value: blackMortalityRate,
+      highlight: true,
+    },
+    {
+      name: 'Hispanic or Latinx',
+      value: latinXMortalityRate,
+      highlight: false,
+    },
+    {
+      name: 'American Indian/Alaska Native',
+      value: aianMortalityRate,
+      highlight: false,
+    },
+    {
+      name: 'Asian',
+      value: 27, // Missing?
+      highlight: false,
+    },
+    {
+      name: 'White',
+      value: whiteMortalityRate,
+      highlight: true,
+    },
+    {
+      name: 'Other',
+      value: otherMortalityRate,
+      highlight: false,
+    },
+    {
+      name: 'Native Hawaiian/ Other Pacific Islander',
+      value: nhpiMortalityRate,
+      highlight: false,
+    },
+    {
+      name: 'Two or more races',
+      value: twoMortalityRate,
+    },
+  ]
+  const perXPeople = 100000
+  const [isCollapsed, toggleIsCollapsed] = useState(true)
   return (
     <div className={nationalChartStyle.wrapper}>
-      <h3 className={nationalChartStyle.header}>Black people account for:</h3>
+      <h4 className={nationalChartStyle.header}>
+        Deaths per <FormatNumber number={perXPeople} /> people by race or
+        ethnicity
+      </h4>
       <div className={nationalChartStyle.charts}>
-        <div className={nationalChartStyle.chart}>
-          <DonutChart value={blackPercentOfPopulation} mobileOnly />
-          <p className={nationalChartStyle.chartLegend}>
-            <span className={nationalChartStyle.number}>
-              {Math.round(blackPercentOfPopulation * 100)}%
-            </span>
-            of the US
-            <br />
-            population
-          </p>
-          <DonutChart value={blackPercentOfPopulation} desktopOnly />
-        </div>
-        <div className={nationalChartStyle.versus}>
-          <abbr title="versus" aria-label="versus">
-            vs.
-          </abbr>
-        </div>
-        <div
-          className={classnames(
-            nationalChartStyle.chart,
-            nationalChartStyle.flip,
-          )}
+        <HorizontalBarChart
+          data={data}
+          fill={lightColor}
+          highlight={totalColor}
+          height={400}
+          marginBottom={40}
+          marginLeft={136}
+          marginRight={40}
+          marginTop={20}
+          xTicks={4}
+          yTicks={data.length}
+          width={400}
+        />
+      </div>
+      <div>
+        <Disclosure
+          open={isCollapsed}
+          onChange={() => toggleIsCollapsed(!isCollapsed)}
         >
-          <DonutChart value={blackPercentOfDeath} />
-          <p className={nationalChartStyle.chartLegend}>
-            <span className={nationalChartStyle.number}>
-              {Math.round(blackPercentOfDeath * 100)}%
-            </span>
-            of deaths
-            <br />
-            where race is known
-          </p>
-        </div>
+          <DisclosureButton className={nationalChartStyle.showNotes}>
+            {isCollapsed ? (
+              <>
+                Notes <span aria-hidden>↑</span>
+              </>
+            ) : (
+              <>
+                Notes <span aria-hidden>↓</span>
+              </>
+            )}
+          </DisclosureButton>
+          <DisclosurePanel className={nationalChartStyle.notes}>
+            These calculations are based on data from The Covid Racial Data
+            Tracker and the U.S. Census Bureau. Race categories may overlap with
+            Hispanic/Latinx ethnicity. Rates are not age-adjusted and some rates
+            are underestimated due to lack of reporting of race and ethnicity
+            categories for COVID-19 deaths.
+          </DisclosurePanel>
+        </Disclosure>
       </div>
     </div>
   )

--- a/src/components/pages/race/national-chart.module.scss
+++ b/src/components/pages/race/national-chart.module.scss
@@ -130,3 +130,26 @@ $chart-breakpoint: $viewport-ms;
     }
   }
 }
+
+.show-notes {
+  display: block;
+  &:hover {
+    text-decoration: underline;
+  }
+  background: transparent;
+  border: 0;
+  text-decoration: underline;
+  color: $color-slate-600;
+  margin-top: spacer(16);
+  margin-bottom: spacer(16);
+  padding: 0;
+  cursor: pointer;
+  abbr {
+    display: inline-block;
+    margin-left: spacer(16);
+  }
+}
+
+.notes {
+  color: $color-slate-600;
+}

--- a/src/data/race/homepage.json
+++ b/src/data/race/homepage.json
@@ -1,8 +1,18 @@
 [
   {
-    "blackLivesLost": 15517,
-    "blackLivesExpectedMultiplier": 2.3,
-    "statesReportingCases": 46,
-    "statesReportingDeaths": 41
+    "blackLivesLost": "26,425",
+    "blackPercentOfPopulation": "0.1267",
+    "blackPercentOfDeath": "0.2332735988",
+    "blackLivesExpectedMultiplier": "1.841149162",
+    "statesReportingCases": "49",
+    "statesReportingDeaths": "48",
+    "blackMortalityRate": "64.0",
+    "aianMortalityRate": "30.1",
+    "nhpiMortalityRate": "20.1",
+    "twoMortalityRate": "2.4",
+    "whiteMortalityRate": "25.2",
+    "otherMortalityRate": "24.8",
+    "latinXMortalityRate": "29.2",
+    "blackwhiteRateRatio": "2.5"
   }
 ]

--- a/src/pages/race/index.js
+++ b/src/pages/race/index.js
@@ -17,7 +17,6 @@ import Charts from '~components/pages/race/charts'
 import Totals from '~components/pages/race/totals'
 import Press from '~components/pages/race/press'
 import Publication from '~components/pages/race/citation'
-import RaceMultiplierHighlight from '~components/pages/race/multiplier-highlight'
 import { FormatNumber } from '~components/utils/format'
 
 export default () => {
@@ -25,6 +24,7 @@ export default () => {
     query {
       covidRaceDataHomepage {
         blackLivesLost
+        blackPercentOfDeath
         blackLivesExpectedMultiplier
       }
       contentfulSocialCard(slug: { eq: "racial-data-tracker" }) {
@@ -39,10 +39,8 @@ export default () => {
       }
     }
   `)
-  const {
-    blackLivesLost,
-    blackLivesExpectedMultiplier,
-  } = data.covidRaceDataHomepage
+  const { blackLivesLost, blackPercentOfDeath } = data.covidRaceDataHomepage
+  const blackwhiteRateRatio = 2.5
   return (
     <>
       <SEO
@@ -73,15 +71,17 @@ export default () => {
         <LandingPageSection noBorder noMargin>
           <LandingPageContainer>
             <LargeHeader center narrow>
-              We’ve lost at least <FormatNumber number={blackLivesLost} /> Black
-              lives to COVID-19 to date.
+              Nationwide, Black people are dying at a rate&nbsp;
+              <FormatNumber number={blackwhiteRateRatio} /> times higher than
+              white people.
             </LargeHeader>
             <NationalChart />
-            {Number(blackLivesExpectedMultiplier) > 1.36 && (
-              <RaceMultiplierHighlight
-                multiplier={blackLivesExpectedMultiplier}
-              />
-            )}
+            <LargeHeader center>
+              We&apos;ve lost at least <FormatNumber number={blackLivesLost} />
+              &nbsp;Black lives to COVID-19 to date. Black people account for
+              &nbsp;{Math.round(blackPercentOfDeath * 100)}% of COVID-19 deaths
+              where race is known.
+            </LargeHeader>
           </LandingPageContainer>
         </LandingPageSection>
         <LandingPageSection noMargin>

--- a/src/utilities/visualization.js
+++ b/src/utilities/visualization.js
@@ -69,5 +69,6 @@ export const getStateName = abbr => {
 }
 
 export const totalColor = colors.colorPlum600
+export const lightColor = colors.colorPlum300
 export const positiveColor = colors.colorHoney500
 export const deathsBarColor = colors.colorSlate600


### PR DESCRIPTION
Based on this mock:
![image](https://user-images.githubusercontent.com/568975/86541290-ab56e200-bed9-11ea-8002-1a7aa6d45232.png)

I'm assuming this replaces the current donut:
![image](https://user-images.githubusercontent.com/568975/86541299-bdd11b80-bed9-11ea-83fc-627cdfe6ac40.png)

If so, whoever continues this work can possibly delete the styling in `national-chart.module.scss#donut-chart`. 

Currently updated data is hardcoded. This should be removed with a real query call. 

There should also be an addition of the exact numbers at the end of each bar, and any a11y tags if needed. 

- [x] Replace hardcoded data with GraphQL call when data is available
- [x] Clean up unused donut chart code if applicable
- [x] Add any needed a11y tags
- [x] Double-check that I didn't break the `HorizontalBarChart` component for other consumer (`_StateComulativeDeathsContainer`)
- [x] Update `horizontal-bar-chart` test
- [x] General cleanup

Curent preview:
![preview-tracker](https://user-images.githubusercontent.com/568975/86541334-04bf1100-beda-11ea-815f-9d8ed51a183c.gif)
