### PR TITLE
fix(design): null when author bio missing

### DIFF
--- a/src/components/pages/blog/author-footer.js
+++ b/src/components/pages/blog/author-footer.js
@@ -3,17 +3,9 @@ import smartypants from 'smartypants'
 import AuthorFooterStyles from './author-footer.module.scss'
 
 export default ({ authors }) => {
-  const footerAuthors = authors.filter(
-    author => author.childContentfulAuthorBiographyTextNode !== null,
-  ) // only keep authors with biographies
-
-  if (footerAuthors.length === 0) {
-    return null
-  }
-
   return (
     <div className={AuthorFooterStyles.container}>
-      {footerAuthors.map(author => (
+      {authors.map(author => (
         <div
           className={AuthorFooterStyles.author}
           key={`author-${author.name}`}

--- a/src/components/pages/blog/author-footer.js
+++ b/src/components/pages/blog/author-footer.js
@@ -7,6 +7,10 @@ export default ({ authors }) => {
     author => author.childContentfulAuthorBiographyTextNode !== null,
   ) // only keep authors with biographies
 
+  if (footerAuthors.length === 0) {
+    return null
+  }
+
   return (
     <div className={AuthorFooterStyles.container}>
       {footerAuthors.map(author => (

--- a/src/components/pages/blog/blog-extras.js
+++ b/src/components/pages/blog/blog-extras.js
@@ -8,7 +8,7 @@ export default ({ blogPost }) => (
   <>
     <hr className={blogExtrasStyles.divider} />
     <div className={blogExtrasStyles.eightColWrapper}>
-      {blogPost.authors.length > 0 && <AuthorFooter authors={blogPost.authors} />}
+      <AuthorFooter authors={blogPost.authors} />
     </div>
     <SectionDivider className={blogExtrasStyles.fullWidth} />
     <div className={blogExtrasStyles.eightColWrapper}>

--- a/src/components/pages/blog/blog-extras.js
+++ b/src/components/pages/blog/blog-extras.js
@@ -8,7 +8,7 @@ export default ({ blogPost }) => (
   <>
     <hr className={blogExtrasStyles.divider} />
     <div className={blogExtrasStyles.eightColWrapper}>
-      <AuthorFooter authors={blogPost.authors} />
+      {blogPost.authors.length > 0 && <AuthorFooter authors={blogPost.authors} />}
     </div>
     <SectionDivider className={blogExtrasStyles.fullWidth} />
     <div className={blogExtrasStyles.eightColWrapper}>

--- a/src/components/pages/blog/blog-extras.js
+++ b/src/components/pages/blog/blog-extras.js
@@ -4,15 +4,25 @@ import SectionDivider from '~components/common/section-divider'
 import AuthorFooter from './author-footer'
 import blogExtrasStyles from './blog-extras.module.scss'
 
-export default ({ blogPost }) => (
-  <>
-    <hr className={blogExtrasStyles.divider} />
-    <div className={blogExtrasStyles.eightColWrapper}>
-      <AuthorFooter authors={blogPost.authors} />
-    </div>
-    <SectionDivider className={blogExtrasStyles.fullWidth} />
-    <div className={blogExtrasStyles.eightColWrapper}>
-      <RelatedPosts blogPost={blogPost} />
-    </div>
-  </>
-)
+export default ({ blogPost }) => {
+  const footerAuthors = blogPost.authors.filter(
+    author => author.childContentfulAuthorBiographyTextNode !== null,
+  ) // only keep authors with biographies
+
+  return (
+    <>
+      {footerAuthors.length > 0 && (
+        <>
+          <hr className={blogExtrasStyles.divider} />
+          <div className={blogExtrasStyles.eightColWrapper}>
+            <AuthorFooter authors={footerAuthors} />
+          </div>
+        </>
+      )}
+      <SectionDivider className={blogExtrasStyles.fullWidth} />
+      <div className={blogExtrasStyles.eightColWrapper}>
+        <RelatedPosts blogPost={blogPost} />
+      </div>
+    </>
+  )
+}


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Fixing #1272 

Returning `null` for the AuthorFooter component when there are no author bios does not remove the hr.

Conditional rendering in BlogPostExtras component would remove hr when there are no biographies.