### PR TITLE
chore: Remove console log from counties plugin

### DIFF
--- a/plugins/gatsby-source-covid-tracking-counties/gatsby-node.js
+++ b/plugins/gatsby-source-covid-tracking-counties/gatsby-node.js
@@ -4,7 +4,6 @@ const crypto = require('crypto')
 exports.sourceNodes = ({ actions, createNodeId, reporter }, configOptions) => {
   return new Promise((resolve, reject) => {
     const { createNode } = actions
-    console.log('COUNTIES')
     const countyResults = {}
     const demographics = require(configOptions.demographics)
     const counties = JSON.parse(fs.readFileSync(configOptions.counties))


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- A console log entry was missed in linting
