### PR TITLE
chore: Change page URLs and add missing navigation links

### DIFF
--- a/src/data/navigation/header.yml
+++ b/src/data/navigation/header.yml
@@ -10,7 +10,7 @@ items:
     link: /race
     subNavigation: race
   - title: About Us
-    link: /about-project
+    link: /about
     subNavigation: about-project
   - title: Blog
     link: /blog

--- a/src/pages/about/newsletter.js
+++ b/src/pages/about/newsletter.js
@@ -8,7 +8,12 @@ import ContentfulContent from '~components/common/contentful-content'
 import GetInvolvedForm from '~components/pages/get-involved/form'
 
 export default ({ data }) => (
-  <Layout title="Sign up for our newsletter" centered>
+  <Layout
+    title="Sign up for our newsletter"
+    path="/about/newsletter"
+    navigation={data.contentfulNavigationGroup.pages}
+    centered
+  >
     <LongContent>
       <ContentfulContent
         content={
@@ -30,6 +35,12 @@ export const query = graphql`
         childMarkdownRemark {
           html
         }
+      }
+    }
+    contentfulNavigationGroup(slug: { eq: "data" }) {
+      pages {
+        title
+        link: url
       }
     }
   }

--- a/src/pages/contact/index.js
+++ b/src/pages/contact/index.js
@@ -28,10 +28,12 @@ export default ({ data }) => {
   return (
     <Layout
       title="Contact"
+      path="/contact"
       socialCard={{
         description:
           'The COVID Tracking Project runs on the effort and diligence of hundreds of volunteers, and we welcome your contribution.',
       }}
+      navigation={data.contentfulNavigationGroup.pages}
       narrow
     >
       <LongContent>
@@ -139,6 +141,12 @@ export const query = graphql`
         childMarkdownRemark {
           html
         }
+      }
+    }
+    contentfulNavigationGroup(slug: { eq: "data" }) {
+      pages {
+        title
+        link: url
       }
     }
   }

--- a/src/pages/contact/volunteer.js
+++ b/src/pages/contact/volunteer.js
@@ -6,7 +6,12 @@ import Layout from '~components/layout'
 import VolunteerForm from '~components/pages/contact/volunteer-form'
 
 export default ({ data }) => (
-  <Layout title="Contact Us &mdash; Volunteering" centered>
+  <Layout
+    title="Contact Us &mdash; Volunteering"
+    navigation={data.contentfulNavigationGroup.pages}
+    path="/contact/volunteer"
+    centered
+  >
     <LongContent>
       <ContentfulContent
         content={
@@ -28,6 +33,12 @@ export const query = graphql`
         childMarkdownRemark {
           html
         }
+      }
+    }
+    contentfulNavigationGroup(slug: { eq: "data" }) {
+      pages {
+        title
+        link: url
       }
     }
   }

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -24,6 +24,7 @@ export default ({ data }) => {
       socialCard={{
         description: 'Our most up-to-date data on COVID-19 in the US.',
       }}
+      path="/data"
       navigation={data.contentfulNavigationGroup.pages}
     >
       <ContentfulContent


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fixes some pages missing subnav
- Adds contact pages to the about-us navigation