### PR TITLE
fix: Input names on radio buttons

### DIFF
--- a/src/components/common/form.js
+++ b/src/components/common/form.js
@@ -133,7 +133,7 @@ const List = ({ type, name, options, label, isRequired, detailText }) => (
             >
               <input
                 type={type}
-                name={name ? name : item.label}
+                name={name || item.label}
                 value={item.label}
                 id={item.value}
               />

--- a/src/components/common/form.js
+++ b/src/components/common/form.js
@@ -131,7 +131,12 @@ const List = ({ type, name, options, label, isRequired, detailText }) => (
               htmlFor={item.value}
               className={formStyles.checkboxLabel}
             >
-              <input type={type} value={item.label} id={item.value} />
+              <input
+                type={type}
+                name={type === 'radio' ? name : item.label}
+                value={item.label}
+                id={item.value}
+              />
               {item.label}
             </label>
           ))}

--- a/src/components/common/form.js
+++ b/src/components/common/form.js
@@ -133,7 +133,7 @@ const List = ({ type, name, options, label, isRequired, detailText }) => (
             >
               <input
                 type={type}
-                name={type === 'radio' ? name : item.label}
+                name={name ? name : item.label}
                 value={item.label}
                 id={item.value}
               />

--- a/src/components/pages/contact/volunteer-form.js
+++ b/src/components/pages/contact/volunteer-form.js
@@ -6,6 +6,7 @@ export default () => {
     <Form
       method="POST"
       name="volunteer"
+      action="/contact/volunteer-success"
       netlify-honeypot="covid-bot-field"
       data-netlify="true"
     >

--- a/src/components/pages/contact/volunteer-form.js
+++ b/src/components/pages/contact/volunteer-form.js
@@ -6,7 +6,6 @@ export default () => {
     <Form
       method="POST"
       name="volunteer"
-      action="/contact/volunteer-success"
       netlify-honeypot="covid-bot-field"
       data-netlify="true"
     >


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
WIP as we figure out the deal with Netlify.

Fixes #1220