### PR TITLE
chore(a11y): Fix color contrast, header depth

### DIFF
--- a/src/components/common/last-updated.module.scss
+++ b/src/components/common/last-updated.module.scss
@@ -1,3 +1,3 @@
 .last-updated {
-  color: $color-slate-500;
+  color: $color-slate-600;
 }

--- a/src/components/pages/data/summary-charts.js
+++ b/src/components/pages/data/summary-charts.js
@@ -286,6 +286,7 @@ export default ({
   return (
     <>
       <div className={styles.infoLine}>
+        <h2 className="a11y-only">Summary charts</h2>
         <div className={styles.toggleContainer}>
           {usHistory && (
             <Toggle
@@ -305,9 +306,9 @@ export default ({
           <LegendComponent name={name || 'National'} />
         </div>
       </div>
-      <Row>
+      <Row className={styles.summaryCharts}>
         <Col {...colProps}>
-          <h5 className={styles.testHeading}>
+          <h3 className={styles.testHeading}>
             New tests{' '}
             <AnnotationIndicator
               annotations={annotations}
@@ -318,7 +319,7 @@ export default ({
               openDisclosure={() => setDisclosureOpen(true)}
             />
             <TestFieldIndicator field={testSource} />
-          </h5>
+          </h3>
           <BarChart
             data={getDataForField(data, testField)}
             lineData={dailyAverage(data, testField)}
@@ -331,7 +332,7 @@ export default ({
           />
         </Col>
         <Col {...colProps}>
-          <h5>
+          <h3>
             New cases{' '}
             <AnnotationIndicator
               annotations={annotations}
@@ -339,7 +340,7 @@ export default ({
               openDisclosure={() => setDisclosureOpen(true)}
             />
             <CalculatedIndicator />
-          </h5>
+          </h3>
           {hasData(positiveField) ? (
             <BarChart
               data={getDataForField(data, positiveField)}
@@ -356,14 +357,14 @@ export default ({
           )}
         </Col>
         <Col {...colProps}>
-          <h5>
+          <h3>
             Current hospitalizations{' '}
             <AnnotationIndicator
               annotations={annotations}
               dataElement="hospitalizations"
               openDisclosure={() => setDisclosureOpen(true)}
             />
-          </h5>
+          </h3>
 
           {hasData(hospitalizedField) ? (
             <BarChart
@@ -386,7 +387,7 @@ export default ({
           )}
         </Col>
         <Col {...colProps}>
-          <h5>
+          <h3>
             New deaths{' '}
             <AnnotationIndicator
               annotations={annotations}
@@ -394,7 +395,7 @@ export default ({
               openDisclosure={() => setDisclosureOpen(true)}
             />
             <CalculatedIndicator />
-          </h5>
+          </h3>
           {hasData(deathField) ? (
             <BarChart
               data={getDataForField(data, deathField)}

--- a/src/components/pages/data/summary-charts.module.scss
+++ b/src/components/pages/data/summary-charts.module.scss
@@ -43,6 +43,16 @@
   }
 }
 
+.summary-charts {
+  h3 {
+    @include type-size(300);
+    @include margin(32, top bottom);
+    &.test-heading {
+      @include margin(16, bottom);
+    }
+  }
+}
+
 .alert-infobox-container {
   height: 286px;
   width: 272px;
@@ -126,8 +136,4 @@
   @include type-size(100);
   margin: 0;
   display: block;
-}
-
-.test-heading {
-  @include margin(8, bottom);
 }

--- a/src/components/pages/state/download-data.js
+++ b/src/components/pages/state/download-data.js
@@ -9,7 +9,7 @@ import downloadDataStyles from './download-data.module.scss'
 const DownloadData = ({ slug, hideLabel = false }) => (
   <div className={downloadDataStyles.container}>
     {!hideLabel && (
-      <h3 className={downloadDataStyles.header}>Get the data as:</h3>
+      <h2 className={downloadDataStyles.header}>Get the data as:</h2>
     )}
     <p>
       <a

--- a/src/components/pages/state/preamble.js
+++ b/src/components/pages/state/preamble.js
@@ -40,10 +40,11 @@ export default ({ state, covidState }) => {
   // todo make state grade wrap as a circle with the grade description
   return (
     <div className={preambleStyle.wrapper}>
+      <h2 className="a11y-only">State overview</h2>
       <Row>
         <Col width={[4, 3, 6]}>
           <div className={preambleStyle.largeDisclosure}>
-            <h4 className={preambleStyle.header}>Where this data comes from</h4>
+            <h3 className={preambleStyle.header}>Where this data comes from</h3>
             <StateLinks
               twitter={state.twitter}
               covid19Site={state.covid19Site}
@@ -55,7 +56,7 @@ export default ({ state, covidState }) => {
           </div>
         </Col>
         <Col width={[4, 3, 6]}>
-          <h4 className={preambleStyle.header}>Current data quality grade</h4>
+          <h3 className={preambleStyle.header}>Current data quality grade</h3>
           <div className={preambleStyle.gradeWrapper}>
             <div
               className={preambleStyle.gradeDescription}
@@ -79,7 +80,7 @@ export default ({ state, covidState }) => {
               onChange={() => setDownloadDataIsOpen(!downloadDataIsOpen)}
             >
               <DisclosureButton className={preambleStyle.button}>
-                <h4
+                <h3
                   className={classnames(
                     preambleStyle.header,
                     preambleStyle.hiddenHeader,
@@ -89,7 +90,7 @@ export default ({ state, covidState }) => {
                   <span className={preambleStyle.toggle}>
                     {downloadDataIsOpen ? <>&#8593;</> : <>&#8595;</>}
                   </span>
-                </h4>
+                </h3>
               </DisclosureButton>
               <DisclosurePanel>
                 <DownloadData state={state} hideLabel />

--- a/src/components/pages/state/preamble.module.scss
+++ b/src/components/pages/state/preamble.module.scss
@@ -29,6 +29,9 @@
   border: 1px solid $color-slate-200;
   border-radius: 4px;
   @include padding(16);
+  h4 {
+    @include type-size(300);
+  }
 }
 
 .button {


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fix header order of state preamble
- Fix header order of summary charts
- Darken the last update component to meet color contrast requirements