### PR TITLE
fix(nav): SSR is rendering "All Posts" in navigation instead of "Blog"

### DIFF
--- a/src/components/layout/header/return-links.js
+++ b/src/components/layout/header/return-links.js
@@ -47,7 +47,7 @@ const ReturnLinks = ({ links, pathNavigation, topNavigation, children }) => {
 
     if (matchingTopNavLink !== -1) {
       // pulls the title info for nav elements
-      returnLinks[index] = topNavigation[matchingTopNavLink]
+      returnLinks[index] = { ...topNavigation[matchingTopNavLink] }
       if (link.title) {
         // use the specific title, if it exists
         returnLinks[index].title = customTitle


### PR DESCRIPTION
Resolves #1409

I looked into this and the string "All Posts" is coming from `blog-category.js` when the return link is passed into the `<Layout />` component.

To fix, I updated `return-links.js` to access the elements of the `topNavigation` array by clone instead of by reference.

I'm still learning how Gatsby's SSR works under the hood but I'm speculating this only occurred in the SSR because `BlogCategoryTemplate` gets imported as its rendering all the pages and not when the JS on the individual pages loads up.
