### PR TITLE
chore: Search tweets with state abbreviation

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -144,7 +144,7 @@ exports.createPages = async ({ graphql, actions }) => {
       component: path.resolve(`./src/templates/state/index.js`),
       context: {
         ...node,
-        nameRegex: `/${node.name}/g`,
+        nameRegex: `/${node.name}|${node.state.toUpperCase()}/g`,
         slug,
       },
     })


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Finds tweets for a state based on name, or capitalized abbreviation