### PR TITLE
chore: Add footnote block support

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -239,6 +239,7 @@ const gatsbyConfig = {
       options: {
         spaceId: process.env.CONTENTFUL_SPACE,
         accessToken: process.env.CONTENTFUL_TOKEN,
+        environment: 'superscript',
         host: process.env.CONTENTFUL_PREVIEW
           ? 'preview.contentful.com'
           : 'cdn.contentful.com',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -239,7 +239,6 @@ const gatsbyConfig = {
       options: {
         spaceId: process.env.CONTENTFUL_SPACE,
         accessToken: process.env.CONTENTFUL_TOKEN,
-        environment: 'superscript',
         host: process.env.CONTENTFUL_PREVIEW
           ? 'preview.contentful.com'
           : 'cdn.contentful.com',

--- a/src/components/pages/blog/blog-content.js
+++ b/src/components/pages/blog/blog-content.js
@@ -1,15 +1,17 @@
 import React from 'react'
-import { BLOCKS } from '@contentful/rich-text-types'
+import { BLOCKS, INLINES } from '@contentful/rich-text-types'
 import marked from 'marked'
 import { documentToReactComponents } from '@contentful/rich-text-react-renderer'
 import LongContent from '~components/common/long-content'
 import CleanSpacing from '~components/utils/clean-spacing'
 import TableContentBlock from './content-blocks/table-content-block'
 import ImageContentBlock from './content-blocks/image-content-block'
+import FootnoteContentBlock from './content-blocks/footnote-content-block'
 import TableauChart from '~components/charts/tableau'
 import blogContentStyles from './blog-content.module.scss'
 
 const BlogContent = ({ content, images }) => {
+  let footnoteNumber = 0
   const options = {
     renderNode: {
       [BLOCKS.PARAGRAPH]: (node, children) => (
@@ -19,6 +21,19 @@ const BlogContent = ({ content, images }) => {
           ))}
         </p>
       ),
+      [INLINES.EMBEDDED_ENTRY]: node => {
+        if (typeof node.data.target.fields === 'undefined') {
+          return null
+        }
+        if (
+          node.data.target.sys.contentType.sys.contentful_id ===
+          'contentBlockFootnoteLink'
+        ) {
+          footnoteNumber += 1
+          return <FootnoteContentBlock number={footnoteNumber} />
+        }
+        return null
+      },
       [BLOCKS.EMBEDDED_ENTRY]: node => {
         if (typeof node.data.target.fields === 'undefined') {
           return null

--- a/src/components/pages/blog/blog-content.js
+++ b/src/components/pages/blog/blog-content.js
@@ -27,7 +27,7 @@ const BlogContent = ({ content, images }) => {
         }
         if (
           node.data.target.sys.contentType.sys.contentful_id ===
-          'contentBlockFootnoteLink'
+          'contentBlockFootnote'
         ) {
           footnoteNumber += 1
           return <FootnoteContentBlock number={footnoteNumber} />

--- a/src/components/pages/blog/content-blocks/footnote-content-block.js
+++ b/src/components/pages/blog/content-blocks/footnote-content-block.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import { Link } from 'gatsby'
+
+const FootnoteContentBlock = ({ number }) => (
+  <sup id={`original-footnote-${number}`}>
+    <Link to={`#footnote-${number}`}>{number}</Link>
+  </sup>
+)
+
+export default FootnoteContentBlock

--- a/src/components/pages/blog/footer/blog-footnotes.js
+++ b/src/components/pages/blog/footer/blog-footnotes.js
@@ -49,7 +49,7 @@ const Footnotes = ({ footnoteText, content }) => {
           dangerouslySetInnerHTML={{ __html: footnoteText }}
         />
       )}
-      {footnotes.length && (
+      {footnotes.length > 0 && (
         <div className={blogFootnotesStyle.footnotes}>
           {footnotes.map((footnote, index) => (
             <Footnote

--- a/src/components/pages/blog/footer/blog-footnotes.js
+++ b/src/components/pages/blog/footer/blog-footnotes.js
@@ -29,7 +29,7 @@ const Footnotes = ({ footnoteText, content }) => {
       if (
         typeof item.nodeType === 'undefined' ||
         item.nodeType !== 'embedded-entry-inline' ||
-        item.data.target.sys.contentType.sys.id !== 'contentBlockFootnoteLink'
+        item.data.target.sys.contentType.sys.id !== 'contentBlockFootnote'
       ) {
         return
       }

--- a/src/components/pages/blog/footer/blog-footnotes.js
+++ b/src/components/pages/blog/footer/blog-footnotes.js
@@ -1,15 +1,67 @@
+/* eslint-disable react/no-array-index-key */
 import React from 'react'
+import marked from 'marked'
+import { Link } from 'gatsby'
 import Container from '~components/common/container'
 import blogFootnotesStyle from './blog-footnotes.module.scss'
 
-const Footnotes = ({ footnotes }) => (
-  <Container centered>
-    <div
-      id="footnotes"
-      className={blogFootnotesStyle.footnotes}
-      dangerouslySetInnerHTML={{ __html: footnotes }}
+const Footnote = ({ number, footnote }) => (
+  <p id={`footnote-${number}`}>
+    <Link to={`#original-footnote-${number}`}>
+      <strong>{number}</strong>
+    </Link>{' '}
+    <span
+      dangerouslySetInnerHTML={{
+        __html: marked.inlineLexer(footnote, []),
+      }}
     />
-  </Container>
+  </p>
 )
+
+const Footnotes = ({ footnoteText, content }) => {
+  const footnotes = []
+
+  content.content.forEach(entry => {
+    if (typeof entry.content === 'undefined') {
+      return
+    }
+    entry.content.forEach(item => {
+      if (
+        typeof item.nodeType === 'undefined' ||
+        item.nodeType !== 'embedded-entry-inline' ||
+        item.data.target.sys.contentType.sys.id !== 'contentBlockFootnoteLink'
+      ) {
+        return
+      }
+      footnotes.push(item.data.target.fields.footnote['en-US'])
+    })
+  })
+  if (!footnoteText && !footnotes.length) {
+    return null
+  }
+
+  return (
+    <Container centered>
+      {footnoteText && (
+        <div
+          id="footnotes"
+          className={blogFootnotesStyle.footnotes}
+          dangerouslySetInnerHTML={{ __html: footnoteText }}
+        />
+      )}
+      {footnotes.length && (
+        <div className={blogFootnotesStyle.footnotes}>
+          {footnotes.map((footnote, index) => (
+            <Footnote
+              key={`footnote-${index}`}
+              number={index + 1}
+              footnote={footnote}
+            />
+          ))}
+        </div>
+      )}
+    </Container>
+  )
+}
 
 export default Footnotes

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -44,14 +44,14 @@ const BlogPostTemplate = ({ data, path }) => {
         content={blogPost.childContentfulBlogPostBlogContentRichTextNode.json}
         images={blogImages}
       />
-      {blogPost.childContentfulBlogPostFootnotesTextNode && (
-        <BlogPostFootnotes
-          footnotes={
-            blogPost.childContentfulBlogPostFootnotesTextNode
-              .childMarkdownRemark.html
-          }
-        />
-      )}
+      <BlogPostFootnotes
+        footnoteText={
+          blogPost.childContentfulBlogPostFootnotesTextNode &&
+          blogPost.childContentfulBlogPostFootnotesTextNode.childMarkdownRemark
+            .html
+        }
+        content={blogPost.childContentfulBlogPostBlogContentRichTextNode.json}
+      />
       <BlogPostExtras blogPost={blogPost} />
     </Layout>
   )


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Uses a new "Content block: Footnote" inline block element to render footnotes.
- Fixes #1504 - Adds a link back to the inline footnote block
- Fixes #1499 - Formats the footnote link as a superscript link

## Pre-merging
- [x] Setup block type in `master` in Contentful
- [x] Change environment in branch back to `master`