### PR TITLE
fix: Sort all states CSV by date, state name

### DIFF
--- a/src/utilities/csv.js
+++ b/src/utilities/csv.js
@@ -30,7 +30,9 @@ module.exports = (graphql, reporter) => {
               }
             }
           }
-          allCovidStateDaily(sort: { fields: date, order: DESC }) {
+          allCovidStateDaily(
+            sort: { fields: [date, state], order: [DESC, ASC] }
+          ) {
             nodes {
               date
               state


### PR DESCRIPTION
<!-- If you are opening this PR for Hacktoberfest, make sure it is substantive
and not just little "Improve Docs" changes to our README, or the issue will be
immediately closed and marked as spam & invalid 🚫👚-->

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Sorts the state history CSVs by date and state name