### PR TITLE
chore: Fix Volunteer form name

### DIFF
--- a/src/components/pages/contact/volunteer-form.js
+++ b/src/components/pages/contact/volunteer-form.js
@@ -10,6 +10,7 @@ export default () => {
       netlify-honeypot="covid-bot-field"
       data-netlify="true"
     >
+      <input type="hidden" name="form-name" value="volunteer" />
       <Input label="Name" type="text" name="name" id="name" isRequired />
 
       <Input


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Fixes missing form name in volunteer form. Fixes #1220
