### PR TITLE
feat: Switch test history table using `totalTestResultsField`

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,6 @@
     "test:dev": "run-s test:lint test",
     "setup": "run-s setup:api-repo setup:env-vars",
     "setup:env-vars": "curl -L https://covidtracking.com/__developer/env-vars > .env",
-    "setup:api-repo": "rm -rf _api || true && git clone --depth 1 https://github.com/COVID19Tracking/covid-public-api.git _api && rm -rf _api/.git"
+    "setup:api-repo": "rm -rf _api || true && git clone --depth 1 --branch preview/state-totals https://github.com/COVID19Tracking/covid-public-api.git _api && rm -rf _api/.git"
   }
 }

--- a/package.json
+++ b/package.json
@@ -146,6 +146,6 @@
     "test:dev": "run-s test:lint test",
     "setup": "run-s setup:api-repo setup:env-vars",
     "setup:env-vars": "curl -L https://covidtracking.com/__developer/env-vars > .env",
-    "setup:api-repo": "rm -rf _api || true && git clone --depth 1 --branch preview/state-totals https://github.com/COVID19Tracking/covid-public-api.git _api && rm -rf _api/.git"
+    "setup:api-repo": "rm -rf _api || true && git clone --depth 1 https://github.com/COVID19Tracking/covid-public-api.git _api && rm -rf _api/.git"
   }
 }

--- a/src/templates/state/tests-viral.js
+++ b/src/templates/state/tests-viral.js
@@ -4,15 +4,22 @@ import TableResponsive from '~components/common/table-responsive'
 import Definitions from '~components/pages/data/definitions'
 import Layout from '~components/layout'
 
+const fieldNameMappings = {
+  'Total Tests (PCR)': 'Total PCR tests in specimens',
+  'Total Test Encounters (PCR)': 'Total PCR tests in test encounters',
+  'Total PCR Tests (People)': 'Total PCR tests in people',
+  posNeg: 'positive + negative',
+}
+
 const StateTestViralTemplate = ({ pageContext, path, data }) => {
   const state = pageContext
   const { slug } = state.childSlug
   const { totalTestResultsField } = data.covidStateInfo
-  const totalTestResultsTitle = `Legacy total test results — ${
-    totalTestResultsField === 'posNeg'
-      ? '(positive + negative)'
-      : totalTestResultsField
-  }`
+  const totalTestResultsTitle = `Total test results - legacy (${
+    typeof fieldNameMappings[totalTestResultsField] !== 'undefined'
+      ? fieldNameMappings[totalTestResultsField]
+      : 'positive + negative'
+  })`
 
   return (
     <Layout

--- a/src/templates/state/tests-viral.js
+++ b/src/templates/state/tests-viral.js
@@ -8,15 +8,11 @@ const StateTestViralTemplate = ({ pageContext, path, data }) => {
   const state = pageContext
   const { slug } = state.childSlug
   const { totalTestResultsField } = data.covidStateInfo
-  const totalTestResultsTitle = (() => {
-    if (totalTestResultsField === 'totalTestEncountersViral') {
-      return 'Total test results - legacy (Total PCR tests in test encounters)'
-    }
-    if (totalTestResultsField === 'totalTestsViral') {
-      return 'Total test results - legacy (Total PCR tests)'
-    }
-    return 'Total test results - legacy (positive + negative)'
-  })()
+  const totalTestResultsTitle = `Legacy total test results — ${
+    totalTestResultsField === 'posNeg'
+      ? '(positive + negative)'
+      : totalTestResultsField
+  })`
 
   return (
     <Layout

--- a/src/templates/state/tests-viral.js
+++ b/src/templates/state/tests-viral.js
@@ -12,7 +12,7 @@ const StateTestViralTemplate = ({ pageContext, path, data }) => {
     totalTestResultsField === 'posNeg'
       ? '(positive + negative)'
       : totalTestResultsField
-  })`
+  }`
 
   return (
     <Layout

--- a/src/templates/state/tests-viral.js
+++ b/src/templates/state/tests-viral.js
@@ -7,18 +7,12 @@ import Layout from '~components/layout'
 const StateTestViralTemplate = ({ pageContext, path, data }) => {
   const state = pageContext
   const { slug } = state.childSlug
-  const { covidStateInfo } = data
+  const { totalTestResultsField } = data.covidStateInfo
   const totalTestResultsTitle = (() => {
-    if (
-      covidStateInfo.covidTrackingProjectPreferredTotalTestField ===
-      'totalTestEncountersViral'
-    ) {
+    if (totalTestResultsField === 'totalTestEncountersViral') {
       return 'Total test results - legacy (Total PCR tests in test encounters)'
     }
-    if (
-      covidStateInfo.covidTrackingProjectPreferredTotalTestField ===
-      'totalTestsViral'
-    ) {
+    if (totalTestResultsField === 'totalTestsViral') {
       return 'Total test results - legacy (Total PCR tests)'
     }
     return 'Total test results - legacy (positive + negative)'
@@ -118,8 +112,7 @@ export const query = graphql`
       }
     }
     covidStateInfo(state: { eq: $state }) {
-      covidTrackingProjectPreferredTotalTestField
-      covidTrackingProjectPreferredTotalTestUnits
+      totalTestResultsField
     }
   }
 `

--- a/src/templates/state/tests-viral.js
+++ b/src/templates/state/tests-viral.js
@@ -7,11 +7,18 @@ import Layout from '~components/layout'
 const StateTestViralTemplate = ({ pageContext, path, data }) => {
   const state = pageContext
   const { slug } = state.childSlug
+  const { covidStateInfo } = data
   const totalTestResultsTitle = (() => {
-    if (['CO', 'RI', 'ND'].indexOf(state.state) > -1) {
+    if (
+      covidStateInfo.covidTrackingProjectPreferredTotalTestField ===
+      'totalTestEncountersViral'
+    ) {
       return 'Total test results - legacy (Total PCR tests in test encounters)'
     }
-    if (['MA'].indexOf(state.state) > -1) {
+    if (
+      covidStateInfo.covidTrackingProjectPreferredTotalTestField ===
+      'totalTestsViral'
+    ) {
       return 'Total test results - legacy (Total PCR tests)'
     }
     return 'Total test results - legacy (positive + negative)'
@@ -109,6 +116,10 @@ export const query = graphql`
           }
         }
       }
+    }
+    covidStateInfo(state: { eq: $state }) {
+      covidTrackingProjectPreferredTotalTestField
+      covidTrackingProjectPreferredTotalTestUnits
     }
   }
 `


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Uses new `totalTestResultsField` as source for history title
- Removes state-specific formatting for test history page.

## Before merging

- [ ] Revert API setup to `master`
