### PR TITLE
chore: Sort counties CSV by state, name

### DIFF
--- a/plugins/gatsby-source-covid-tracking-counties/gatsby-node.js
+++ b/plugins/gatsby-source-covid-tracking-counties/gatsby-node.js
@@ -10,13 +10,19 @@ exports.sourceNodes = ({ actions, createNodeId, reporter }, configOptions) => {
     counties.forEach(county => {
       const fipsKey =
         !county.fips && county.county === 'New York City' ? 'nyc' : county.fips
+      if (!fipsKey) {
+        return
+      }
       if (typeof countyResults[fipsKey] === 'undefined') {
         countyResults[fipsKey] = {
           name: county.county,
           state: county.state,
           fips: fipsKey,
           current: county,
-          demographics: demographics.find(element => element.fips === fipsKey),
+          demographics: demographics.find(
+            element =>
+              element.fips.replace(/^0+/, '') === fipsKey.replace(/^0+/, ''),
+          ),
         }
       }
     })

--- a/src/utilities/csv.js
+++ b/src/utilities/csv.js
@@ -15,7 +15,10 @@ module.exports = (graphql, reporter) => {
               }
             }
           }
-          allCounties(filter: { demographics: { total: { gt: 0 } } }) {
+          allCounties(
+            filter: { demographics: { total: { gt: 0 } } }
+            sort: { fields: [state, name] }
+          ) {
             nodes {
               name
               state


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fixes issue with counties with padded FIPS code in NYT dataset
- Sort counties CSV file by state, then county name