### PR TITLE
fix(anhpi-notes): typo in nhpiDeathCaution

### DIFF
--- a/src/components/pages/race/dashboard/anhpi-notes.js
+++ b/src/components/pages/race/dashboard/anhpi-notes.js
@@ -24,7 +24,7 @@ export default (data, stateNotes) => {
       ? data.nhpiANHPIPosNotes
       : notes.nhpiPos
   }
-  if (data.nhpiIDeathCaution) {
+  if (data.nhpiDeathCaution) {
     notes.nhpiDeath = data.nhpiANHPIDeathNotes
       ? data.nhpiANHPIDeathNotes
       : notes.nhpiDeath


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
