### PR TITLE
fix: Add data repo to production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "set-tz": "^0.2.0"
   },
   "scripts": {
-    "build": "run-s setup:api-repo build:gatsby build:test",
+    "build": "run-s setup:api-repo setup:data-repo build:gatsby build:test",
     "build-preview": "run-s setup build:gatsby build:test",
     "build:gatsby": "gatsby build",
     "build:test": "jest --verbose --config=\"{}\" -- src/__tests__/build/index.js",


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
