### PR TITLE
chore: Setup data definitions page

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,3 @@
-
 require(`@babel/register`)({
   presets: ['@babel/preset-env', '@babel/preset-react'],
   plugins: ['@babel/plugin-transform-runtime'],
@@ -7,7 +6,8 @@ require('dotenv').config()
 
 const algoliaQueries = require('./src/utilities/algolia').queries
 const sassImports = require('./src/utilities/sass-imports.js')
-const formatStringList = require('./src/components/utils/format').formatStringList
+const formatStringList = require('./src/components/utils/format')
+  .formatStringList
 
 const gatsbyConfig = {
   siteMetadata: {
@@ -189,6 +189,7 @@ const gatsbyConfig = {
       options: {
         spaceId: process.env.CONTENTFUL_SPACE,
         accessToken: process.env.CONTENTFUL_TOKEN,
+        environment: 'data-definitions',
       },
     },
 
@@ -290,7 +291,6 @@ const gatsbyConfig = {
           {
             serialize: ({ query: { site, allContentfulBlogPost } }) => {
               return allContentfulBlogPost.nodes.map(node => {
-
                 return Object.assign(
                   {},
                   {
@@ -299,7 +299,9 @@ const gatsbyConfig = {
                     date: node.publishDate,
                     url: `${site.siteMetadata.siteUrl}/blog/${node.slug}`,
                     guid: `${site.siteMetadata.siteUrl}/blog/${node.slug}`,
-                    author: formatStringList(node.authors.map(author => author.name))
+                    author: formatStringList(
+                      node.authors.map(author => author.name),
+                    ),
                   },
                 )
               })

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -70,6 +70,12 @@ exports.createPages = async ({ graphql, actions }) => {
           slug
         }
       }
+      allContentfulDataDefinition {
+        nodes {
+          id
+          slug
+        }
+      }
       allCounties(filter: { demographics: { total: { gt: 0 } } }) {
         nodes {
           name
@@ -128,6 +134,14 @@ exports.createPages = async ({ graphql, actions }) => {
     createPage({
       path: `/data/charts/${node.slug}`,
       component: path.resolve(`./src/templates/chart.js`),
+      context: node,
+    })
+  })
+
+  result.data.allContentfulDataDefinition.nodes.forEach(node => {
+    createPage({
+      path: `/about-data/data-definitions/${node.slug}`,
+      component: path.resolve(`./src/templates/data-definition.js`),
       context: node,
     })
   })

--- a/src/pages/about-data/data-definitions.js
+++ b/src/pages/about-data/data-definitions.js
@@ -1,0 +1,41 @@
+import React from 'react'
+import { graphql } from 'gatsby'
+import ContentfulContent from '~components/common/contentful-content'
+import Layout from '~components/layout'
+
+export default ({ data }) => (
+  <Layout title="Data definition" path="about-data/data-definitions" narrow>
+    {data.allContentfulDataDefinition.nodes.map(definition => (
+      <>
+        <h2 id={definition.slug}>{definition.name}</h2>
+        <ContentfulContent
+          id={definition.contentful_id}
+          content={
+            definition.childContentfulDataDefinitionDefinitionTextNode
+              .childMarkdownRemark.html
+          }
+        />
+      </>
+    ))}
+  </Layout>
+)
+
+export const query = graphql`
+  query {
+    allContentfulDataDefinition {
+      nodes {
+        apiFieldName
+        cdcDefinition
+        contentful_id
+        csteDefinition
+        name
+        slug
+        childContentfulDataDefinitionDefinitionTextNode {
+          childMarkdownRemark {
+            html
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/templates/data-definition.js
+++ b/src/templates/data-definition.js
@@ -1,0 +1,35 @@
+import React from 'react'
+import { graphql } from 'gatsby'
+import ContentfulContent from '~components/common/contentful-content'
+import Layout from '../components/layout'
+
+export default ({ data }) => (
+  <Layout title={data.contentfulDataDefinition.name} narrow>
+    <ContentfulContent
+      id={data.contentfulDataDefinition.contentful_id}
+      content={
+        data.contentfulDataDefinition
+          .childContentfulDataDefinitionDefinitionTextNode.childMarkdownRemark
+          .html
+      }
+    />
+  </Layout>
+)
+
+export const query = graphql`
+  query($id: String!) {
+    contentfulDataDefinition(id: { eq: $id }) {
+      apiFieldName
+      cdcDefinition
+      contentful_id
+      csteDefinition
+      name
+      slug
+      childContentfulDataDefinitionDefinitionTextNode {
+        childMarkdownRemark {
+          html
+        }
+      }
+    }
+  }
+`


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fixes #1202 
- Adds a page that lists all data definitions.

## Pre-merge steps
- [ ] Move conetnt types and content to production environment in Contentful
- [ ] Remove environment from this branch