### PR TITLE
feat: Add /1M label to per cap summary charts y-axis

### DIFF
--- a/src/components/charts/bar-chart.js
+++ b/src/components/charts/bar-chart.js
@@ -33,6 +33,7 @@ const BarChart = ({
   yTicks,
   lastXTick,
   renderTooltipContents,
+  perCapLabel,
 }) => {
   const [tooltip, setTooltip] = useState(null)
   // Used for tooltip optimization
@@ -117,6 +118,8 @@ const BarChart = ({
                   >
                     <text className={chartStyles.label}>
                       {formatNumber(tick)}
+                      {tick > 0 &&
+                        perCapLabel /* this only displays if passed */}
                     </text>
                   </svg>
                   <line
@@ -292,6 +295,7 @@ BarChart.defaultProps = {
   yTicks: 4,
   showTicks: 4,
   renderTooltipContents: null,
+  perCapLabel: null,
 }
 
 BarChart.propTypes = {
@@ -333,5 +337,6 @@ BarChart.propTypes = {
   yMax: PropTypes.number,
   yTicks: PropTypes.number,
   renderTooltipContents: PropTypes.func,
+  perCapLabel: PropTypes.string,
 }
 export default BarChart

--- a/src/components/common/summary-charts.js
+++ b/src/components/common/summary-charts.js
@@ -255,6 +255,11 @@ export default ({ name = 'National', history, usHistory, annotations }) => {
       // eslint-disable-next-line no-restricted-globals
       location.replace('#chart-annotations')
     },
+    ...(usePerCap
+      ? {
+          perCapLabel: usePerCap && '/1M',
+        }
+      : {}),
   }
   return (
     <>

--- a/src/components/common/summary-charts.js
+++ b/src/components/common/summary-charts.js
@@ -257,7 +257,7 @@ export default ({ name = 'National', history, usHistory, annotations }) => {
     },
     ...(usePerCap
       ? {
-          perCapLabel: usePerCap && '/1M',
+          perCapLabel: '/1M',
         }
       : {}),
   }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
closes #1286 

![image](https://user-images.githubusercontent.com/16123225/88339186-98307880-cd07-11ea-988d-4954fe6f1a71.png)
