### PR TITLE
fix: US Population missing from BQ results

### DIFF
--- a/plugins/gatsby-transformer-covid-census/gatsby-node.js
+++ b/plugins/gatsby-transformer-covid-census/gatsby-node.js
@@ -7,7 +7,7 @@ const onCreateNode = async (
 ) => {
   const { createNode, createParentChildLink } = actions
   const { fields, usType, stateType, stateInfoType, sources } = configOptions
-  const usPopulation = await fs.readJson(sources.us).pop()
+  const usPopulation = await fs.readJson(sources.us)
   const statePopulation = await fs.readJson(sources.states)
 
   const createPopulationNumbers = population => {
@@ -43,7 +43,7 @@ const onCreateNode = async (
   }
 
   if (node.internal.type === usType) {
-    createPopulationNumbers(usPopulation.population)
+    createPopulationNumbers(usPopulation[0].population)
     return
   }
 

--- a/plugins/gatsby-transformer-covid-census/gatsby-node.js
+++ b/plugins/gatsby-transformer-covid-census/gatsby-node.js
@@ -7,7 +7,7 @@ const onCreateNode = async (
 ) => {
   const { createNode, createParentChildLink } = actions
   const { fields, usType, stateType, stateInfoType, sources } = configOptions
-  const usPopulation = await fs.readJson(sources.us)
+  const usPopulation = await fs.readJson(sources.us).pop()
   const statePopulation = await fs.readJson(sources.states)
 
   const createPopulationNumbers = population => {


### PR DESCRIPTION
<!-- If you are opening this PR for Hacktoberfest, make sure it is substantive
and not just little "Improve Docs" changes to our README, or the issue will be
immediately closed and marked as spam & invalid 🚫👚-->

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fixes 7-day average population calculation for US numbers