### PR TITLE
Chore: remove hard-wired redirects

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,25 +1,3 @@
-
-/api/states/info.csv                          https://api.covidtracking.com/v1/states/info.csv
-/api/states/daily.csv                         https://api.covidtracking.com/v1/states/daily.csv
-/api/states.csv                               https://api.covidtracking.com/v1/states/current.csv
-/api/us.csv                                   https://api.covidtracking.com/v1/us/current.csv
-/api/us/daily.csv                             https://api.covidtracking.com/v1/us/daily.csv
-/api/states/daily state=:state date=:date     https://api.covidtracking.com/v1/states/:state/:date.json
-/api/statesdaily state=:state date=:date      https://api.covidtracking.com/v1/states/:state/:date.json
-/api/states state=:state                      https://api.covidtracking.com/v1/states/:state/current.json
-/api/us date=:date                            https://api.covidtracking.com/v1/us/:date.json
-/api/us/daily date=:date                      https://api.covidtracking.com/v1/us/:date.json
-/api/v1/us.json                               https://api.covidtracking.com/v1/us/current.json
-/api/v1/states.json                           https://api.covidtracking.com/v1/states/current.json
-/api/states/info                              https://api.covidtracking.com/v1/states/info.json
-/api/states/daily                             https://api.covidtracking.com/v1/states/daily.json
-/api/states.json                              https://api.covidtracking.com/v1/states/current.json
-/api/states                                   https://api.covidtracking.com/v1/states/current.json
-/api/us                                       https://api.covidtracking.com/v1/us/current.json
-/api/us.csv                                   https://api.covidtracking.com/v1/us/current.csv
-/api/us/daily                                 https://api.covidtracking.com/v1/us/daily.json
-/api/v1/*                                     https://api.covidtracking.com/v1/:splat
-
 /screenshots/*                                https://covid-tracking-project-data.s3.us-east-1.amazonaws.com/state_screenshots/:splat 200
 /best-practices                               https://docs.google.com/document/d/1OyN6_1UeDePwPwKi6UKZB8GwNC7-kSf1-BO2af8kqVA/edit
 /sheets                                       https://docs.google.com/spreadsheets/u/2/d/e/2PACX-1vRwAqp96T9sYYq2-i7Tj0pvTf6XVHjDSMIKBdZHXiCGGdNC0ypEU9NbngS8mxea55JuCFuua1MUeOj5/pubhtml


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Removes redirects in static file for API