### PR TITLE
Add native lazy loading to blog img elements

### DIFF
--- a/src/components/pages/blog/content-blocks/image-content-block.js
+++ b/src/components/pages/blog/content-blocks/image-content-block.js
@@ -19,7 +19,7 @@ const ImageContentBlock = ({
     )}
   >
     {keepSize ? (
-      <img src={imageUrl} alt={image.title} />
+      <img src={imageUrl} alt={image.title} loading="lazy" />
     ) : (
       <Img fluid={image.fluid} alt={image.title} />
     )}


### PR DESCRIPTION
### Description

Fixes #1500 

I added the native lazy loading attribute to blog images which do not use Gatsby Image. Native lazy loading is [supported by](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#Browser_compatibility) most desktop browsers, the exceptions being IE and Safari (Safari is working on implementing it). I found a polyfill [dependency](https://github.com/mfranzke/loading-attribute-polyfill) we could use to get it working in Safari. But since this is not a critical function, I'm not sure it justifies adding another dependency or the potential confusion of additional code.
