### PR TITLE
chore: Change API domain name

### DIFF
--- a/src/components/common/summary-charts.js
+++ b/src/components/common/summary-charts.js
@@ -201,8 +201,9 @@ export default ({ name = 'National', history, usHistory, annotations }) => {
 
     [usHistory, usePerCap, sliceStart, sliceEnd],
   )
-  // TODO: These two state exemptions should be removed after they reach 30 days of
-  // hospitalization data. That or we should rethink this requirement. -goleary
+  // TODO: These two state exemptions should be removed after they
+  // reach 30 days of hospitalization data. That or we should
+  // rethink this requirement. -goleary
   const hasData = field =>
     name === 'Hawaii' ||
     name === 'Florida' ||

--- a/src/components/pages/data/api/explorer.js
+++ b/src/components/pages/data/api/explorer.js
@@ -11,7 +11,7 @@ import explorerStyles from './explorer.module.scss'
 import definition from '../../../../../_api/v1/openapi.json'
 
 const PreviewUrl = ({ path, format, parameters }) => {
-  let examplePath = path.replace('{format}', format)
+  let examplePath = path.replace('{format}', format).replace('/api/', '/')
   parameters.forEach(parameter => {
     if (parameter.name !== 'format') {
       examplePath = examplePath.replace(
@@ -23,12 +23,14 @@ const PreviewUrl = ({ path, format, parameters }) => {
   return (
     <>
       <p className={explorerStyles.pathDescription}>
-        <code>{path.replace('{format}', format)}</code>
+        <code>{path.replace('{format}', format).replace('/api/', '/')}</code>
       </p>
       <p className={explorerStyles.pathDescription}>
         <strong>Example:</strong>{' '}
         <code>
-          <a href={examplePath}>{examplePath}</a>
+          <a
+            href={`https://api.covidtracking.com${examplePath}`}
+          >{`https://api.covidtracking.com${examplePath}`}</a>
         </code>
       </p>
     </>

--- a/src/pages/data/api.js
+++ b/src/pages/data/api.js
@@ -19,6 +19,13 @@ export default ({ data }) => {
           id={data.contentfulSnippet.contentful_id}
         />
       </LongContent>
+      <h2>API domain name</h2>
+      <p>
+        All API requests should be made to:{' '}
+        <strong>
+          <code>https://api.covidtracking.com</code>
+        </strong>
+      </p>
       <ApiExplorer />
     </Layout>
   )


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds a note about the change of the API domain to `api.covidtracking.com`