### PR TITLE
fix(blog): remove on hover underline for blog authors without links

### DIFF
--- a/src/components/pages/blog/byline.module.scss
+++ b/src/components/pages/blog/byline.module.scss
@@ -51,6 +51,8 @@
       &:focus {
         @include link-focus-dark-bg;
       }
+    }
+    a.author-inner {
       &:hover {
         @include link-hover-dark-bg;
       }


### PR DESCRIPTION
Fixes #1340 