### PR TITLE
chore: Remove US daily average from test chart

### DIFF
--- a/src/components/pages/data/summary-charts.js
+++ b/src/components/pages/data/summary-charts.js
@@ -323,7 +323,6 @@ export default ({
           <BarChart
             data={getDataForField(data, testField)}
             lineData={dailyAverage(data, testField)}
-            refLineData={dailyAverage(usData, testField)}
             fill={colors.colorPlum200}
             lineColor={colors.colorPlum700}
             annotations={splitAnnotations.tests}


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Removes comparison of state tests to US tests by 1M because they are mixing units.
