### PR TITLE
chore: Hide API-only definitions in definitions page

### DIFF
--- a/src/pages/about-data/data-definitions.js
+++ b/src/pages/about-data/data-definitions.js
@@ -76,7 +76,10 @@ export const query = graphql`
         }
       }
     }
-    allContentfulDataDefinition(sort: { fields: name }) {
+    allContentfulDataDefinition(
+      sort: { fields: name }
+      filter: { apiOnly: { ne: true } }
+    ) {
       nodes {
         name
         fieldName


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Hides API-only definitions from the definitions page.