### PR TITLE
feat(blog): update language for related weekly update posts

### DIFF
--- a/src/components/pages/blog/footer/related-posts.js
+++ b/src/components/pages/blog/footer/related-posts.js
@@ -20,7 +20,7 @@ const RelatedPosts = ({ blogPost }) => {
     // 2. (if no explicit related posts) Use recent posts from the
     //    post's first category if there are at least 3 others
     footerPosts = categories[0].blog_post.filter(post => post.publishDate)
-    relatedTitle = `More “${categories[0].name}” posts`
+    relatedTitle = categories[0].name == 'Weekly Update' ? 'More Weekly Updates' : `More “${categories[0].name}” posts`
   } else {
     // 3. (if no category) Display recent posts
     const recentPosts = useStaticQuery(graphql`


### PR DESCRIPTION
This handles a special case for blog categories such that related weekly update posts appear like:

![image](https://user-images.githubusercontent.com/18607205/97755059-22823880-1abe-11eb-9ede-7674e4d6fa71.png)

...instead of:
![image](https://user-images.githubusercontent.com/18607205/97754491-37aa9780-1abd-11eb-9d31-d578736e8fb3.png)
