### PR TITLE
chore: Complete conversion of number to words in CRDT

### DIFF
--- a/src/components/pages/race/charts/county-overview-charts.js
+++ b/src/components/pages/race/charts/county-overview-charts.js
@@ -25,6 +25,17 @@ const numberToWord = [
   'Seven',
   'Eight',
   'Nine',
+  'Ten',
+  'Eleven',
+  'Twelve',
+  'Thirteen',
+  'Fourteen',
+  'Fifteen',
+  'Sixteen',
+  'Seventeen',
+  'Eighteen',
+  'Nineteen',
+  'Twenty',
 ]
 
 const numberWords = number =>


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fixes bug where we had not fully listed all possible number-to-word conversions in the CRDT homepage