### PR TITLE
chore: Add markdown support to API descriptions

### DIFF
--- a/src/components/pages/data/api/explorer.js
+++ b/src/components/pages/data/api/explorer.js
@@ -5,6 +5,7 @@ import {
   DisclosureButton,
   DisclosurePanel,
 } from '@reach/disclosure'
+import marked from 'marked'
 import DetailText from '~components/common/detail-text'
 import explorerStyles from './explorer.module.scss'
 import definition from '../../../../../_api/v1/openapi.json'
@@ -50,7 +51,13 @@ const Fields = ({ schema }) => {
                 <span className="a11y-only">Field type: </span>
                 {fields[property].type}
               </div>
-              <p>{fields[property].description}</p>
+              {fields[property].description && (
+                <div
+                  dangerouslySetInnerHTML={{
+                    __html: marked(fields[property].description),
+                  }}
+                />
+              )}
 
               {fields[property].type === 'integer' &&
                 fields[property].nullable && (


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds markdown support to descriptions in API
- Part of https://github.com/COVID19Tracking/covid-public-api-build/pull/78