### PR TITLE
chore: Use encounters for RI

### DIFF
--- a/src/components/common/summary-table.js
+++ b/src/components/common/summary-table.js
@@ -132,7 +132,9 @@ export default ({
       columns: [
         {
           header:
-            data.state === 'CO' ? 'Test encounters' : 'Positive + Negative',
+            ['CO', 'RI'].indexOf(data.state) > -1
+              ? 'Test encounters'
+              : 'Positive + Negative',
           data: data.totalTestResults,
           wide: true,
         },


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Change RI to use total test encounters