### PR TITLE
feat: Add table of contents

### DIFF
--- a/src/__tests__/components/common/__snapshots__/table-of-contents.js.snap
+++ b/src/__tests__/components/common/__snapshots__/table-of-contents.js.snap
@@ -1,22 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Components : Common: Table of Contents renders correctly 1`] = `
-<ul
+<div
   className="tableOfContents"
 >
-  <li>
-    <a
-      href="#a"
-    >
-      A
-    </a>
-  </li>
-  <li>
-    <a
-      href="#b"
-    >
-      B
-    </a>
-  </li>
-</ul>
+  <h2>
+    Table of contents
+  </h2>
+  <ul>
+    <li>
+      <a
+        href="#a"
+      >
+        A
+      </a>
+    </li>
+    <li>
+      <a
+        href="#b"
+      >
+        B
+      </a>
+    </li>
+  </ul>
+</div>
 `;

--- a/src/__tests__/components/common/__snapshots__/table-of-contents.js.snap
+++ b/src/__tests__/components/common/__snapshots__/table-of-contents.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Components : Common: Table of Contents renders correctly 1`] = `
+<ul
+  className="tableOfContents"
+>
+  <li>
+    <a
+      href="#a"
+    >
+      A
+    </a>
+  </li>
+  <li>
+    <a
+      href="#b"
+    >
+      B
+    </a>
+  </li>
+</ul>
+`;

--- a/src/__tests__/components/common/table-of-contents.js
+++ b/src/__tests__/components/common/table-of-contents.js
@@ -1,0 +1,19 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import TableOfContents from '~components/common/table-of-contents'
+
+describe('Components : Common: Table of Contents', () => {
+  it('renders correctly', () => {
+    const tree = renderer
+      .create(
+        <TableOfContents
+          headings={[
+            { id: 'a', value: 'A' },
+            { id: 'b', value: 'B' },
+          ]}
+        />,
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/common/table-of-contents.js
+++ b/src/components/common/table-of-contents.js
@@ -1,7 +1,8 @@
 import React from 'react'
+import tocStyle from './table-of-contents.module.scss'
 
 export default ({ headings }) => (
-  <ul>
+  <ul className={tocStyle.tableOfContents}>
     {headings.map(heading => (
       <li key={`toc-${heading.id}`}>
         <a href={`#${heading.id}`}>{heading.value}</a>

--- a/src/components/common/table-of-contents.js
+++ b/src/components/common/table-of-contents.js
@@ -1,0 +1,11 @@
+import React from 'react'
+
+export default ({ headings }) => (
+  <ul>
+    {headings.map(heading => (
+      <li key={`toc-${heading.id}`}>
+        <a href={`#${heading.id}`}>{heading.value}</a>
+      </li>
+    ))}
+  </ul>
+)

--- a/src/components/common/table-of-contents.js
+++ b/src/components/common/table-of-contents.js
@@ -2,11 +2,14 @@ import React from 'react'
 import tocStyle from './table-of-contents.module.scss'
 
 export default ({ headings }) => (
-  <ul className={tocStyle.tableOfContents}>
-    {headings.map(heading => (
-      <li key={`toc-${heading.id}`}>
-        <a href={`#${heading.id}`}>{heading.value}</a>
-      </li>
-    ))}
-  </ul>
+  <div className={tocStyle.tableOfContents}>
+    <h2>Table of contents</h2>
+    <ul>
+      {headings.map(heading => (
+        <li key={`toc-${heading.id}`}>
+          <a href={`#${heading.id}`}>{heading.value}</a>
+        </li>
+      ))}
+    </ul>
+  </div>
 )

--- a/src/components/common/table-of-contents.module.scss
+++ b/src/components/common/table-of-contents.module.scss
@@ -1,0 +1,8 @@
+.table-of-contents {
+  list-style-type: none;
+  @include margin(32, bottom);
+  padding-left: 0;
+  li {
+    @include margin(16, bottom);
+  }
+}

--- a/src/components/common/table-of-contents.module.scss
+++ b/src/components/common/table-of-contents.module.scss
@@ -8,8 +8,12 @@
   ul {
     list-style-type: none;
     padding-left: 0;
+    margin-bottom: 0;
     li {
       @include margin(16, bottom);
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
   }
 }

--- a/src/components/common/table-of-contents.module.scss
+++ b/src/components/common/table-of-contents.module.scss
@@ -1,8 +1,15 @@
 .table-of-contents {
-  list-style-type: none;
   @include margin(32, bottom);
-  padding-left: 0;
-  li {
-    @include margin(16, bottom);
+  @include padding(32);
+  background: $color-plum-100;
+  h2 {
+    margin: 0;
+  }
+  ul {
+    list-style-type: none;
+    padding-left: 0;
+    li {
+      @include margin(16, bottom);
+    }
   }
 }

--- a/src/templates/content.js
+++ b/src/templates/content.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { graphql } from 'gatsby'
 import ContentfulContent from '~components/common/contentful-content'
+import TableOfContents from '~components/common/table-of-contents'
 import LongContent from '~components/common/long-content'
 import Layout from '~components/layout'
 
@@ -15,6 +16,12 @@ const ContentPage = ({ data, path }) => {
       socialCard={contentfulPage.socialCard}
       centered
     >
+      {contentfulPage.enableToc &&
+        contentfulPage.body.childMarkdownRemark.headings && (
+          <TableOfContents
+            headings={contentfulPage.body.childMarkdownRemark.headings}
+          />
+        )}
       <LongContent>
         <ContentfulContent
           id={contentfulPage.contentful_id}
@@ -35,9 +42,14 @@ export const query = graphql`
       contentful_id
       returnLinkTitle
       returnLinkUrl
+      enableToc
       body {
         childMarkdownRemark {
           html
+          headings(depth: h2) {
+            id
+            value
+          }
         }
       }
       socialCard {


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Uses an `enableToc` field in Contentful to turn on a table of contents
- Creates a simple TOC on the top of the page with links to `h2` headings
- Fixes #1337 