### PR TITLE
fix(format-number): handle zeros properly

### DIFF
--- a/src/components/utils/format.js
+++ b/src/components/utils/format.js
@@ -42,7 +42,7 @@ const FormatNumber = ({ number, nullValue = false, precision = 0 }) => {
       Math.round(parseFloat(number) * precisionDenominator) /
       precisionDenominator
   }
-  return <>{roundedNumber ? roundedNumber.toLocaleString() : nullDisplay}</>
+  return <>{roundedNumber !== null ? roundedNumber.toLocaleString() : nullDisplay}</>
 }
 
 const getListSpacer = (index, length, useAmpersand = true) => {

--- a/src/components/utils/format.js
+++ b/src/components/utils/format.js
@@ -42,7 +42,9 @@ const FormatNumber = ({ number, nullValue = false, precision = 0 }) => {
       Math.round(parseFloat(number) * precisionDenominator) /
       precisionDenominator
   }
-  return <>{roundedNumber !== null ? roundedNumber.toLocaleString() : nullDisplay}</>
+  return (
+    <>{roundedNumber !== null ? roundedNumber.toLocaleString() : nullDisplay}</>
+  )
 }
 
 const getListSpacer = (index, length, useAmpersand = true) => {


### PR DESCRIPTION
previously, a zero would result in 'N/A' since zero was evaluated
as false. this instead adds an explicit null check, which returns
zeros as zero, not 'N/A'.

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
