### PR TITLE
fix: Missing slug in CSV download link in mobile

### DIFF
--- a/src/components/pages/state/preamble.js
+++ b/src/components/pages/state/preamble.js
@@ -93,11 +93,7 @@ const StatePreamble = ({ state, covidState }) => {
                 </h3>
               </DisclosureButton>
               <DisclosurePanel>
-                <DownloadData
-                  state={state}
-                  slug={state.childSlug.slug}
-                  hideLabel
-                />
+                <DownloadData slug={state.childSlug.slug} hideLabel />
               </DisclosurePanel>
             </Disclosure>
           </div>

--- a/src/components/pages/state/preamble.js
+++ b/src/components/pages/state/preamble.js
@@ -93,7 +93,11 @@ const StatePreamble = ({ state, covidState }) => {
                 </h3>
               </DisclosureButton>
               <DisclosurePanel>
-                <DownloadData state={state} hideLabel />
+                <DownloadData
+                  state={state}
+                  slug={state.childSlug.slug}
+                  hideLabel
+                />
               </DisclosurePanel>
             </Disclosure>
           </div>


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Since we switch the download link component out for mobile, the slug in the URL was broken. This fixes that.