### PR TITLE
chore: Fix sort on annotations in notes

### DIFF
--- a/src/components/pages/data/summary-charts.js
+++ b/src/components/pages/data/summary-charts.js
@@ -263,8 +263,8 @@ const SummaryCharts = ({
 
   const splitAnnotations = generateAnnotationNumbers(annotations.nodes)
   const flattenedAnnotations = Object.values(splitAnnotations)
-    .reduce((acc, val) => [...acc, ...val], []) // .flat() // doesn't work in node
-    .sort((a, b) => a.annotationNumber - b.annotationNumber)
+    .reduce((acc, val) => [...acc, ...val], [])
+    .sort((a, b) => (a.annotationNumber > b.annotationNumber ? 1 : -1))
 
   const getAlertMessage = (field, current = false) =>
     `${name} has not reported data on  ${


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Sort was reversed on notes and annotations