### PR TITLE
chore: Add deathIncrease column

### DIFF
--- a/src/utilities/csv.js
+++ b/src/utilities/csv.js
@@ -80,6 +80,7 @@ module.exports = (graphql, reporter) => {
             nodes {
               date
               death
+              deathIncrease
               inIcuCumulative
               inIcuCurrently
               hospitalizedIncrease


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Adds `deathIncrease` to national CSV download.