### PR TITLE
fix(a11y): Label state nav with abbr

### DIFF
--- a/src/__tests__/components/pages/data/__snapshots__/state-nav.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-nav.js.snap
@@ -66,14 +66,18 @@ exports[`Components : Pages : Data : State navigation renders correctly 1`] = `
             <a
               href="#state-ca"
             >
-              CA
+              <abbr>
+                CA
+              </abbr>
             </a>
           </li>
           <li>
             <a
               href="#state-nm"
             >
-              NM
+              <abbr>
+                NM
+              </abbr>
             </a>
           </li>
         </ul>
@@ -144,14 +148,18 @@ exports[`Components : Pages : Data : State navigation renders correctly 2`] = `
             <a
               href="/data/state/california"
             >
-              CA
+              <abbr>
+                CA
+              </abbr>
             </a>
           </li>
           <li>
             <a
               href="/data/state/new-mexico"
             >
-              NM
+              <abbr>
+                NM
+              </abbr>
             </a>
           </li>
         </ul>

--- a/src/__tests__/components/pages/data/__snapshots__/state-nav.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/state-nav.js.snap
@@ -66,18 +66,14 @@ exports[`Components : Pages : Data : State navigation renders correctly 1`] = `
             <a
               href="#state-ca"
             >
-              <abbr>
-                CA
-              </abbr>
+              CA
             </a>
           </li>
           <li>
             <a
               href="#state-nm"
             >
-              <abbr>
-                NM
-              </abbr>
+              NM
             </a>
           </li>
         </ul>
@@ -148,18 +144,14 @@ exports[`Components : Pages : Data : State navigation renders correctly 2`] = `
             <a
               href="/data/state/california"
             >
-              <abbr>
-                CA
-              </abbr>
+              CA
             </a>
           </li>
           <li>
             <a
               href="/data/state/new-mexico"
             >
-              <abbr>
-                NM
-              </abbr>
+              NM
             </a>
           </li>
         </ul>

--- a/src/components/pages/data/state-nav.js
+++ b/src/components/pages/data/state-nav.js
@@ -41,7 +41,7 @@ const StateNav = ({ stateList, className, externalLinks = false }) => {
               return (
                 <li key={state.state}>
                   <Link to={`/data/state/${state.childSlug.slug}`}>
-                    {state.state}
+                    <abbr title={state.name}>{state.state}</abbr>
                   </Link>
                 </li>
               )
@@ -49,7 +49,7 @@ const StateNav = ({ stateList, className, externalLinks = false }) => {
             return (
               <li key={state.state}>
                 <Link to={`#state-${state.state.toLowerCase()}`}>
-                  {state.state}
+                  <abbr title={state.name}>{state.state}</abbr>
                 </Link>
               </li>
             )

--- a/src/components/pages/data/state-nav.js
+++ b/src/components/pages/data/state-nav.js
@@ -40,16 +40,22 @@ const StateNav = ({ stateList, className, externalLinks = false }) => {
             if (externalLinks) {
               return (
                 <li key={state.state}>
-                  <Link to={`/data/state/${state.childSlug.slug}`}>
-                    <abbr title={state.name}>{state.state}</abbr>
+                  <Link
+                    to={`/data/state/${state.childSlug.slug}`}
+                    aria-label={state.name}
+                  >
+                    {state.state}
                   </Link>
                 </li>
               )
             }
             return (
               <li key={state.state}>
-                <Link to={`#state-${state.state.toLowerCase()}`}>
-                  <abbr title={state.name}>{state.state}</abbr>
+                <Link
+                  to={`#state-${state.state.toLowerCase()}`}
+                  aria-label={state.name}
+                >
+                  {state.state}
                 </Link>
               </li>
             )


### PR DESCRIPTION
<!-- If you are opening this PR for Hacktoberfest, make sure it is substantive
and not just little "Improve Docs" changes to our README, or the issue will be
immediately closed and marked as spam & invalid 🚫👚-->

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->

- Adds `abbr` tags to improve accessibility of the state navs