### PR TITLE
chore: Force hide responsive table labels on desktop

### DIFF
--- a/src/__tests__/components/common/__snapshots__/table-responsive.js.snap
+++ b/src/__tests__/components/common/__snapshots__/table-responsive.js.snap
@@ -26,7 +26,7 @@ exports[`Components : Common: Responsive table renders correctly 1`] = `
         className="noWrap"
       >
         <span
-          className="label"
+          className="cellLabel"
         >
           Date
         </span>
@@ -40,7 +40,7 @@ exports[`Components : Common: Responsive table renders correctly 1`] = `
         className=""
       >
         <span
-          className="label"
+          className="cellLabel"
         >
           Data
         </span>
@@ -56,7 +56,7 @@ exports[`Components : Common: Responsive table renders correctly 1`] = `
         className="noWrap"
       >
         <span
-          className="label"
+          className="cellLabel"
         >
           Date
         </span>
@@ -70,7 +70,7 @@ exports[`Components : Common: Responsive table renders correctly 1`] = `
         className=""
       >
         <span
-          className="label"
+          className="cellLabel"
         >
           Data
         </span>

--- a/src/components/common/table-responsive.js
+++ b/src/components/common/table-responsive.js
@@ -30,7 +30,7 @@ const TableResponsive = ({ labels, data }) => (
                   alignLeft && tableStyles.alignLeft,
                 )}
               >
-                <span className={tableResponsiveStyles.label}>
+                <span className={tableResponsiveStyles.cellLabel}>
                   {label || <FieldName field={field} />}
                 </span>
                 <span className={tableResponsiveStyles.value}>

--- a/src/components/common/table-responsive.module.scss
+++ b/src/components/common/table-responsive.module.scss
@@ -25,12 +25,12 @@ $table-breakpoint: $viewport-lg;
   white-space: nowrap;
 }
 
-.label {
+.cell-label {
   white-space: pre-line;
   font-weight: bold;
   display: inline-block;
   text-align: left;
   @media (min-width: $table-breakpoint) {
-    display: none !important;
+    display: none;
   }
 }

--- a/src/components/common/table-responsive.module.scss
+++ b/src/components/common/table-responsive.module.scss
@@ -31,6 +31,6 @@ $table-breakpoint: $viewport-lg;
   display: inline-block;
   text-align: left;
   @media (min-width: $table-breakpoint) {
-    display: none;
+    display: none !important;
   }
 }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Fixes an esoteric issue with CSS minified class names and labels in responsive tables