### PR TITLE
chore: Add pending to all-states-daily export

### DIFF
--- a/src/utilities/csv.js
+++ b/src/utilities/csv.js
@@ -52,6 +52,7 @@ module.exports = (graphql, reporter) => {
               negativeTestsViral
               onVentilatorCumulative
               onVentilatorCurrently
+              pending
               positive
               positiveCasesViral
               positiveIncrease


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Fixes https://github.com/COVID19Tracking/covid-public-api-build/issues/98

- Adds "pending" to the all-states-daily CSV