### PR TITLE
fix(design): Changed breakpoint so tablets display mobile chart design

### DIFF
--- a/src/components/charts/tableau.module.scss
+++ b/src/components/charts/tableau.module.scss
@@ -1,12 +1,12 @@
 .chart {
   @include margin(32, top bottom);
   &.mobile {
-    @media (min-width: $viewport-md) {
+    @media (min-width: $viewport-lg) {
       display: none;
     }
   }
   &.has-mobile-view {
-    @media (max-width: $viewport-md) {
+    @media (max-width: $viewport-lg) {
       display: none;
     }
   }


### PR DESCRIPTION
 Fixes Charts truncated on iPad #1428

Per conversation with Peter Walker, this just changes the breakpoint at which the mobile design loads instead of the desktop one.
