### PR TITLE
chore: Add US historical CSV data to National page

### DIFF
--- a/src/pages/data/national/index.js
+++ b/src/pages/data/national/index.js
@@ -4,6 +4,7 @@ import ContentfulContent from '~components/common/contentful-content'
 import Layout from '~components/layout'
 import { FormatDate, FormatNumber } from '~components/utils/format'
 import TableResponsive from '~components/common/table-responsive'
+import { DownloadData } from '~components/pages/state/download-data'
 
 const formatNumber = number => <FormatNumber number={number} />
 
@@ -23,6 +24,7 @@ const ContentPage = ({ data }) => (
       }
       id={data.contentfulSnippet.contentful_id}
     />
+    <DownloadData slug="national" />
 
     <TableResponsive
       labels={[

--- a/src/utilities/csv.js
+++ b/src/utilities/csv.js
@@ -76,6 +76,28 @@ module.exports = (graphql, reporter) => {
               totalTestsViralIncrease
             }
           }
+          allCovidUsDaily(sort: { fields: date, order: DESC }) {
+            nodes {
+              date
+              death
+              inIcuCumulative
+              inIcuCurrently
+              hospitalizedIncrease
+              hospitalizedCurrently
+              hospitalizedCumulative
+              negative
+              negativeIncrease
+              onVentilatorCumulative
+              onVentilatorCurrently
+              posNeg
+              positive
+              positiveIncrease
+              recovered
+              states
+              totalTestResults
+              totalTestResultsIncrease
+            }
+          }
         }
       `)
         .then(result => {
@@ -103,6 +125,11 @@ module.exports = (graphql, reporter) => {
           fs.outputFileSync(
             './public/data/download/all-states-history.csv',
             parse(data.allCovidStateDaily.nodes),
+          )
+
+          fs.outputFileSync(
+            './public/data/download/national-history.csv',
+            parse(data.allCovidUsDaily.nodes),
           )
 
           reporter.success(`Saved state CSV files`)


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds a US national daily CSV file
- Adds links to that file, the API, and spreadsheet to the national history page
- Fixes #1368 