### PR TITLE
fix: Safari white space above header

### DIFF
--- a/src/components/layout/header/header.module.scss
+++ b/src/components/layout/header/header.module.scss
@@ -255,7 +255,7 @@
     flex-wrap: wrap;
     justify-content: space-between;
     transition: display 150ms;
-    @include margin(24, top);
+    @include padding(24, top);
   }
 
   .return-link {


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Removes a white space above the header in Safari.

![image](https://user-images.githubusercontent.com/270536/88115552-9d5cbe80-cb73-11ea-863d-59246e7187ca.png)
