### PR TITLE
chore(ci): Make storybook a parallel workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
       - run:
           name: lint
           command: 'npm run test:lint'
-  storybook-test:
+  storybook:
     executor: main-executor
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,6 @@ workflows:
       - gatsby-test:
           requires:
             - api
-      - storybook-test:
+      - storybook:
           requires:
             - api
-            - gatsby-build


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Removes build dependency of the storybook workflow