### PR TITLE
chore: Set chart height

### DIFF
--- a/src/pages/data/longtermcare.js
+++ b/src/pages/data/longtermcare.js
@@ -104,7 +104,7 @@ export default ({ data }) => (
     </Container>
     <TableauChart
       id="ltc-1"
-      height={550}
+      height={525}
       mobileHeight={450}
       viewUrl="https://public.tableau.com/views/WebsiteCharts-CTPLong-TermCare/deathsbydate?:language=en&:display_count=y&:origin=viz_share_link"
       viewUrlMobile="https://public.tableau.com/views/WebsiteCharts-CTPLong-TermCare/deathsbydate?:language=en&:display_count=y&:origin=viz_share_link"


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Update chart height in LTC landing page.