### PR TITLE
chore: Refactor responsive table

### DIFF
--- a/src/components/common/table-responsive.js
+++ b/src/components/common/table-responsive.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 import { FieldName } from '~components/utils/field-name'
+import { FormatNumber } from '~components/utils/format'
 import tableStyles from './table.module.scss'
 import tableResponsiveStyles from './table-responsive.module.scss'
 
@@ -16,13 +17,17 @@ export default ({ labels, data }) => (
     <tbody>
       {data.map(row => (
         <tr>
-          {labels.map(({ field, label, format, noWrap }) => (
+          {labels.map(({ field, label, format, isNumeric, noWrap }) => (
             <td className={classnames(noWrap && tableResponsiveStyles.noWrap)}>
               <span className={tableResponsiveStyles.label}>
                 {label || <FieldName field={field} />}
               </span>
               <span className={tableResponsiveStyles.value}>
-                {format ? format(row[field]) : row[field]}
+                {isNumeric ? (
+                  <FormatNumber number={row[field]} />
+                ) : (
+                  <>{format ? format(row[field]) : row[field]}</>
+                )}
               </span>
             </td>
           ))}

--- a/src/pages/data/download.js
+++ b/src/pages/data/download.js
@@ -17,6 +17,15 @@ export default ({ data }) => (
       id={data.contentfulSnippet.contentful_id}
     />
 
+    <h2>National data</h2>
+    <p>
+      Download{' '}
+      <a href="/data/download/national-history.csv">
+        summary data for the United States
+      </a>
+      .
+    </p>
+
     <h2>State Data</h2>
     <p>
       Download{' '}

--- a/src/pages/data/national/cases.js
+++ b/src/pages/data/national/cases.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import { graphql } from 'gatsby'
 import TableResponsive from '~components/common/table-responsive'
-import { FormatDate, FormatNumber } from '~components/utils/format'
+import { FormatDate } from '~components/utils/format'
 import Layout from '~components/layout'
-
-const formatNumber = number => <FormatNumber number={number} />
 
 export default ({ data }) => {
   return (
@@ -28,14 +26,12 @@ export default ({ data }) => {
           },
           {
             field: 'positive',
-
-            format: formatNumber,
+            isNumeric: true,
           },
 
           {
             field: 'positiveIncrease',
-
-            format: formatNumber,
+            isNumeric: true,
           },
         ]}
         data={data.allCovidUsDaily.nodes}

--- a/src/pages/data/national/cases.js
+++ b/src/pages/data/national/cases.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import TableResponsive from '~components/common/table-responsive'
 import { FormatDate } from '~components/utils/format'
-import { FormatDate } from '~components/utils/format'
 import Definitions from '~components/pages/data/definitions'
 import Layout from '~components/layout'
 

--- a/src/pages/data/national/hospitalization.js
+++ b/src/pages/data/national/hospitalization.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import { graphql } from 'gatsby'
 import TableResponsive from '~components/common/table-responsive'
-import { FormatDate, FormatNumber } from '~components/utils/format'
+import { FormatDate } from '~components/utils/format'
 import Layout from '~components/layout'
-
-const formatNumber = number => <FormatNumber number={number} />
 
 export default ({ data }) => {
   return (
@@ -28,38 +26,31 @@ export default ({ data }) => {
           },
           {
             field: 'hospitalizedCumulative',
-
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'hospitalizedCurrently',
-
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'hospitalizedIncrease',
-
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'inIcuCumulative',
-
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'inIcuCurrently',
-
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'onVentilatorCumulative',
-
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'onVentilatorCurrently',
-
-            format: formatNumber,
+            isNumeric: true,
           },
         ]}
         data={data.allCovidUsDaily.nodes}

--- a/src/pages/data/national/outcomes.js
+++ b/src/pages/data/national/outcomes.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import { graphql } from 'gatsby'
 import TableResponsive from '~components/common/table-responsive'
-import { FormatDate, FormatNumber } from '~components/utils/format'
+import { FormatDate } from '~components/utils/format'
 import Layout from '~components/layout'
-
-const formatNumber = number => <FormatNumber number={number} />
 
 export default ({ data }) => {
   return (
@@ -28,18 +26,15 @@ export default ({ data }) => {
           },
           {
             field: 'recovered',
-
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'death',
-
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'deathIncrease',
-
-            format: formatNumber,
+            isNumeric: true,
           },
         ]}
         data={data.allCovidUsDaily.nodes}

--- a/src/pages/data/national/tests.js
+++ b/src/pages/data/national/tests.js
@@ -1,10 +1,8 @@
 import React from 'react'
 import { graphql } from 'gatsby'
 import TableResponsive from '~components/common/table-responsive'
-import { FormatDate, FormatNumber } from '~components/utils/format'
+import { FormatDate } from '~components/utils/format'
 import Layout from '~components/layout'
-
-const formatNumber = number => <FormatNumber number={number} />
 
 export default ({ data }) => (
   <Layout
@@ -27,28 +25,23 @@ export default ({ data }) => (
         },
         {
           field: 'negative',
-
-          format: formatNumber,
+          isNumeric: true,
         },
         {
           field: 'negativeIncrease',
-
-          format: formatNumber,
+          isNumeric: true,
         },
         {
           field: 'positive',
-
-          format: formatNumber,
+          isNumeric: true,
         },
         {
           field: 'positiveIncrease',
-
-          format: formatNumber,
+          isNumeric: true,
         },
         {
           field: 'totalTestResults',
-
-          format: formatNumber,
+          isNumeric: true,
         },
       ]}
       data={data.allCovidUsDaily.nodes}

--- a/src/templates/state/cases.js
+++ b/src/templates/state/cases.js
@@ -2,10 +2,8 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import TableResponsive from '~components/common/table-responsive'
 import Definitions from '~components/pages/data/definitions'
-import { FormatDate, FormatNumber } from '~components/utils/format'
+import { FormatDate } from '~components/utils/format'
 import Layout from '~components/layout'
-
-const formatNumber = number => <FormatNumber number={number} />
 
 export default ({ pageContext, path, data }) => {
   const state = pageContext
@@ -29,16 +27,16 @@ export default ({ pageContext, path, data }) => {
           },
           {
             field: 'positive',
-            format: formatNumber,
+            isNumeric: true,
           },
 
           {
             field: 'positiveIncrease',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'positiveCasesViral',
-            format: formatNumber,
+            isNumeric: true,
           },
         ]}
         data={data.allCovidStateDaily.nodes}

--- a/src/templates/state/hospitalization.js
+++ b/src/templates/state/hospitalization.js
@@ -2,10 +2,8 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import TableResponsive from '~components/common/table-responsive'
 import Definitions from '~components/pages/data/definitions'
-import { FormatDate, FormatNumber } from '~components/utils/format'
+import { FormatDate } from '~components/utils/format'
 import Layout from '~components/layout'
-
-const formatNumber = number => <FormatNumber number={number} />
 
 export default ({ pageContext, path, data }) => {
   const state = pageContext
@@ -30,31 +28,31 @@ export default ({ pageContext, path, data }) => {
           },
           {
             field: 'hospitalizedCumulative',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'hospitalizedCurrently',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'hospitalizedIncrease',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'inIcuCumulative',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'inIcuCurrently',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'onVentilatorCumulative',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'onVentilatorCurrently',
-            format: formatNumber,
+            isNumeric: true,
           },
         ]}
         data={data.allCovidStateDaily.nodes}

--- a/src/templates/state/outcomes.js
+++ b/src/templates/state/outcomes.js
@@ -2,10 +2,8 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import TableResponsive from '~components/common/table-responsive'
 import Definitions from '~components/pages/data/definitions'
-import { FormatDate, FormatNumber } from '~components/utils/format'
+import { FormatDate } from '~components/utils/format'
 import Layout from '~components/layout'
-
-const formatNumber = number => <FormatNumber number={number} />
 
 export default ({ pageContext, path, data }) => {
   const state = pageContext
@@ -29,23 +27,23 @@ export default ({ pageContext, path, data }) => {
           },
           {
             field: 'recovered',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'death',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'deathIncrease',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'deathProbable',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'deathConfirmed',
-            format: formatNumber,
+            isNumeric: true,
           },
         ]}
         data={data.allCovidStateDaily.nodes}

--- a/src/templates/state/tests-antibody.js
+++ b/src/templates/state/tests-antibody.js
@@ -2,10 +2,8 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import TableResponsive from '~components/common/table-responsive'
 import Definitions from '~components/pages/data/definitions'
-import { FormatDate, FormatNumber } from '~components/utils/format'
+import { FormatDate } from '~components/utils/format'
 import Layout from '~components/layout'
-
-const formatNumber = number => <FormatNumber number={number} />
 
 export default ({ pageContext, path, data }) => {
   const state = pageContext
@@ -30,27 +28,27 @@ export default ({ pageContext, path, data }) => {
           },
           {
             field: 'totalTestsPeopleAntibody',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'totalTestsAntibody',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'negativeTestsPeopleAntibody',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'negativeTestsAntibody',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'positiveTestsPeopleAntibody',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'positiveTestsAntibody',
-            format: formatNumber,
+            isNumeric: true,
           },
         ]}
         data={data.allCovidStateDaily.nodes}

--- a/src/templates/state/tests-viral.js
+++ b/src/templates/state/tests-viral.js
@@ -2,10 +2,8 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import TableResponsive from '~components/common/table-responsive'
 import Definitions from '~components/pages/data/definitions'
-import { FormatDate, FormatNumber } from '~components/utils/format'
+import { FormatDate } from '~components/utils/format'
 import Layout from '~components/layout'
-
-const formatNumber = number => <FormatNumber number={number} />
 
 export default ({ pageContext, path, data }) => {
   const state = pageContext
@@ -30,19 +28,19 @@ export default ({ pageContext, path, data }) => {
           },
           {
             field: 'positiveTestsViral',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'totalTestsPeopleViral',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'totalTestsViral',
-            format: formatNumber,
+            isNumeric: true,
           },
           {
             field: 'totalTestEncountersViral',
-            format: formatNumber,
+            isNumeric: true,
           },
         ]}
         data={data.allCovidStateDaily.nodes}


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Refactors responsive table to remove duplicate field formatter