### PR TITLE
chore: Remove hacktoberfest warning from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,3 @@
-<!-- If you are opening this PR for Hacktoberfest, make sure it is substantive
-and not just little "Improve Docs" changes to our README, or the issue will be
-immediately closed and marked as spam & invalid 🚫👚-->
-
 <!--
   Check out the docs at https://covid19tracking.github.io/website-docs first.
   Make sure that running `npm run test` works locally before opening a PR.


### PR DESCRIPTION
<!-- If you are opening this PR for Hacktoberfest, make sure it is substantive
and not just little "Improve Docs" changes to our README, or the issue will be
immediately closed and marked as spam & invalid 🚫👚-->

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->

- Removes hacktoberfest warning from PR templates