### PR TITLE
chore(crdt-dashboard): Fix less than zero percent display

### DIFF
--- a/src/__tests__/components/pages/race/dashboard/__snapshots__/breakdown-tables.js.snap
+++ b/src/__tests__/components/pages/race/dashboard/__snapshots__/breakdown-tables.js.snap
@@ -132,7 +132,7 @@ exports[`Components : Pages : Race : Dashboard : Ethnicity Table renders correct
         <td
           className="borderLeft"
         >
-          0
+          &lt;1
           %
         </td>
       </tr>

--- a/src/__tests__/components/pages/race/dashboard/__snapshots__/percent.js.snap
+++ b/src/__tests__/components/pages/race/dashboard/__snapshots__/percent.js.snap
@@ -7,7 +7,7 @@ Array [
 ]
 `;
 
-exports[`Components : Race : Dashboard : Percent renders correctly 2`] = `"–"`;
+exports[`Components : Race : Dashboard : Percent renders correctly 2`] = `"-"`;
 
 exports[`Components : Race : Dashboard : Percent renders correctly 3`] = `
 Array [
@@ -18,7 +18,7 @@ Array [
 
 exports[`Components : Race : Dashboard : Percent renders correctly 4`] = `
 Array [
-  "0",
+  "<1",
   "%",
 ]
 `;

--- a/src/components/pages/race/dashboard/percent.js
+++ b/src/components/pages/race/dashboard/percent.js
@@ -2,20 +2,20 @@ import React from 'react'
 import percentStyles from './percent.module.scss'
 
 export default ({ number, highlight }) => {
-  if (number !== null) {
-    let percentage = '0'
-    if (Math.round(number * 100) > 0) {
-      percentage = number * 100 > 1 ? Math.round(number * 100) : '<1'
-    }
-    return (
-      <>
-        {highlight ? (
-          <span className={percentStyles.highlight}>{percentage}%</span>
-        ) : (
-          <>{percentage}%</>
-        )}
-      </>
-    )
+  if (number === null) {
+    return <>-</>
   }
-  return <>–</>
+  let percentage = '0'
+  if (number > 0) {
+    percentage = number * 100 > 1 ? Math.round(number * 100) : '<1'
+  }
+  return (
+    <>
+      {highlight ? (
+        <span className={percentStyles.highlight}>{percentage}%</span>
+      ) : (
+        <>{percentage}%</>
+      )}
+    </>
+  )
 }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Refactors CRDT dashboard percentage display to only display `0%` if there is actually zero percent, instead of zero after rounding.
- Fixes #1305
