### PR TITLE
chore: exempt Hawaii from 30 day data requirment on summary charts

### DIFF
--- a/src/components/common/summary-charts.js
+++ b/src/components/common/summary-charts.js
@@ -201,8 +201,10 @@ export default ({ name = 'National', history, usHistory, annotations }) => {
 
     [usHistory, usePerCap, sliceStart, sliceEnd],
   )
-
+  // TODO: These two state exemptions should be removed after they reach 30 days of
+  // hospitalization data. That or we should rethink this requirement. -goleary
   const hasData = field =>
+    name === 'Hawaii' ||
     name === 'Florida' ||
     (data.filter(item => item[field.replace('perCap_', '')] !== null).length >=
       data.length * 0.3 &&


### PR DESCRIPTION
They have 10 days of data as of today and we want to show that despite the 30% out of the last 90 day requirement to display a graph.
