### PR TITLE
chore: Add total test results to total tests page

### DIFF
--- a/src/pages/about-data/total-tests.js
+++ b/src/pages/about-data/total-tests.js
@@ -17,7 +17,10 @@ const DataStateTotalTestsPage = ({ data }) => {
       state: (
         <Link to={`/data/state/${state.childSlug.slug}`}>{state.name}</Link>
       ),
-      totalTestResultsField: state.totalTestResultsField,
+      totalTestResultsField:
+        state.totalTestResultsField === 'posNeg'
+          ? 'Positive + negative PCR tests'
+          : state.totalTestResultsField,
       field: (
         <Link to={`/about-data/data-definitions#definition-${column}`}>
           <FieldName field={column} />

--- a/src/pages/about-data/total-tests.js
+++ b/src/pages/about-data/total-tests.js
@@ -17,6 +17,7 @@ const DataStateTotalTestsPage = ({ data }) => {
       state: (
         <Link to={`/data/state/${state.childSlug.slug}`}>{state.name}</Link>
       ),
+      totalTestResultsField: state.totalTestResultsField,
       field: (
         <Link to={`/about-data/data-definitions#definition-${column}`}>
           <FieldName field={column} />
@@ -49,13 +50,18 @@ const DataStateTotalTestsPage = ({ data }) => {
             alignLeft: true,
           },
           {
+            field: 'totalTestResultsField',
+            label: 'Total test results field',
+            alignLeft: true,
+          },
+          {
             field: 'field',
-            label: 'Total tests field',
+            label: 'New Tests chart field',
             alignLeft: true,
           },
           {
             field: 'units',
-            label: 'Units',
+            label: 'New Tests chart units',
             alignLeft: true,
           },
         ]}
@@ -103,6 +109,7 @@ export const query = graphql`
         name
         covidTrackingProjectPreferredTotalTestField
         covidTrackingProjectPreferredTotalTestUnits
+        totalTestResultsField
       }
     }
   }

--- a/src/pages/about-data/total-tests.js
+++ b/src/pages/about-data/total-tests.js
@@ -19,7 +19,7 @@ const DataStateTotalTestsPage = ({ data }) => {
       ),
       totalTestResultsField:
         state.totalTestResultsField === 'posNeg'
-          ? 'Positive + negative PCR tests'
+          ? 'Positive + Negative'
           : state.totalTestResultsField,
       field: (
         <Link to={`/about-data/data-definitions#definition-${column}`}>

--- a/src/pages/about-data/total-tests.js
+++ b/src/pages/about-data/total-tests.js
@@ -56,12 +56,12 @@ const DataStateTotalTestsPage = ({ data }) => {
           },
           {
             field: 'field',
-            label: 'New Tests chart field',
+            label: '"New Tests" chart field',
             alignLeft: true,
           },
           {
             field: 'units',
-            label: 'New Tests chart units',
+            label: '"New Tests" chart units',
             alignLeft: true,
           },
         ]}


### PR DESCRIPTION
<!-- If you are opening this PR for Hacktoberfest, make sure it is substantive
and not just little "Improve Docs" changes to our README, or the issue will be
immediately closed and marked as spam & invalid 🚫👚-->

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds `totalTestResultsField` to the total test results page table