### PR TITLE
Fixes #1321 - removes media inquiries from contact form dropdown

### DIFF
--- a/src/pages/contact/index.js
+++ b/src/pages/contact/index.js
@@ -14,7 +14,6 @@ const reasons = [
   '-- Select a reason --',
   'I have questions about the state data grades',
   'I have feedback on the COVID Racial Data Tracker',
-  'I’m a journalist with a media question',
   'I want to report an issue with the website or web accessibility',
   'I want to report an issue with your data',
   'Something else!',


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
