### PR TITLE
chore: Add order prop to definitions component

### DIFF
--- a/src/__tests__/components/pages/data/__snapshots__/definitions.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/definitions.js.snap
@@ -96,3 +96,100 @@ exports[`Components : Pages : Data : Definitions renders correctly 1`] = `
   </div>
 </div>
 `;
+
+exports[`Components : Pages : Data : Definitions renders correctly 2`] = `
+<div
+  className="row definitions"
+>
+  <div
+    className="col colSmall4 colMedium6 colLarge3"
+  >
+    <h3
+      className="header"
+    >
+      Definitions
+    </h3>
+    <button
+      className="expandAll"
+      onClick={[Function]}
+      type="button"
+    >
+      Expand all
+    </button>
+  </div>
+  <div
+    className="col colSmall4 colMedium6 colLarge9 paddingLeftSmall0 paddingLeftMedium0 paddingLeftLarge8"
+  >
+    <div>
+      <button
+        aria-controls="definition-pane--0"
+        aria-expanded={false}
+        className="definitionButton"
+        onClick={[Function]}
+        type="button"
+      >
+        Test definition B
+         
+        <span
+          aria-hidden={true}
+          className="arrowDown"
+        >
+          ↓
+        </span>
+         
+        <span
+          aria-hidden={true}
+          className="arrowUp"
+        >
+          ↑
+        </span>
+      </button>
+      <div
+        className="pane"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "Test <strong>definition</strong> content B.",
+          }
+        }
+        hidden={true}
+        id="definition-pane--0"
+      />
+    </div>
+    <div>
+      <button
+        aria-controls="definition-pane--1"
+        aria-expanded={false}
+        className="definitionButton"
+        onClick={[Function]}
+        type="button"
+      >
+        Test definition A
+         
+        <span
+          aria-hidden={true}
+          className="arrowDown"
+        >
+          ↓
+        </span>
+         
+        <span
+          aria-hidden={true}
+          className="arrowUp"
+        >
+          ↑
+        </span>
+      </button>
+      <div
+        className="pane"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "Test <strong>definition</strong> content A.",
+          }
+        }
+        hidden={true}
+        id="definition-pane--1"
+      />
+    </div>
+  </div>
+</div>
+`;

--- a/src/__tests__/components/pages/data/definitions.js
+++ b/src/__tests__/components/pages/data/definitions.js
@@ -2,32 +2,37 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import Definitions from '~components/pages/data/definitions'
 
+const definitions = [
+  {
+    name: 'Test definition A',
+    fieldName: 'a',
+    childContentfulDataDefinitionDefinitionTextNode: {
+      childMarkdownRemark: {
+        html: 'Test <strong>definition</strong> content A.',
+      },
+    },
+  },
+  {
+    name: 'Test definition B',
+    fieldName: 'b',
+    childContentfulDataDefinitionDefinitionTextNode: {
+      childMarkdownRemark: {
+        html: 'Test <strong>definition</strong> content B.',
+      },
+    },
+  },
+]
+
 describe('Components : Pages : Data : Definitions', () => {
   it('renders correctly', () => {
     const tree = renderer
-      .create(
-        <Definitions
-          definitions={[
-            {
-              name: 'Test definition A',
-              childContentfulDataDefinitionDefinitionTextNode: {
-                childMarkdownRemark: {
-                  html: 'Test <strong>definition</strong> content A.',
-                },
-              },
-            },
-            {
-              name: 'Test definition B',
-              childContentfulDataDefinitionDefinitionTextNode: {
-                childMarkdownRemark: {
-                  html: 'Test <strong>definition</strong> content B.',
-                },
-              },
-            },
-          ]}
-        />,
-      )
+      .create(<Definitions definitions={definitions} order={['a', 'b']} />)
       .toJSON()
     expect(tree).toMatchSnapshot()
+
+    const reverseOrderTree = renderer
+      .create(<Definitions definitions={definitions} order={['b', 'a']} />)
+      .toJSON()
+    expect(reverseOrderTree).toMatchSnapshot()
   })
 })

--- a/src/components/pages/data/definitions.js
+++ b/src/components/pages/data/definitions.js
@@ -9,7 +9,6 @@ const Definitions = ({ definitions, order }) => {
       definitions.find(definition => definition.fieldName === field),
     )
   })
