### PR TITLE
chore: Add LTC death charts

### DIFF
--- a/src/components/pages/data/ltc/download-links.js
+++ b/src/components/pages/data/ltc/download-links.js
@@ -5,7 +5,7 @@ import linksStyle from './download-links.module.scss'
 export default () => (
   <div className={linksStyle.links}>
     <CtaAnchorLink
-      href="https://docs.google.com/spreadsheets/d/e/2PACX-1vRa9HnmEl83YXHfbgSPpt0fJe4SyuYLc0GuBAglF4yMYaoKSPRCyXASaWXMrTu1WEYp1oeJZIYHpj7t/pub?gid=1274701484&single=true&output=csv"
+      href="https://docs.google.com/spreadsheets/d/e/2PACX-1vRa9HnmEl83YXHfbgSPpt0fJe4SyuYLc0GuBAglF4yMYaoKSPRCyXASaWXMrTu1WEYp1oeJZIYHpj7t/pub?gid=827060758&single=true&output=csv"
       bold
       centered
     >

--- a/src/pages/data/longtermcare.js
+++ b/src/pages/data/longtermcare.js
@@ -91,7 +91,7 @@ export default ({ data }) => (
     <Container centered>
       <LongContent>
         <ContentfulContent
-          id={data.content2.contentful_id}
+          id={data.timechartNotes.contentful_id}
           content={
             data.timechartNotes.childContentfulSnippetContentTextNode
               .childMarkdownRemark.html
@@ -106,6 +106,17 @@ export default ({ data }) => (
       viewUrl="https://public.tableau.com/views/WebsiteCharts-CTPLong-TermCare/deathsbydate?:language=en&:display_count=y&:origin=viz_share_link"
       viewUrlMobile="https://public.tableau.com/views/WebsiteCharts-CTPLong-TermCare/deathsbydate?:language=en&:display_count=y&:origin=viz_share_link"
     />
+    <Container centered>
+      <LongContent>
+        <ContentfulContent
+          id={data.contentDefinitions.contentful_id}
+          content={
+            data.contentDefinitions.childContentfulSnippetContentTextNode
+              .childMarkdownRemark.html
+          }
+        />
+      </LongContent>
+    </Container>
     <Container>
       <DetailText small>
         <ContentfulContent
@@ -166,6 +177,14 @@ export const query = graphql`
       }
     }
     contentThanks: contentfulSnippet(slug: { eq: "ltc-thanks" }) {
+      contentful_id
+      childContentfulSnippetContentTextNode {
+        childMarkdownRemark {
+          html
+        }
+      }
+    }
+    contentDefinitions: contentfulSnippet(slug: { eq: "ltc-definitions" }) {
       contentful_id
       childContentfulSnippetContentTextNode {
         childMarkdownRemark {

--- a/src/pages/data/longtermcare.js
+++ b/src/pages/data/longtermcare.js
@@ -120,7 +120,7 @@ export default ({ data }) => (
         />
       </LongContent>
     </Container>
-    <Container>
+    <Container centered>
       <DetailText small>
         <ContentfulContent
           id={data.noteTable.contentful_id}

--- a/src/pages/data/longtermcare.js
+++ b/src/pages/data/longtermcare.js
@@ -87,6 +87,26 @@ export default ({ data }) => (
           }
         />
       </LongContent>
+    </Container>
+    <Container centered>
+      <LongContent>
+        <ContentfulContent
+          id={data.content2.contentful_id}
+          content={
+            data.timechartNotes.childContentfulSnippetContentTextNode
+              .childMarkdownRemark.html
+          }
+        />
+      </LongContent>
+    </Container>
+    <TableauChart
+      id="ltc-1"
+      height={550}
+      mobileHeight={450}
+      viewUrl="https://public.tableau.com/views/WebsiteCharts-CTPLong-TermCare/deathsbydate?:language=en&:display_count=y&:origin=viz_share_link"
+      viewUrlMobile="https://public.tableau.com/views/WebsiteCharts-CTPLong-TermCare/deathsbydate?:language=en&:display_count=y&:origin=viz_share_link"
+    />
+    <Container>
       <DetailText small>
         <ContentfulContent
           id={data.noteTable.contentful_id}
@@ -154,6 +174,14 @@ export const query = graphql`
       }
     }
     noteTopLine: contentfulSnippet(slug: { eq: "ltc-top-notes" }) {
+      contentful_id
+      childContentfulSnippetContentTextNode {
+        childMarkdownRemark {
+          html
+        }
+      }
+    }
+    timechartNotes: contentfulSnippet(slug: { eq: "ltc-timechart-notes" }) {
       contentful_id
       childContentfulSnippetContentTextNode {
         childMarkdownRemark {

--- a/src/pages/data/longtermcare.js
+++ b/src/pages/data/longtermcare.js
@@ -90,13 +90,16 @@ export default ({ data }) => (
     </Container>
     <Container centered>
       <LongContent>
-        <ContentfulContent
-          id={data.timechartNotes.contentful_id}
-          content={
-            data.timechartNotes.childContentfulSnippetContentTextNode
-              .childMarkdownRemark.html
-          }
-        />
+        <h2>Deaths in Long-Term Care Facilities by Region</h2>
+        <DetailText small>
+          <ContentfulContent
+            id={data.timechartNotes.contentful_id}
+            content={
+              data.timechartNotes.childContentfulSnippetContentTextNode
+                .childMarkdownRemark.html
+            }
+          />
+        </DetailText>
       </LongContent>
     </Container>
     <TableauChart


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds new snippet
- Adds new chart
- Changes URL for downloading dataset