### PR TITLE
chore: Fix shortened contentful blog redirects

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -206,6 +206,11 @@ exports.createPages = async ({ graphql, actions }) => {
         component: path.resolve(`./src/templates/blog-post.js`),
         context: { ...node, blogImages },
       })
+
+      createRedirect({
+        fromPath: shortPath,
+        toPath: longPath,
+      })
     }
   })
 


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Fixes missing redirects from contentful ID based redirects