### PR TITLE
chore: Reformat timestamp

### DIFF
--- a/src/__tests__/components/common/__snapshots__/last-updated.js.snap
+++ b/src/__tests__/components/common/__snapshots__/last-updated.js.snap
@@ -3,9 +3,9 @@
 exports[`Components : Common: Last updated renders correctly 1`] = `
 Array [
   <p
-    className="lastUpdated"
+    className="lastUpdated national"
   >
-    Our dataset was last updated at
+    Data for
      
     Aug 18 2020
   </p>,
@@ -14,7 +14,7 @@ Array [
   >
     State’s dataset was last updated at
      
-    8/18/20 12:00 am
+    Aug 18, 2020 12:00 am
      
     <abbr
       aria-label="Eastern Time"

--- a/src/components/common/last-updated.js
+++ b/src/components/common/last-updated.js
@@ -6,7 +6,12 @@ import lastUpdatedStyle from './last-updated.module.scss'
 
 // date format matches stats.lastUpdateEt
 const LastUpdated = ({ date, national }) => (
-  <p className={classnames(lastUpdatedStyle.lastUpdated, national && lastUpdatedStyle.national}>
+  <p
+    className={classnames(
+      lastUpdatedStyle.lastUpdated,
+      national && lastUpdatedStyle.national,
+    )}
+  >
     {national ? <>Data for</> : <>State’s dataset was last updated at</>}{' '}
     {national ? (
       date

--- a/src/components/common/last-updated.js
+++ b/src/components/common/last-updated.js
@@ -6,16 +6,12 @@ import lastUpdatedStyle from './last-updated.module.scss'
 // date format matches stats.lastUpdateEt
 const LastUpdated = ({ date, national }) => (
   <p className={lastUpdatedStyle.lastUpdated}>
-    {national ? (
-      <>Our dataset was last updated at</>
-    ) : (
-      <>State’s dataset was last updated at</>
-    )}{' '}
+    {national ? <>Data for</> : <>State’s dataset was last updated at</>}{' '}
     {national ? (
       date
     ) : (
       <>
-        <FormatDate date={date} format="M/d/yy h:mm a" /> <Timezone />
+        <FormatDate date={date} format="LLLL d yyyy h:mm a" /> <Timezone />
       </>
     )}
   </p>

--- a/src/components/common/last-updated.js
+++ b/src/components/common/last-updated.js
@@ -17,7 +17,7 @@ const LastUpdated = ({ date, national }) => (
       date
     ) : (
       <>
-        <FormatDate date={date} format="LLL d yyyy h:mm a" /> <Timezone />
+        <FormatDate date={date} format="LLL d, yyyy h:mm a" /> <Timezone />
       </>
     )}
   </p>

--- a/src/components/common/last-updated.js
+++ b/src/components/common/last-updated.js
@@ -1,17 +1,18 @@
 import React from 'react'
+import classnames from 'classnames'
 import { FormatDate } from '~components/utils/format'
 import Timezone from './timezone'
 import lastUpdatedStyle from './last-updated.module.scss'
 
 // date format matches stats.lastUpdateEt
 const LastUpdated = ({ date, national }) => (
-  <p className={lastUpdatedStyle.lastUpdated}>
+  <p className={classnames(lastUpdatedStyle.lastUpdated, national && lastUpdatedStyle.national}>
     {national ? <>Data for</> : <>State’s dataset was last updated at</>}{' '}
     {national ? (
       date
     ) : (
       <>
-        <FormatDate date={date} format="LLLL d yyyy h:mm a" /> <Timezone />
+        <FormatDate date={date} format="LLL d yyyy h:mm a" /> <Timezone />
       </>
     )}
   </p>

--- a/src/components/common/last-updated.module.scss
+++ b/src/components/common/last-updated.module.scss
@@ -1,3 +1,4 @@
 .last-updated {
-  color: $color-slate-600;
+  color: $color-slate-700;
+  font-weight: bold;
 }

--- a/src/components/common/last-updated.module.scss
+++ b/src/components/common/last-updated.module.scss
@@ -1,4 +1,6 @@
 .last-updated {
   color: $color-slate-700;
-  font-weight: bold;
+  &.national {
+    font-weight: bold;
+  }
 }

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -34,7 +34,7 @@ const DataPage = ({ data }) => {
       <DownloadDataRow
         slug="all-states"
         lastUpdateEt={DateTime.fromISO(data.lastUpdate.nodes[0].date).toFormat(
-          'LLL d yyyy',
+          'LLLL d yyyy',
         )}
         national
       />

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -34,7 +34,7 @@ const DataPage = ({ data }) => {
       <DownloadDataRow
         slug="all-states"
         lastUpdateEt={DateTime.fromISO(data.lastUpdate.nodes[0].date).toFormat(
-          'LLLL d yyyy',
+          'LLLL d, yyyy',
         )}
         national
       />


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fixes #1381 
- Reformats latest date component