### PR TITLE
feat: Tableu embeds and footnotes

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -189,7 +189,6 @@ const gatsbyConfig = {
       options: {
         spaceId: process.env.CONTENTFUL_SPACE,
         accessToken: process.env.CONTENTFUL_TOKEN,
-        environment: 'tableau-embed',
       },
     },
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,3 @@
-
 require(`@babel/register`)({
   presets: ['@babel/preset-env', '@babel/preset-react'],
   plugins: ['@babel/plugin-transform-runtime'],
@@ -7,7 +6,8 @@ require('dotenv').config()
 
 const algoliaQueries = require('./src/utilities/algolia').queries
 const sassImports = require('./src/utilities/sass-imports.js')
-const formatStringList = require('./src/components/utils/format').formatStringList
+const formatStringList = require('./src/components/utils/format')
+  .formatStringList
 
 const gatsbyConfig = {
   siteMetadata: {
@@ -189,6 +189,7 @@ const gatsbyConfig = {
       options: {
         spaceId: process.env.CONTENTFUL_SPACE,
         accessToken: process.env.CONTENTFUL_TOKEN,
+        environment: 'tableau-embed',
       },
     },
 
@@ -290,7 +291,6 @@ const gatsbyConfig = {
           {
             serialize: ({ query: { site, allContentfulBlogPost } }) => {
               return allContentfulBlogPost.nodes.map(node => {
-
                 return Object.assign(
                   {},
                   {
@@ -299,7 +299,9 @@ const gatsbyConfig = {
                     date: node.publishDate,
                     url: `${site.siteMetadata.siteUrl}/blog/${node.slug}`,
                     guid: `${site.siteMetadata.siteUrl}/blog/${node.slug}`,
-                    author: formatStringList(node.authors.map(author => author.name))
+                    author: formatStringList(
+                      node.authors.map(author => author.name),
+                    ),
                   },
                 )
               })

--- a/src/components/pages/blog/blog-content.js
+++ b/src/components/pages/blog/blog-content.js
@@ -5,6 +5,7 @@ import LongContent from '~components/common/long-content'
 import CleanSpacing from '~components/utils/clean-spacing'
 import TableContentBlock from './table-content-block'
 import ImageContentBlock from './image-content-block'
+import TableauChart from '~components/charts/tableau'
 import blogContentStyles from './blog-content.module.scss'
 
 export default ({ content, images }) => {
@@ -27,6 +28,20 @@ export default ({ content, images }) => {
         ) {
           return (
             <TableContentBlock table={node.data.target.fields.table['en-US']} />
+          )
+        }
+        if (
+          node.data.target.sys.contentType.sys.contentful_id ===
+          'contentBlockTableauChart'
+        ) {
+          const { url, height, mobileUrl } = node.data.target.fields
+          return (
+            <TableauChart
+              id={node.data.target.sys.contentful_id}
+              viewUrl={url['en-US']}
+              viewUrlMobile={mobileUrl['en-US']}
+              height={height['en-US']}
+            />
           )
         }
         if (

--- a/src/components/pages/blog/blog-footnotes.js
+++ b/src/components/pages/blog/blog-footnotes.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import Container from '~components/common/container'
+import blogFootnotesStyle from './blog-footnotes.module.scss'
+
+export default ({ footnotes }) => (
+  <Container centered>
+    <div
+      id="footnotes"
+      className={blogFootnotesStyle.footnotes}
+      dangerouslySetInnerHTML={{ __html: footnotes }}
+    />
+  </Container>
+)

--- a/src/components/pages/blog/blog-footnotes.module.scss
+++ b/src/components/pages/blog/blog-footnotes.module.scss
@@ -1,0 +1,10 @@
+.footnotes {
+  @include margin(32, top bottom);
+  @include type-size(100);
+  ol {
+    li {
+      list-style-type: decimal;
+      @include margin(8, bottom);
+    }
+  }
+}

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -4,6 +4,7 @@ import Hero from '~components/pages/blog/blog-hero'
 import Layout from '~components/layout'
 import FeaturedImage from '~components/pages/blog/featured-image'
 import BlogPostContent from '~components/pages/blog/blog-content'
+import BlogPostFootnotes from '~components/pages/blog/blog-footnotes'
 import BlogPostExtras from '~components/pages/blog/blog-extras'
 
 export default ({ data, path }) => {
@@ -42,6 +43,14 @@ export default ({ data, path }) => {
         content={blogPost.childContentfulBlogPostBlogContentRichTextNode.json}
         images={blogImages}
       />
+      {blogPost.childContentfulBlogPostFootnotesTextNode && (
+        <BlogPostFootnotes
+          footnotes={
+            blogPost.childContentfulBlogPostFootnotesTextNode
+              .childMarkdownRemark.html
+          }
+        />
+      )}
       <BlogPostExtras blogPost={blogPost} />
     </Layout>
   )


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds support for embedded tableau content blocks
- Adds stubbed-out support for footnotes