### PR TITLE
fix(design): reduce height of blog categories to the content

### DIFF
--- a/src/components/pages/blog/blog-categories-list.js
+++ b/src/components/pages/blog/blog-categories-list.js
@@ -30,32 +30,34 @@ const BlogCategoriesList = () => {
   const [isOpen, setIsOpen] = useState(false)
 
   return (
-    <TabletDisclosure className={blogCategoriesListStyles.container}>
-      <TabletDisclosureHeader isOpen={isOpen} setIsOpen={setIsOpen}>
-        <h3>Posts by Category</h3>
-      </TabletDisclosureHeader>
-      <TabletDisclosureContent isOpen={isOpen}>
-        <ul
-          role="navigation"
-          aria-label="Categories"
-          className={blogCategoriesListStyles.categoryList}
-        >
-          {categories.map(category => (
-            <li
-              className={blogCategoriesListStyles.category}
-              key={category.slug}
-            >
-              <Link to={`/blog/category/${category.slug}`}>
-                <p className={blogCategoriesListStyles.categoryText}>
-                  {category.name} (
-                  {category.blog_post && category.blog_post.length})
-                </p>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </TabletDisclosureContent>
-    </TabletDisclosure>
+    <div className={blogCategoriesListStyles.wrapper}>
+      <TabletDisclosure className={blogCategoriesListStyles.container}>
+        <TabletDisclosureHeader isOpen={isOpen} setIsOpen={setIsOpen}>
+          <h3>Posts by Category</h3>
+        </TabletDisclosureHeader>
+        <TabletDisclosureContent isOpen={isOpen}>
+          <ul
+            role="navigation"
+            aria-label="Categories"
+            className={blogCategoriesListStyles.categoryList}
+          >
+            {categories.map(category => (
+              <li
+                className={blogCategoriesListStyles.category}
+                key={category.slug}
+              >
+                <Link to={`/blog/category/${category.slug}`}>
+                  <p className={blogCategoriesListStyles.categoryText}>
+                    {category.name} (
+                    {category.blog_post && category.blog_post.length})
+                  </p>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </TabletDisclosureContent>
+      </TabletDisclosure>
+    </div>
   )
 }
 

--- a/src/components/pages/blog/blog-categories-list.module.scss
+++ b/src/components/pages/blog/blog-categories-list.module.scss
@@ -1,3 +1,7 @@
+.wrapper {
+  position: relative;
+}
+
 .container {
   border-radius: 4px;
   background-color: $color-plum-100;


### PR DESCRIPTION
Resolves #1404

This PR adds a wrapper div to the blog categories list so it has the height of the content instead of the column (see screenshot).

Since this is my first PR, I wanted to introduce myself real quick as well. I'm a full-time freelancer based in Indiana. I specialize in WordPress and Vue.js but I've done a little bit of React work in the past. I'll keep looking through the issues list but I'd love to contribute more to this project.

Let me know if this PR looks alright and feel free to reach out! I'll keep familiarizing myself with the project.

![Screen Shot 2020-09-08 at 10 52 28 AM](https://user-images.githubusercontent.com/2183946/92492762-b96afc80-f1c1-11ea-9a55-6764726fb2ab.png)
