### PR TITLE
chore: Fix 7 days ago date, hover CSS

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -5,12 +5,17 @@ require(`@babel/register`)({
 require('dotenv').config()
 const setTZ = require('set-tz')
 const { DateTime } = require('luxon')
+const fs = require('fs')
 const algoliaQueries = require('./src/utilities/algolia').queries
 const sassImports = require('./src/utilities/sass-imports.js')
 const formatStringList = require('./src/components/utils/format')
   .formatStringList
 
 setTZ('America/New_York')
+
+const usDates = JSON.parse(fs.readFileSync('./_api/v1/us/daily.json'))
+const latestDate = usDates.sort((a, b) => (a.date > b.date ? -1 : 1)).shift()
+  .date
 
 const gatsbyConfig = {
   siteMetadata: {
@@ -290,7 +295,7 @@ const gatsbyConfig = {
       resolve: `gatsby-plugin-global-context`,
       options: {
         context: {
-          sevenDaysAgo: DateTime.local()
+          sevenDaysAgo: DateTime.fromISO(latestDate)
             .minus({ days: 7 })
             .toISODate(),
         },

--- a/src/components/layout/header/navigation.module.scss
+++ b/src/components/layout/header/navigation.module.scss
@@ -93,7 +93,6 @@
     padding: spacer(8);
     cursor: pointer;
     &:hover,
-    &[data-selected],
     &:focus {
       color: white;
       background: black;


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fixes #1463 by setting seven days ago against the most recent date in US daily
- Fixes #1457 by removing an unused `[data-selected]` CSS selector that is always set on SSR