### PR TITLE
chore: Change license in footer

### DIFF
--- a/src/__tests__/components/layout/__snapshots__/footer.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/footer.js.snap
@@ -109,7 +109,7 @@ exports[`Components : Layout : Footer renders correctly 1`] = `
       <a
         href="/license"
       >
-        (CC BY-NC 4.0)
+        (CC BY 4.0)
       </a>
     </span>
     <a

--- a/src/__tests__/components/layout/__snapshots__/index.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/index.js.snap
@@ -612,7 +612,7 @@ Array [
         <a
           href="/license"
         >
-          (CC BY-NC 4.0)
+          (CC BY 4.0)
         </a>
       </span>
       <a
@@ -1245,7 +1245,7 @@ Array [
         <a
           href="/license"
         >
-          (CC BY-NC 4.0)
+          (CC BY 4.0)
         </a>
       </span>
       <a

--- a/src/components/layout/footer.js
+++ b/src/components/layout/footer.js
@@ -60,7 +60,7 @@ const Footer = () => (
     <div className={footerStyles.copyright}>
       <span>
         CovidTracking.com Copyright &copy; {new Date().getFullYear()} by The
-        Atlantic Monthly Group. <Link to="/license">(CC BY-NC 4.0)</Link>
+        Atlantic Monthly Group. <Link to="/license">(CC BY 4.0)</Link>
       </span>
       <a href="#reach-skip-nav" className={footerStyles.backToTop}>
         <span>Back to top</span>


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Changes the footer license to CC BY 4.0