-  console.log(orderedDefinitions)
   const [expanded, setExpanded] = useState([])
   return (
     <Row className={definitionStyles.definitions}>

--- a/src/components/pages/data/definitions.js
+++ b/src/components/pages/data/definitions.js
@@ -2,7 +2,14 @@ import React, { useState } from 'react'
 import { Row, Col } from '~components/common/grid'
 import definitionStyles from './definitions.module.scss'
 
-const Definitions = ({ definitions }) => {
+const Definitions = ({ definitions, order }) => {
+  const orderedDefinitions = []
+  order.forEach(field => {
+    orderedDefinitions.push(
+      definitions.find(definition => definition.fieldName === field),
+    )
+  })
+  console.log(orderedDefinitions)
   const [expanded, setExpanded] = useState([])
   return (
     <Row className={definitionStyles.definitions}>
@@ -12,14 +19,14 @@ const Definitions = ({ definitions }) => {
           className={definitionStyles.expandAll}
           type="button"
           onClick={() => {
-            if (expanded.length === definitions.length) {
+            if (expanded.length === orderedDefinitions.length) {
               setExpanded([])
               return
             }
-            setExpanded(Array.from(definitions.keys()))
+            setExpanded(Array.from(orderedDefinitions.keys()))
           }}
         >
-          {expanded.length === definitions.length ? (
+          {expanded.length === orderedDefinitions.length ? (
             <>Collapse all</>
           ) : (
             <>Expand all</>
@@ -27,7 +34,7 @@ const Definitions = ({ definitions }) => {
         </button>
       </Col>
       <Col width={[4, 6, 9]} paddingLeft={[0, 0, 8]}>
-        {definitions.map((definition, key) => (
+        {orderedDefinitions.map((definition, key) => (
           <div key={`definition-${definition.name}`}>
             <button
               type="button"

--- a/src/pages/data/national/cases.js
+++ b/src/pages/data/national/cases.js
@@ -16,7 +16,10 @@ const NationalDataCasesPage = ({ data }) => {
         { link: `/data/national`, title: 'Totals for the US' },
       ]}
     >
-      <Definitions definitions={data.allContentfulDataDefinition.nodes} />
+      <Definitions
+        definitions={data.allContentfulDataDefinition.nodes}
+        order={['positive', 'positiveIncrease']}
+      />
       <TableResponsive
         labels={[
           {

--- a/src/pages/data/national/hospitalization.js
+++ b/src/pages/data/national/hospitalization.js
@@ -23,8 +23,8 @@ const NationalDataHospitalizationPage = ({ data }) => {
           'hospitalizedCurrently',
           'inIcuCumulative',
           'inIcuCurrently',
-          'onVentilatorCurrently',
           'onVentilatorCumulative',
+          'onVentilatorCurrently',
         ]}
       />
       <TableResponsive

--- a/src/pages/data/national/hospitalization.js
+++ b/src/pages/data/national/hospitalization.js
@@ -16,7 +16,17 @@ const NationalDataHospitalizationPage = ({ data }) => {
         { link: `/data/national`, title: 'Totals for the US' },
       ]}
     >
-      <Definitions definitions={data.allContentfulDataDefinition.nodes} />
+      <Definitions
+        definitions={data.allContentfulDataDefinition.nodes}
+        order={[
+          'hospitalizedCumulative',
+          'hospitalizedCurrently',
+          'inIcuCumulative',
+          'inIcuCurrently',
+          'onVentilatorCurrently',
+          'onVentilatorCumulative',
+        ]}
+      />
       <TableResponsive
         labels={[
           {

--- a/src/pages/data/national/index.js
+++ b/src/pages/data/national/index.js
@@ -27,7 +27,20 @@ const NationalDataPage = ({ data }) => (
     />
     <DownloadData slug="national" />
 
-    <Definitions definitions={data.allContentfulDataDefinition.nodes} />
+    <Definitions
+      definitions={data.allContentfulDataDefinition.nodes}
+      order={[
+        'states',
+        'totalTestResultsIncrease',
+        'positive',
+        'negative',
+        'hospitalizedCumulative',
+        'hospitalizedCurrently',
+        'death',
+        'recovered',
+        'totalTestResults',
+      ]}
+    />
     <TableResponsive
       labels={[
         {
@@ -89,9 +102,12 @@ export const query = graphql`
             "totalTestResultsIncrease"
             "positive"
             "negative"
+            "hospitalizedCumulative"
             "totalTestResults"
             "hospitalizedCurrently"
             "recovered"
+            "death"
+            "totalTestResults"
           ]
         }
       }

--- a/src/pages/data/national/outcomes.js
+++ b/src/pages/data/national/outcomes.js
@@ -16,7 +16,10 @@ const NationalDataOutcomesPage = ({ data }) => {
         { link: `/data/national`, title: 'Totals for the US' },
       ]}
     >
-      <Definitions definitions={data.allContentfulDataDefinition.nodes} />
+      <Definitions
+        definitions={data.allContentfulDataDefinition.nodes}
+        order={['recovered', 'death']}
+      />
       <TableResponsive
         labels={[
           {

--- a/src/pages/data/national/tests.js
+++ b/src/pages/data/national/tests.js
@@ -15,7 +15,10 @@ const NationalDataTestPage = ({ data }) => (
       { link: `/data/national`, title: 'Totals for the US' },
     ]}
   >
-    <Definitions definitions={data.allContentfulDataDefinition.nodes} />
+    <Definitions
+      definitions={data.allContentfulDataDefinition.nodes}
+      order={['positive', 'negative', 'totalTestResults']}
+    />
     <TableResponsive
       labels={[
         {

--- a/src/templates/state/cases.js
+++ b/src/templates/state/cases.js
@@ -16,7 +16,15 @@ const StateCasesTemplate = ({ pageContext, path, data }) => {
       ]}
       path={path}
     >
-      <Definitions definitions={data.allContentfulDataDefinition.nodes} />
+      <Definitions
+        definitions={data.allContentfulDataDefinition.nodes}
+        order={[
+          'positive',
+          'positiveIncrease',
+          'positiveCasesViral',
+          'probableCases',
+        ]}
+      />
       <TableResponsive
         labels={[
           {

--- a/src/templates/state/hospitalization.js
+++ b/src/templates/state/hospitalization.js
@@ -16,7 +16,17 @@ const StateHospitalizationTemplate = ({ pageContext, path, data }) => {
       ]}
       path={path}
     >
-      <Definitions definitions={data.allContentfulDataDefinition.nodes} />
+      <Definitions
+        definitions={data.allContentfulDataDefinition.nodes}
+        order={[
+          'hospitalizedCumulative',
+          'hospitalizedCurrently',
+          'inIcuCumulative',
+          'inIcuCurrently',
+          'onVentilatorCumulative',
+          'onVentilatorCurrently',
+        ]}
+      />
 
       <TableResponsive
         labels={[

--- a/src/templates/state/outcomes.js
+++ b/src/templates/state/outcomes.js
@@ -16,7 +16,10 @@ const StateOutcomesTemplate = ({ pageContext, path, data }) => {
       ]}
       path={path}
     >
-      <Definitions definitions={data.allContentfulDataDefinition.nodes} />
+      <Definitions
+        definitions={data.allContentfulDataDefinition.nodes}
+        order={['recovered', 'death', 'deathProbable', 'deathConfirmed']}
+      />
       <TableResponsive
         labels={[
           {

--- a/src/templates/state/tests-antibody.js
+++ b/src/templates/state/tests-antibody.js
@@ -17,7 +17,17 @@ const StateTestAntibodiesTemplate = ({ pageContext, path, data }) => {
       ]}
       path={path}
     >
-      <Definitions definitions={data.allContentfulDataDefinition.nodes} />
+      <Definitions
+        definitions={data.allContentfulDataDefinition.nodes}
+        order={[
+          'totalTestsPeopleAntibody',
+          'totalTestsAntibody',
+          'negativeTestsPeopleAntibody',
+          'negativeTestsAntibody',
+          'positiveTestsPeopleAntibody',
+          'positiveTestsAntibody',
+        ]}
+      />
       <TableResponsive
         labels={[
           {

--- a/src/templates/state/tests-viral.js
+++ b/src/templates/state/tests-viral.js
@@ -38,6 +38,13 @@ const StateTestViralTemplate = ({ pageContext, path, data }) => {
           }
           return result
         })}
+        order={[
+          'positiveTestsViral',
+          'totalTestsPeopleViral',
+          'totalTestsViral',
+          'totalTestEncountersViral',
+          'totalTestResults',
+        ]}
       />
       <TableResponsive
         labels={[


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds an `order` prop to the definitions component for state history pages
- Fixes #1502 
