### PR TITLE
chore: GraphQL audit

### DIFF
--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -82,9 +82,6 @@ export const query = graphql`
     nationalSummaryFootnote: contentfulSnippet(
       slug: { eq: "national-summary-footnote" }
     ) {
-      id
-      contentful_id
-      name
       content {
         childMarkdownRemark {
           html
@@ -92,7 +89,6 @@ export const query = graphql`
       }
     }
     dataPreamble: contentfulSnippet(slug: { eq: "data-preamble" }) {
-      id
       contentful_id
       name
       content {
@@ -102,18 +98,18 @@ export const query = graphql`
       }
     }
     covidUs {
+      death
+      hospitalizedCumulative
+      hospitalizedCurrently
+      inIcuCumulative
+      inIcuCurrently
+      negative
+      onVentilatorCumulative
+      onVentilatorCurrently
+      pending
       positive
       positiveIncrease
-      negative
-      pending
-      hospitalizedCurrently
-      hospitalizedCumulative
-      inIcuCurrently
-      inIcuCumulative
       recovered
-      onVentilatorCurrently
-      onVentilatorCumulative
-      death
       totalTestResults
       totalTestResultsIncrease
     }
@@ -123,11 +119,11 @@ export const query = graphql`
     }
     allCovidStateInfo(sort: { fields: name }) {
       nodes {
-        name
-        state
-        notes
         covid19Site
         covid19SiteSecondary
+        name
+        notes
+        state
         twitter
         childSlug {
           slug
@@ -137,10 +133,10 @@ export const query = graphql`
     allCovidUsDaily {
       nodes {
         date(formatString: "YYYYMMDD")
-        totalTestResultsIncrease
-        positiveIncrease
-        hospitalizedCurrently
         deathIncrease
+        hospitalizedCurrently
+        positiveIncrease
+        totalTestResultsIncrease
         childPopulation {
           deathIncrease {
             percent
@@ -160,6 +156,7 @@ export const query = graphql`
     allCovidState {
       nodes {
         dataQualityGrade
+        dateModified(formatString: "MMM D, YYYY h:mm a")
         death
         deathConfirmed
         deathProbable
@@ -168,24 +165,22 @@ export const query = graphql`
         inIcuCumulative
         inIcuCurrently
         lastUpdateEt
-        dateModified(formatString: "MMM D, YYYY h:mm a")
         negative
         negativeTestsViral
         onVentilatorCumulative
         onVentilatorCurrently
         positive
         positiveCasesViral
-        probableCases
         positiveIncrease
         positiveTestsViral
+        probableCases
         recovered
         state
+        totalTestEncountersViral
         totalTestResults
-        totalTestResults
+        totalTestsAntibody
         totalTestsPeopleViral
         totalTestsViral
-        totalTestEncountersViral
-        totalTestsAntibody
       }
     }
     allCovidStateDaily(filter: { date: { eq: $sevenDaysAgo } }) {
@@ -209,9 +204,9 @@ export const query = graphql`
         description {
           description
         }
-        date(formatString: "YYYYMMDD")
-        dataElement
         contentful_id
+        dataElement
+        date(formatString: "YYYYMMDD")
         childContentfulChartAnnotationDescriptionTextNode {
           childMarkdownRemark {
             html

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -179,7 +179,7 @@ export const query = graphql`
         probableCases
         positiveIncrease
         positiveTestsViral
-        posNeg
+
         recovered
         state
         totalTestResults

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -173,13 +173,11 @@ export const query = graphql`
         negativeTestsViral
         onVentilatorCumulative
         onVentilatorCurrently
-        pending
         positive
         positiveCasesViral
         probableCases
         positiveIncrease
         positiveTestsViral
-
         recovered
         state
         totalTestResults

--- a/src/pages/data/longtermcare.js
+++ b/src/pages/data/longtermcare.js
@@ -132,9 +132,9 @@ export default LongTermCarePage
 export const query = graphql`
   query {
     covidLtcWebsite {
-      facilitiesCumulative
-      deathsCumulative
       casesCumulative
+      deathsCumulative
+      facilitiesCumulative
     }
     contentfulSnippetCollection(slug: { eq: "long-term-care-landing-page" }) {
       snippets {

--- a/src/pages/data/national/index.js
+++ b/src/pages/data/national/index.js
@@ -85,7 +85,6 @@ export const query = graphql`
         hospitalizedCurrently
         states
         positive
-        pending
         negative
         hospitalizedCumulative
         death

--- a/src/pages/data/national/index.js
+++ b/src/pages/data/national/index.js
@@ -80,16 +80,16 @@ export const query = graphql`
     }
     allCovidUsDaily(sort: { order: DESC, fields: date }) {
       nodes {
+        date(formatString: "MMM D, YYYY")
+        death
+        hospitalizedCumulative
+        hospitalizedCurrently
+        negative
+        positive
+        recovered
+        states
         totalTestResults
         totalTestResultsIncrease
-        hospitalizedCurrently
-        states
-        positive
-        negative
-        hospitalizedCumulative
-        death
-        date(formatString: "MMM D, YYYY")
-        recovered
       }
     }
     allContentfulDataDefinition(

--- a/src/templates/state/index.js
+++ b/src/templates/state/index.js
@@ -131,20 +131,12 @@ export const query = graphql`
       sort: { fields: date, order: DESC }
     ) {
       nodes {
-        totalTestResults
-        totalTestEncountersViral
         totalTestEncountersViralIncrease
         totalTestsViralIncrease
         totalTestsPeopleViralIncrease
         totalTestResultsIncrease
-        positive
         positiveIncrease
-        pending
-        negative
-        hospitalized
         hospitalizedCurrently
-        hospitalizedIncrease
-        death
         deathIncrease
         date(formatString: "YYYYMMDD")
         childPopulation {

--- a/src/templates/state/index.js
+++ b/src/templates/state/index.js
@@ -103,7 +103,7 @@ export const query = graphql`
       negative
       lastUpdateEt
       dateModified(formatString: "MMM D, YYYY h:mm a")
-      pending
+
       hospitalizedCurrently
       hospitalizedCumulative
       inIcuCurrently

--- a/src/templates/state/index.js
+++ b/src/templates/state/index.js
@@ -82,29 +82,15 @@ export const query = graphql`
     }
     allCovidUsDaily {
       nodes {
-        totalTestResults
-        totalTestResultsIncrease
-        positive
-        positiveIncrease
-        pending
-        negative
-        hospitalized
-        hospitalizedIncrease
-        hospitalizedCurrently
-        death
-        deathIncrease
         date(formatString: "YYYYMMDD")
         childPopulation {
           deathIncrease {
             percent
           }
-          hospitalizedCurrently {
-            percent
-          }
           positiveIncrease {
             percent
           }
-          totalTestResultsIncrease {
+          hospitalizedCurrently {
             percent
           }
         }
@@ -130,7 +116,6 @@ export const query = graphql`
       deathConfirmed
       totalTestResults
       dataQualityGrade
-      posNeg
       probableCases
       positiveCasesViral
       positiveTestsViral

--- a/src/utilities/csv.js
+++ b/src/utilities/csv.js
@@ -93,7 +93,6 @@ module.exports = (graphql, reporter) => {
               negativeIncrease
               onVentilatorCumulative
               onVentilatorCurrently
-              posNeg
               positive
               positiveIncrease
               recovered

--- a/src/utilities/csv.js
+++ b/src/utilities/csv.js
@@ -54,7 +54,6 @@ module.exports = (graphql, reporter) => {
               negativeTestsViral
               onVentilatorCumulative
               onVentilatorCurrently
-              pending
               positive
               positiveCasesViral
               positiveIncrease


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Sorted fields in long queries
- Removed unused fields in state and data pages