### PR TITLE
Kevee/homepage test results

### DIFF
--- a/src/__tests__/components/pages/homepage/__snapshots__/latest-totals.js.snap
+++ b/src/__tests__/components/pages/homepage/__snapshots__/latest-totals.js.snap
@@ -49,7 +49,7 @@ exports[`Components : Pages : Homepage : Latest Totals renders correctly 1`] = `
           <div
             className="number"
           >
-            N/A
+            5,795,728
           </div>
           <div
             className="label"

--- a/src/__tests__/components/pages/homepage/__snapshots__/latest-totals.js.snap
+++ b/src/__tests__/components/pages/homepage/__snapshots__/latest-totals.js.snap
@@ -49,7 +49,7 @@ exports[`Components : Pages : Homepage : Latest Totals renders correctly 1`] = `
           <div
             className="number"
           >
-            5,795,728
+            N/A
           </div>
           <div
             className="label"

--- a/src/__tests__/components/pages/homepage/latest-totals.js
+++ b/src/__tests__/components/pages/homepage/latest-totals.js
@@ -6,7 +6,7 @@ import LatestTotals from '~components/pages/homepage/latest-totals'
 beforeEach(() => {
   useStaticQuery.mockImplementation(() => ({
     covidUs: {
-      posNeg: 5795728,
+      totalTestResults: 5795728,
       positive: 1005592,
       death: 52525,
     },

--- a/src/components/pages/homepage/latest-totals.js
+++ b/src/components/pages/homepage/latest-totals.js
@@ -36,7 +36,7 @@ const HomepageLatestTotals = () => {
           <Col width={[4, 6, 4]}>
             <Total
               label="Total test results"
-              number={<FormatNumber number={totals.posNeg} />}
+              number={<FormatNumber number={totals.totalTestResults} />}
             />
           </Col>
           <Col width={[4, 6, 4]}>

--- a/src/components/pages/homepage/latest-totals.js
+++ b/src/components/pages/homepage/latest-totals.js
@@ -11,7 +11,7 @@ const HomepageLatestTotals = () => {
   const data = useStaticQuery(graphql`
     {
       covidUs {
-        posNeg
+        totalTestResults
         positive
         death
       }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Changes source of data for homepage total test results number from `posNeg` to `totalTestResults`
