### PR TITLE
fix: Missing date on homepage blog posts

### DIFF
--- a/src/__tests__/components/pages/homepage/__snapshots__/blog-list.js.snap
+++ b/src/__tests__/components/pages/homepage/__snapshots__/blog-list.js.snap
@@ -57,7 +57,9 @@ exports[`Components : Pages : Homepage : Blog list renders correctly 1`] = `
               </span>
               <span
                 className="date"
-              />
+              >
+                April 23, 2020
+              </span>
             </span>
           </div>
         </li>
@@ -103,7 +105,9 @@ exports[`Components : Pages : Homepage : Blog list renders correctly 1`] = `
               </span>
               <span
                 className="date"
-              />
+              >
+                April 15, 2020
+              </span>
             </span>
           </div>
         </li>

--- a/src/components/pages/homepage/blog-list.js
+++ b/src/components/pages/homepage/blog-list.js
@@ -73,7 +73,7 @@ const HomepageBlogList = () => {
                 </p>
                 <Byline
                   authors={node.authors}
-                  date={node.publishDate}
+                  published={node.publishDate}
                   smallmargin
                 />
               </li>


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Fixes #1462