### PR TITLE
chore: Handle sizes that keep their native sizes

### DIFF
--- a/src/components/pages/blog/blog-content.js
+++ b/src/components/pages/blog/blog-content.js
@@ -49,12 +49,16 @@ export default ({ content, images }) => {
           node.data.target.sys.contentType.sys.contentful_id ===
           'contentBlockImage'
         ) {
-          const { caption } = node.data.target.fields
+          const { caption, keepSize } = node.data.target.fields
           return (
             <ImageContentBlock
               image={images[node.data.target.sys.contentful_id].image}
               caption={caption}
+              keepSize={keepSize && keepSize['en-US']}
               className={blogContentStyles.image}
+              imageUrl={
+                node.data.target.fields.image['en-US'].fields.file['en-US'].url
+              }
             />
           )
         }

--- a/src/components/pages/blog/image-content-block.js
+++ b/src/components/pages/blog/image-content-block.js
@@ -4,9 +4,19 @@ import Img from 'gatsby-image'
 import ImageCredit from '~components/common/image-credit'
 import imageContentBlockStyles from './image-content-block.module.scss'
 
-export default ({ caption, image, className }) => (
-  <div className={classnames(className, imageContentBlockStyles.image)}>
-    <Img fluid={image.fluid} alt={image.title} />
+export default ({ caption, image, className, keepSize = false, imageUrl }) => (
+  <div
+    className={classnames(
+      className,
+      imageContentBlockStyles.image,
+      keepSize && imageContentBlockStyles.keepSize,
+    )}
+  >
+    {keepSize ? (
+      <img src={imageUrl} alt={image.title} />
+    ) : (
+      <Img fluid={image.fluid} alt={image.title} />
+    )}
     {caption && <ImageCredit>{caption['en-US']}</ImageCredit>}
   </div>
 )

--- a/src/components/pages/blog/image-content-block.module.scss
+++ b/src/components/pages/blog/image-content-block.module.scss
@@ -1,3 +1,9 @@
 .image {
   margin-bottom: spacer(24);
+  &.keep-size {
+    img {
+      width: auto;
+      margin: 0 auto;
+    }
+  }
 }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Adds support for the "Keep regular image size" checkbox in Contentful.