### PR TITLE
chore: Hack scrollrama

### DIFF
--- a/src/components/pages/blog-features/scrollytelling/index.js
+++ b/src/components/pages/blog-features/scrollytelling/index.js
@@ -8,9 +8,7 @@ export default ({ copy, images }) => {
   // This callback fires when a Step hits the offset threshold. It receives the
   // data prop of the step, which in this demo stores the index of the step.
   const onStepEnter = props => setCurrentStepIndex(props.data)
-  if (typeof window === 'undefined') {
-    return null
-  }
+
   return (
     <div className={styles.scrollyContainer}>
       <div className={styles.stickyImage}>

--- a/src/utilities/scrollama.js
+++ b/src/utilities/scrollama.js
@@ -325,7 +325,11 @@ var Scrollama = /*#__PURE__*/ (function(_Component) {
 
     _defineProperty(_assertThisInitialized(_this), 'stepElIds', [])
 
-    _defineProperty(_assertThisInitialized(_this), 'viewH', window.innerHeight)
+    _defineProperty(
+      _assertThisInitialized(_this),
+      'viewH',
+      typeof window !== 'undefined' ? window.innerHeight : 400,
+    )
 
     _defineProperty(_assertThisInitialized(_this), 'pageH', 0)
 
@@ -343,6 +347,9 @@ var Scrollama = /*#__PURE__*/ (function(_Component) {
       _assertThisInitialized(_this),
       'updateDirection',
       function() {
+        if (typeof window === 'undefined') {
+          return
+        }
         if (window.pageYOffset > _this.previousYOffset) {
           _this.direction = 'down'
         } else if (window.pageYOffset < _this.previousYOffset) {
@@ -376,7 +383,7 @@ var Scrollama = /*#__PURE__*/ (function(_Component) {
     })
 
     _defineProperty(_assertThisInitialized(_this), 'handleResize', function() {
-      _this.viewH = window.innerHeight
+      _this.viewH = typeof window !== 'undefined' ? window.innerHeight : 300
       _this.pageH = getPageHeight()
 
       _this.setState({
@@ -710,14 +717,18 @@ var Scrollama = /*#__PURE__*/ (function(_Component) {
       value: function domDidLoad() {
         this.handleResize()
         this.handleEnable(true)
-        window.addEventListener('resize', this.handleResize)
+        if (typeof window !== 'undefined') {
+          window.addEventListener('resize', this.handleResize)
+        }
       },
     },
     {
       key: 'componentWillUnmount',
       value: function componentWillUnmount() {
-        window.removeEventListener('load', this.domDidLoad.bind(this))
-        window.removeEventListener('resize', this.handleResize)
+        if (typeof window !== 'undefined') {
+          window.removeEventListener('load', this.domDidLoad.bind(this))
+          window.removeEventListener('resize', this.handleResize)
+        }
         this.handleEnable(false)
       },
       /* Get step can take a step id or grab an id off a target element */


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Hack scrollama to just override all instances of `window` if undefined