### PR TITLE
feat: Add definitions to national sub-pages

### DIFF
--- a/src/pages/data/national/cases.js
+++ b/src/pages/data/national/cases.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import TableResponsive from '~components/common/table-responsive'
 import { FormatDate, FormatNumber } from '~components/utils/format'
+import Definitions from '~components/pages/data/definitions'
 import Layout from '~components/layout'
 
 const formatNumber = number => <FormatNumber number={number} />
@@ -18,7 +19,7 @@ export default ({ data }) => {
         { link: `/data/national`, title: 'Totals for the US' },
       ]}
     >
-      <p>Cases</p>
+      <Definitions definitions={data.allContentfulDataDefinition.nodes} />
       <TableResponsive
         labels={[
           {
@@ -51,6 +52,19 @@ export const query = graphql`
         date
         positive
         positiveIncrease
+      }
+    }
+    allContentfulDataDefinition(
+      filter: { fieldName: { in: ["positive", "positiveIncrease"] } }
+    ) {
+      nodes {
+        name
+        fieldName
+        childContentfulDataDefinitionDefinitionTextNode {
+          childMarkdownRemark {
+            html
+          }
+        }
       }
     }
   }

--- a/src/pages/data/national/hospitalization.js
+++ b/src/pages/data/national/hospitalization.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import TableResponsive from '~components/common/table-responsive'
 import { FormatDate, FormatNumber } from '~components/utils/format'
+import Definitions from '~components/pages/data/definitions'
 import Layout from '~components/layout'
 
 const formatNumber = number => <FormatNumber number={number} />
@@ -18,7 +19,7 @@ export default ({ data }) => {
         { link: `/data/national`, title: 'Totals for the US' },
       ]}
     >
-      <p>Hospitalization</p>
+      <Definitions definitions={data.allContentfulDataDefinition.nodes} />
       <TableResponsive
         labels={[
           {
@@ -80,6 +81,31 @@ export const query = graphql`
         inIcuCurrently
         onVentilatorCumulative
         onVentilatorCurrently
+      }
+    }
+    allContentfulDataDefinition(
+      sort: { fields: name }
+      filter: {
+        fieldName: {
+          in: [
+            "hospitalizedCumulative"
+            "hospitalizedCurrently"
+            "inIcuCurrently"
+            "inIcuCumulative"
+            "onVentilatorCumulative"
+            "onVentilatorCurrently"
+          ]
+        }
+      }
+    ) {
+      nodes {
+        name
+        fieldName
+        childContentfulDataDefinitionDefinitionTextNode {
+          childMarkdownRemark {
+            html
+          }
+        }
       }
     }
   }

--- a/src/pages/data/national/index.js
+++ b/src/pages/data/national/index.js
@@ -4,6 +4,7 @@ import ContentfulContent from '~components/common/contentful-content'
 import Layout from '~components/layout'
 import { FormatDate, FormatNumber } from '~components/utils/format'
 import TableResponsive from '~components/common/table-responsive'
+import Definitions from '~components/pages/data/definitions'
 import { DownloadData } from '~components/pages/state/download-data'
 
 const formatNumber = number => <FormatNumber number={number} />
