### PR TITLE
chore: Change link to LTC notes CSV

### DIFF
--- a/src/components/pages/data/ltc/download-links.js
+++ b/src/components/pages/data/ltc/download-links.js
@@ -26,7 +26,7 @@ const DataLongTermCareLinks = () => (
       Download the current outbreak dataset
     </CtaAnchorLink>
     <CtaAnchorLink
-      href="https://docs.google.com/spreadsheets/d/e/2PACX-1vRa9HnmEl83YXHfbgSPpt0fJe4SyuYLc0GuBAglF4yMYaoKSPRCyXASaWXMrTu1WEYp1oeJZIYHpj7t/pub?gid=299613558&single=true&output=csv"
+      href="https://docs.google.com/spreadsheets/d/e/2PACX-1vRa9HnmEl83YXHfbgSPpt0fJe4SyuYLc0GuBAglF4yMYaoKSPRCyXASaWXMrTu1WEYp1oeJZIYHpj7t/pub?gid=336757465&single=true&output=csv"
       centered
     >
       Download state notes


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Fixes a link to the LTC notes
