### PR TITLE
chore: Move chart note to below deaths chart

### DIFF
--- a/src/pages/data/longtermcare.js
+++ b/src/pages/data/longtermcare.js
@@ -91,15 +91,6 @@ export default ({ data }) => (
     <Container centered>
       <LongContent>
         <h2>Deaths in Long-Term Care Facilities by Region</h2>
-        <DetailText small>
-          <ContentfulContent
-            id={data.timechartNotes.contentful_id}
-            content={
-              data.timechartNotes.childContentfulSnippetContentTextNode
-                .childMarkdownRemark.html
-            }
-          />
-        </DetailText>
       </LongContent>
     </Container>
     <TableauChart
@@ -111,6 +102,15 @@ export default ({ data }) => (
     />
     <Container centered>
       <LongContent>
+        <DetailText small>
+          <ContentfulContent
+            id={data.timechartNotes.contentful_id}
+            content={
+              data.timechartNotes.childContentfulSnippetContentTextNode
+                .childMarkdownRemark.html
+            }
+          />
+        </DetailText>
         <ContentfulContent
           id={data.contentDefinitions.contentful_id}
           content={


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Changes order of LTC landing page.