@@ -26,6 +27,7 @@ const ContentPage = ({ data }) => (
     />
     <DownloadData slug="national" />
 
+    <Definitions definitions={data.allContentfulDataDefinition.nodes} />
     <TableResponsive
       labels={[
         {
@@ -37,14 +39,14 @@ const ContentPage = ({ data }) => (
           label: 'State (or territory)',
           format: formatNumber,
         },
-        { field: 'totalTestResultsIncrease' },
-        { field: 'positive' },
-        { field: 'negative' },
-        { field: 'hospitalized' },
-        { field: 'hospitalizedCurrently' },
-        { field: 'death' },
-        { field: 'recovered' },
-        { field: 'totalTestResults' },
+        { field: 'totalTestResultsIncrease', format: formatNumber },
+        { field: 'positive', format: formatNumber },
+        { field: 'negative', format: formatNumber },
+        { field: 'hospitalizedCumulative', format: formatNumber },
+        { field: 'hospitalizedCurrently', format: formatNumber },
+        { field: 'death', format: formatNumber },
+        { field: 'recovered', format: formatNumber },
+        { field: 'totalTestResults', format: formatNumber },
       ]}
       data={data.allCovidUsDaily.nodes}
     />
@@ -72,10 +74,36 @@ export const query = graphql`
         positive
         pending
         negative
-        hospitalized
+        hospitalizedCumulative
         death
         date
         recovered
+      }
+    }
+    allContentfulDataDefinition(
+      sort: { fields: name }
+      filter: {
+        fieldName: {
+          in: [
+            "states"
+            "totalTestResultsIncrease"
+            "positive"
+            "negative"
+            "totalTestResults"
+            "hospitalizedCurrently"
+            "recovered"
+          ]
+        }
+      }
+    ) {
+      nodes {
+        name
+        fieldName
+        childContentfulDataDefinitionDefinitionTextNode {
+          childMarkdownRemark {
+            html
+          }
+        }
       }
     }
   }

--- a/src/pages/data/national/index.js
+++ b/src/pages/data/national/index.js
@@ -33,6 +33,7 @@ const ContentPage = ({ data }) => (
         {
           field: 'date',
           format: date => <FormatDate date={date} format="ccc LLL d yyyy" />,
+          noWrap: true,
         },
         {
           field: 'states',

--- a/src/pages/data/national/outcomes.js
+++ b/src/pages/data/national/outcomes.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import TableResponsive from '~components/common/table-responsive'
 import { FormatDate, FormatNumber } from '~components/utils/format'
+import Definitions from '~components/pages/data/definitions'
 import Layout from '~components/layout'
 
 const formatNumber = number => <FormatNumber number={number} />
@@ -18,7 +19,7 @@ export default ({ data }) => {
         { link: `/data/national`, title: 'Totals for the US' },
       ]}
     >
-      <p>Outcomes</p>
+      <Definitions definitions={data.allContentfulDataDefinition.nodes} />
       <TableResponsive
         labels={[
           {
@@ -56,6 +57,20 @@ export const query = graphql`
         death
         deathIncrease
         recovered
+      }
+    }
+    allContentfulDataDefinition(
+      sort: { fields: name }
+      filter: { fieldName: { in: ["recovered", "death"] } }
+    ) {
+      nodes {
+        name
+        fieldName
+        childContentfulDataDefinitionDefinitionTextNode {
+          childMarkdownRemark {
+            html
+          }
+        }
       }
     }
   }

--- a/src/pages/data/national/tests.js
+++ b/src/pages/data/national/tests.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import TableResponsive from '~components/common/table-responsive'
 import { FormatDate, FormatNumber } from '~components/utils/format'
+import Definitions from '~components/pages/data/definitions'
 import Layout from '~components/layout'
 
 const formatNumber = number => <FormatNumber number={number} />
@@ -17,7 +18,7 @@ export default ({ data }) => (
       { link: `/data/national`, title: 'Totals for the US' },
     ]}
   >
-    <p>Testing</p>
+    <Definitions definitions={data.allContentfulDataDefinition.nodes} />
     <TableResponsive
       labels={[
         {
@@ -67,6 +68,21 @@ export const query = graphql`
         positiveIncrease
         totalTestResults
         totalTestResultsIncrease
+      }
+    }
+    allContentfulDataDefinition(
+      filter: {
+        fieldName: { in: ["positive", "negative", "totalTestResults"] }
+      }
+    ) {
+      nodes {
+        fieldName
+        name
+        childContentfulDataDefinitionDefinitionTextNode {
+          childMarkdownRemark {
+            html
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds definitions to national history subpages
- Fixes formatting of US totals page