### PR TITLE
chore: Remove link to public spreadsheet

### DIFF
--- a/src/components/pages/state/download-data.js
+++ b/src/components/pages/state/download-data.js
@@ -26,13 +26,6 @@ const DownloadData = ({ slug, hideLabel = false }) => (
       >
         API
       </Link>
-      <a
-        href="https://docs.google.com/spreadsheets/u/2/d/e/2PACX-1vRwAqp96T9sYYq2-i7Tj0pvTf6XVHjDSMIKBdZHXiCGGdNC0ypEU9NbngS8mxea55JuCFuua1MUeOj5/pubhtml"
-        className={downloadDataStyles.button}
-        aria-label={`Get ${slug} data as a spreadsheet`}
-      >
-        Spreadsheet
-      </a>
     </p>
   </div>
 )


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Per our [deprecation announcement](https://apichanges.covidtracking.com/deprecation-of-the-public-spreadsheet-172468), this removes the public sheet from the website.