### PR TITLE
fix(charts): Fixed yTicks issue at low y-values

### DIFF
--- a/src/components/charts/bar-chart.js
+++ b/src/components/charts/bar-chart.js
@@ -60,13 +60,18 @@ const BarChart = ({
     .domain(dateDomain)
     .range([marginLeft, width - marginRight])
 
+  const yMaxEffective =
+    yMax || max([...data, ...(refLineData || [])], d => d.value)
+
   const yScale = scaleLinear()
-    .domain([0, yMax || max([...data, ...(refLineData || [])], d => d.value)])
+    .domain([0, yMaxEffective])
     .nice()
     .range([height - totalYMargin, 0])
 
   const xTickAmount = timeMonth.every(1)
-
+  const yTicksThreshold = 4
+  const yTicksEffective =
+    yTicks || yMaxEffective < yTicksThreshold ? yMaxEffective : yTicksThreshold
   const lastTime = xScaleTime.ticks(timeDay.every(1)).pop()
 
   let lineFn = null
@@ -106,7 +111,7 @@ const BarChart = ({
       >
         {/* y ticks */}
         <g transform={`translate(${marginLeft} ${marginTop})`}>
-          {yScale.ticks(yTicks).map(
+          {yScale.ticks(yTicksEffective).map(
             (tick, i) =>
               i < showTicks && (
                 <g key={tick}>
@@ -292,7 +297,7 @@ BarChart.defaultProps = {
   width: 300,
   height: 300,
   yMax: null,
-  yTicks: 4,
+  yTicks: null,
   showTicks: 4,
   renderTooltipContents: null,
   perCapLabel: null,


### PR DESCRIPTION
fix for issue #1293
-if maximum y-value is less than 4, the same number of corresponding y-ticks will be displayed

-changed default value of yTIcks to null to allow a specified yTicks argument to override code logic
