### PR TITLE
fix(summary-charts): stop exempting Florida from data reqs

### DIFF
--- a/src/components/common/summary-charts.js
+++ b/src/components/common/summary-charts.js
@@ -206,7 +206,6 @@ export default ({ name = 'National', history, usHistory, annotations }) => {
   // rethink this requirement. -goleary
   const hasData = field =>
     name === 'Hawaii' ||
-    name === 'Florida' ||
     (data.filter(item => item[field.replace('perCap_', '')] !== null).length >=
       data.length * 0.3 &&
       data.filter(item => item[field.replace('perCap_', '')] > 0).length > 0)


### PR DESCRIPTION
This shouldn't change anything since FL has now been reporting hosp data for 30 days (:tada:), but it'll clean up the code a bit.

Fixes #1330
