### PR TITLE
chore: Change from "Get involved" to "Volunteer"

### DIFF
--- a/src/__tests__/components/layout/__snapshots__/header.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/header.js.snap
@@ -216,7 +216,7 @@ exports[`Components : Layout : Header renders correctly 1`] = `
           className="getInvolved"
           href="/contact/volunteer"
         >
-          Get Involved
+          Volunteer
         </a>
         <div
           className="mobilePointer"
@@ -448,7 +448,7 @@ exports[`Components : Layout : Header renders correctly 1`] = `
             className="getInvolved"
             href="/contact/volunteer"
           >
-            Get involved
+            Volunteer
           </a>
         </div>
       </div>
@@ -707,7 +707,7 @@ exports[`Components : Layout : Header renders correctly 2`] = `
           className="getInvolved"
           href="/contact/volunteer"
         >
-          Get Involved
+          Volunteer
         </a>
         <div
           className="mobilePointer"
@@ -939,7 +939,7 @@ exports[`Components : Layout : Header renders correctly 2`] = `
             className="getInvolved"
             href="/contact/volunteer"
           >
-            Get involved
+            Volunteer
           </a>
         </div>
       </div>
@@ -1198,7 +1198,7 @@ exports[`Components : Layout : Header renders correctly 3`] = `
           className="getInvolved"
           href="/contact/volunteer"
         >
-          Get Involved
+          Volunteer
         </a>
         <div
           className="mobilePointer"
@@ -1430,7 +1430,7 @@ exports[`Components : Layout : Header renders correctly 3`] = `
             className="getInvolved"
             href="/contact/volunteer"
           >
-            Get involved
+            Volunteer
           </a>
         </div>
       </div>
@@ -1693,7 +1693,7 @@ exports[`Components : Layout : Header renders correctly 4`] = `
           className="getInvolved"
           href="/contact/volunteer"
         >
-          Get Involved
+          Volunteer
         </a>
         <div
           className="mobilePointer"
@@ -1925,7 +1925,7 @@ exports[`Components : Layout : Header renders correctly 4`] = `
             className="getInvolved"
             href="/contact/volunteer"
           >
-            Get involved
+            Volunteer
           </a>
         </div>
       </div>
@@ -2184,7 +2184,7 @@ exports[`Components : Layout : Header renders correctly 5`] = `
           className="getInvolved"
           href="/contact/volunteer"
         >
-          Get Involved
+          Volunteer
         </a>
         <div
           className="mobilePointer"
@@ -2416,7 +2416,7 @@ exports[`Components : Layout : Header renders correctly 5`] = `
             className="getInvolved"
             href="/contact/volunteer"
           >
-            Get involved
+            Volunteer
           </a>
         </div>
       </div>

--- a/src/__tests__/components/layout/__snapshots__/index.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/index.js.snap
@@ -224,7 +224,7 @@ Array [
             className="getInvolved"
             href="/contact/volunteer"
           >
-            Get Involved
+            Volunteer
           </a>
           <div
             className="mobilePointer"
@@ -456,7 +456,7 @@ Array [
               className="getInvolved"
               href="/contact/volunteer"
             >
-              Get involved
+              Volunteer
             </a>
           </div>
         </div>
@@ -869,7 +869,7 @@ Array [
             className="getInvolved"
             href="/contact/volunteer"
           >
-            Get Involved
+            Volunteer
           </a>
           <div
             className="mobilePointer"
@@ -1101,7 +1101,7 @@ Array [
               className="getInvolved"
               href="/contact/volunteer"
             >
-              Get involved
+              Volunteer
             </a>
           </div>
         </div>

--- a/src/components/layout/header/mobile-menu.js
+++ b/src/components/layout/header/mobile-menu.js
@@ -62,7 +62,7 @@ const MobileMenu = ({ expanded, topNavigation, subNavigation }) => {
         isMobile
       />
       <Link to="/contact/volunteer" className={headerStyle.getInvolved}>
-        Get Involved
+        Volunteer
       </Link>
       <div className={mobileMenuStyle.mobilePointer} />
     </div>

--- a/src/components/layout/header/tools.js
+++ b/src/components/layout/header/tools.js
@@ -9,7 +9,7 @@ const Tools = () => (
       <HeaderSearch />
     </div>
     <Link to="/contact/volunteer" className={headerStyle.getInvolved}>
-      Get involved
+      Volunteer
     </Link>
   </div>
 )


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Renames the "Get involved" button to "Volunteer"