### PR TITLE
chore: Add fathom to track CRDT downloads

### DIFF
--- a/src/__tests__/components/pages/race/__snapshots__/cta-links.js.snap
+++ b/src/__tests__/components/pages/race/__snapshots__/cta-links.js.snap
@@ -20,6 +20,7 @@ exports[`Components : Race : CTA Links renders correctly 1`] = `
   <a
     className="cta centered"
     href="https://docs.google.com/spreadsheets/d/e/2PACX-1vR_xmYt4ACPDZCDJcY12kCiMiH0ODyx3E1ZvgOHB8ae1tRcjXbs_yWBOA4j4uoCEADVfC1PS2jYO68B/pub?gid=43720681&single=true&output=csv"
+    onClick={[Function]}
   >
     Get the complete dataset (CSV)
     <span

--- a/src/components/common/landing-page/call-to-action.js
+++ b/src/components/common/landing-page/call-to-action.js
@@ -24,7 +24,13 @@ const CtaLink = ({ to, children, centered = false, bold = false }) => (
   </Link>
 )
 
-const CtaAnchorLink = ({ href, children, centered = false, bold = false }) => (
+const CtaAnchorLink = ({
+  href,
+  children,
+  onClick,
+  centered = false,
+  bold = false,
+}) => (
   <a
     href={href}
     className={classnames(
@@ -32,6 +38,7 @@ const CtaAnchorLink = ({ href, children, centered = false, bold = false }) => (
       centered && ctaLinkStyle.centered,
       bold && ctaLinkStyle.bold,
     )}
+    onClick={onClick}
   >
     {children}
     <Arrow />

--- a/src/components/pages/race/cta-links.js
+++ b/src/components/pages/race/cta-links.js
@@ -13,6 +13,11 @@ export default () => (
     <CtaAnchorLink
       centered
       href="https://docs.google.com/spreadsheets/d/e/2PACX-1vR_xmYt4ACPDZCDJcY12kCiMiH0ODyx3E1ZvgOHB8ae1tRcjXbs_yWBOA4j4uoCEADVfC1PS2jYO68B/pub?gid=43720681&single=true&output=csv"
+      onClick={() => {
+        if (typeof window.fathom !== 'undefined') {
+          window.fathom.trackGoal('Y2UISYEJ', 0)
+        }
+      }}
     >
       Get the complete dataset (CSV)
     </CtaAnchorLink>


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Adds fathom Goal to CRDT download link.