### PR TITLE
feat: Refactor contentful rich text to canary version

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -59,9 +59,6 @@ exports.createPages = async ({ graphql, actions }) => {
           slug
           overrideBlogPage
           overrideBlogPath
-          childContentfulBlogPostBlogContentRichTextNode {
-            json
-          }
         }
       }
       allContentfulBlogCategory {
@@ -212,18 +209,6 @@ exports.createPages = async ({ graphql, actions }) => {
   })
 
   result.data.allContentfulBlogPost.nodes.forEach(node => {
-    const blogImages = []
-    node.childContentfulBlogPostBlogContentRichTextNode.json.content
-      .filter(
-        block =>
-          block.nodeType === 'embedded-entry-block' &&
-          block.data.target.sys.contentType &&
-          block.data.target.sys.contentType.sys.id === 'contentBlockImage',
-      )
-      .forEach(image => {
-        blogImages.push(image.data.target.sys.contentful_id)
-      })
-
     const longPath = `/blog/${node.slug}`
     const shortPath = `/${node.contentful_id}`
 
@@ -236,7 +221,7 @@ exports.createPages = async ({ graphql, actions }) => {
       createPage({
         path: longPath,
         component: path.resolve(`./src/templates/blog-post.js`),
-        context: { ...node, blogImages },
+        context: node,
       })
 
       createRedirect({

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
   "scripts": {
     "build": "run-s setup:api-repo setup:data-repo build:gatsby build:test",
     "build-preview": "run-s setup build:gatsby build:test",
-    "build:gatsby": "gatsby build",
+    "build:gatsby": "GATSBY_EXPERIMENTAL_PAGE_BUILD_ON_DATA_CHANGES=true gatsby build --log-pages",
     "build:test": "jest --verbose --config=\"{}\" -- src/__tests__/build/index.js",
     "clean": "run-p clean:*",
     "clean:gatsby": "gatsby clean",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   ],
   "dependencies": {
     "@contentful/rich-text-plain-text-renderer": "^14.1.1",
-    "@contentful/rich-text-react-renderer": "^13.4.0",
     "@contentful/rich-text-types": "^14.1.0",
     "@loadable/component": "^5.13.2",
     "@reach/alert": "^0.9.1",
@@ -68,7 +67,7 @@
     "gatsby-plugin-sitemap": "^2.4.14",
     "gatsby-remark-autolink-headers": "^2.3.14",
     "gatsby-remark-smartypants": "^2.3.12",
-    "gatsby-source-contentful": "^2.3.48",
+    "gatsby-source-contentful": "4.0.0-4.0.0-rc.0.20",
     "gatsby-source-filesystem": "^2.3.31",
     "gatsby-transformer-json": "^2.4.13",
     "gatsby-transformer-remark": "^2.8.36",

--- a/src/components/pages/blog/content-blocks/related-posts-block.js
+++ b/src/components/pages/blog/content-blocks/related-posts-block.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import marked from 'marked'
 import { Link } from 'gatsby'
 import relatedPostStyles from './related-posts-block.module.scss'
 
@@ -9,15 +8,13 @@ const RelatedPostsContentBlock = ({ headline, subtitle, references }) => (
     {subtitle && (
       <div
         className={relatedPostStyles.subtitle}
-        dangerouslySetInnerHTML={{ __html: marked(subtitle) }}
+        dangerouslySetInnerHTML={{ __html: subtitle }}
       />
     )}
     <ul>
-      {references.map(reference => (
-        <li key={reference.fields.slug['en-US']}>
-          <Link to={`/blog/${reference.fields.slug['en-US']}`}>
-            {reference.fields.title['en-US']}
-          </Link>
+      {references.map(({ slug, title }) => (
+        <li key={slug}>
+          <Link to={`/blog/${slug}`}>{title}</Link>
         </li>
       ))}
     </ul>

--- a/src/components/pages/blog/footer/blog-footnotes.js
+++ b/src/components/pages/blog/footer/blog-footnotes.js
@@ -1,4 +1,4 @@
-/* eslint-disable react/no-array-index-key */
+/* eslint-disable no-underscore-dangle,react/no-array-index-key */
 import React from 'react'
 import marked from 'marked'
 import { Link } from 'gatsby'
@@ -18,29 +18,10 @@ const Footnote = ({ number, footnote }) => (
   </p>
 )
 
-const Footnotes = ({ footnoteText, content }) => {
-  const footnotes = []
-
-  content.content.forEach(entry => {
-    if (typeof entry.content === 'undefined') {
-      return
-    }
-    entry.content.forEach(item => {
-      if (
-        typeof item.nodeType === 'undefined' ||
-        item.nodeType !== 'embedded-entry-inline' ||
-        typeof item.data.target.sys.contentType === 'undefined' ||
-        item.data.target.sys.contentType.sys.id !== 'contentBlockFootnote'
-      ) {
-        return
-      }
-      footnotes.push(item.data.target.fields.footnote['en-US'])
-    })
-  })
-  if (!footnoteText && !footnotes.length) {
-    return null
-  }
-
+const Footnotes = ({ footnoteText, contentBlocks }) => {
+  const footnotes = contentBlocks.filter(
+    block => block.__typename === 'ContentfulContentBlockFootnote',
+  )
   return (
     <Container centered>
       {footnoteText && (
@@ -52,11 +33,11 @@ const Footnotes = ({ footnoteText, content }) => {
       )}
       {footnotes.length > 0 && (
         <div className={blogFootnotesStyle.footnotes}>
-          {footnotes.map((footnote, index) => (
+          {footnotes.map(({ footnote }, index) => (
             <Footnote
               key={`footnote-${index}`}
               number={index + 1}
-              footnote={footnote}
+              footnote={footnote.footnote}
             />
           ))}
         </div>

--- a/src/components/pages/state/long-term-care/facilities.js
+++ b/src/components/pages/state/long-term-care/facilities.js
@@ -304,7 +304,7 @@ const LongTermCareFacilities = ({ facilities }) => {
                   { lower: true },
                 )
                 return (
-                  <tr key={facility.id} id={facilityId}>
+                  <tr key={facilityId} id={facilityId}>
                     {hasCounty && <Td alignLeft>{facility.county}</Td>}
                     {hasCity && <Td alignLeft>{facility.city}</Td>}
                     <Td alignLeft>

--- a/src/pages/blog/test-positivity.js
+++ b/src/pages/blog/test-positivity.js
@@ -229,9 +229,7 @@ export const query = graphql`
           }
         }
       }
-      childContentfulBlogPostBlogContentRichTextNode {
-        json
-      }
+
       featuredImage {
         resize(width: 900) {
           src

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -10,10 +10,6 @@ import Hero from '~components/pages/blog/blog-hero'
 
 const BlogPostTemplate = ({ data, path }) => {
   const blogPost = data.contentfulBlogPost
-  const blogImages = {}
-  data.allContentfulContentBlockImage.nodes.forEach(image => {
-    blogImages[image.contentful_id] = image
-  })
   const socialCard = blogPost.socialCard || { description: blogPost.lede.lede }
   const hero = (
     <Hero
@@ -40,17 +36,14 @@ const BlogPostTemplate = ({ data, path }) => {
       {blogPost.featuredImage && (
         <FeaturedImage image={blogPost.featuredImage} />
       )}
-      <BlogPostContent
-        content={blogPost.childContentfulBlogPostBlogContentRichTextNode.json}
-        images={blogImages}
-      />
+      <BlogPostContent content={blogPost.blogContent} />
       <BlogPostFootnotes
         footnoteText={
           blogPost.childContentfulBlogPostFootnotesTextNode &&
           blogPost.childContentfulBlogPostFootnotesTextNode.childMarkdownRemark
             .html
         }
-        content={blogPost.childContentfulBlogPostBlogContentRichTextNode.json}
+        contentBlocks={blogPost.blogContent.references}
       />
       <BlogPostExtras blogPost={blogPost} />
     </Layout>
@@ -60,7 +53,7 @@ const BlogPostTemplate = ({ data, path }) => {
 export default BlogPostTemplate
 
 export const query = graphql`
-  query($id: String!, $blogImages: [String]) {
+  query($id: String!) {
     contentfulBlogPost(id: { eq: $id }) {
       contentful_id
       title
@@ -127,6 +120,11 @@ export const query = graphql`
           lede
         }
       }
+      childContentfulBlogPostFootnotesTextNode {
+        childMarkdownRemark {
+          html
+        }
+      }
       categories {
         name
         slug
@@ -160,8 +158,75 @@ export const query = graphql`
           }
         }
       }
-      childContentfulBlogPostBlogContentRichTextNode {
-        json
+      blogContent {
+        raw
+        references {
+          ... on ContentfulContentBlockTableauChart {
+            id
+            contentful_id
+            name
+            height
+            mobileUrl
+            url
+          }
+          ... on ContentfulContentBlockTable {
+            id
+            contentful_id
+            table {
+              table
+            }
+          }
+          ... on ContentfulContentBlockRelatedPosts {
+            id
+            contentful_id
+            headline
+            subtitle {
+              childMarkdownRemark {
+                html
+              }
+            }
+            relatedPosts {
+              title
+              slug
+            }
+          }
+          ... on ContentfulContentBlockMarkdown {
+            id
+            contentful_id
+            childContentfulContentBlockMarkdownContentTextNode {
+              childMarkdownRemark {
+                html
+              }
+            }
+          }
+          ... on ContentfulContentBlockImage {
+            id
+            contentful_id
+            keepSize
+            fullWidthMobile
+            caption
+            image {
+              file {
+                url
+              }
+              title
+              description
+              fluid(maxWidth: 2000, sizes: "4") {
+                aspectRatio
+                sizes
+                src
+                srcSet
+              }
+            }
+          }
+          ... on ContentfulContentBlockFootnote {
+            id
+            contentful_id
+            footnote {
+              footnote
+            }
+          }
+        }
       }
       featuredImage {
         resize(width: 900) {
@@ -177,29 +242,6 @@ export const query = graphql`
       childContentfulBlogPostBodyTextNode {
         childMarkdownRemark {
           html
-        }
-      }
-
-      childContentfulBlogPostFootnotesTextNode {
-        childMarkdownRemark {
-          html
-        }
-      }
-    }
-    allContentfulContentBlockImage(
-      filter: { contentful_id: { in: $blogImages } }
-    ) {
-      nodes {
-        contentful_id
-        image {
-          title
-          description
-          fluid(maxWidth: 2000, sizes: "4") {
-            aspectRatio
-            sizes
-            src
-            srcSet
-          }
         }
       }
     }

--- a/src/templates/state/long-term-care.js
+++ b/src/templates/state/long-term-care.js
@@ -188,7 +188,6 @@ export const query = graphql`
     ) {
       group(field: facility_name, limit: 1) {
         nodes {
-          id
           facility_name
           city
           date

--- a/src/utilities/algolia.js
+++ b/src/utilities/algolia.js
@@ -53,8 +53,8 @@ const blogPostQuery = `{
           lede
         }
         updatedAt(formatString: "MMMM D, YYYY")
-        childContentfulBlogPostBlogContentRichTextNode {
-          json
+        blogContent {
+          raw
         }
         body {
           body
@@ -195,15 +195,13 @@ function chunkBlogPosts(data) {
     const firstChunk = { ...baseChunk, section: 'section0' }
 
     let bodyChunks
-    if (node.childContentfulBlogPostBlogContentRichTextNode === null) {
+    if (node.blogContent === null) {
       // todo remove this once we fully transition to rich text for blog posts
       bodyChunks = marked(node.body.body)
         .split('\n')
         .filter(chunk => chunk !== '')
     } else {
-      bodyChunks = documentToPlainTextString(
-        node.childContentfulBlogPostBlogContentRichTextNode.json,
-      )
+      bodyChunks = documentToPlainTextString(JSON.parse(node.blogContent.raw))
         .split('. ') // new sentences
         .filter(chunk => chunk !== '')
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1199,22 +1199,22 @@
   dependencies:
     "@contentful/rich-text-types" "^14.1.1"
 
-"@contentful/rich-text-react-renderer@^13.4.0":
-  version "13.4.0"
-  resolved "https://registry.yarnpkg.com/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-13.4.0.tgz#2efb556f58d608472c2dde692153c7b7b985fae7"
-  integrity sha512-hZL0DQ+Qj+a9CWsu7bmEp5eh6ERX5pcL+k8+LNlkR3j1jBNraANV2qL3tGXZoR5haSxeCMo+KTryMf/7BRZbrg==
+"@contentful/rich-text-react-renderer@^14.1.1":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-react-renderer/-/rich-text-react-renderer-14.1.2.tgz#b7fff19faa0512f034f1717774a0d9b348bb07fc"
+  integrity sha512-UmZ5nNvFXuD4LA2TKDDD52FgzmeMAQUVu5p9UqKDVDG6twHAD4DiWtoXSRM5Bebftlx2UH+UeWHbxIOgF/lV5A==
   dependencies:
-    "@contentful/rich-text-types" "^13.4.0"
-
-"@contentful/rich-text-types@^13.4.0":
-  version "13.4.0"
-  resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-13.4.0.tgz#a59c311ebd1b801ee00edbc08663c8d78da26171"
-  integrity sha512-YPdYqGmWiGAood7ri2BUXfPQKNthkQYV1rmQdaq4UAxWK5NLB5NXckaUYLbohqhHKtrq4tnfzVn+ePWID7Dzbg==
+    "@contentful/rich-text-types" "^14.1.2"
 
 "@contentful/rich-text-types@^14.1.0", "@contentful/rich-text-types@^14.1.1":
   version "14.1.1"
   resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-14.1.1.tgz#2b105c8fdb36cd1f8ed06ce077a853f4ab5e3770"
   integrity sha512-Iow9U3so7V+2AngYLmt42BGtHjHGl+DQpxvXaryJe1X9LPHrQ41pALztJZFzDgajoEswBjOgmI9CFeQ1oUAdJA==
+
+"@contentful/rich-text-types@^14.1.2":
+  version "14.1.2"
+  resolved "https://registry.yarnpkg.com/@contentful/rich-text-types/-/rich-text-types-14.1.2.tgz#33162fdbf427891122a96030f806ca9a9cf0e844"
+  integrity sha512-XbgZ7op5uyYYszipgQg/bYobF4b+llXyTwS8hISRniQY9xKESz544eP2OGmRc4J3MHx29M7Vmx7TVA/IK65giQ==
 
 "@egoist/vue-to-react@^1.1.0":
   version "1.1.0"
@@ -1355,6 +1355,11 @@
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-8.5.1.tgz#fde96064ca446dec8c55a8c2f130957b070c6e06"
   integrity sha512-yN7kbciD87WzLGc5539Tn0sApjyiGHAJgKvG9W8C7O+6c7qmoQMfVs0W4bX17eqz6C78QJqqFrtgdK5EWf6Qow==
 
+"@hapi/hoek@^9.0.0":
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.0.tgz#6c9eafc78c1529248f8f4d92b0799a712b6052c6"
+  integrity sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==
+
 "@hapi/joi@^15.0.0", "@hapi/joi@^15.1.1":
   version "15.1.1"
   resolved "https://registry.yarnpkg.com/@hapi/joi/-/joi-15.1.1.tgz#c675b8a71296f02833f8d6d243b34c57b8ce19d7"
@@ -1371,6 +1376,13 @@
   integrity sha512-tAag0jEcjwH+P2quUfipd7liWCNX2F8NvYjQp2wtInsZxnMlypdw0FtAOLxtvvkO+GSRRbmNi8m/5y42PQJYCQ==
   dependencies:
     "@hapi/hoek" "^8.3.0"
+
+"@hapi/topo@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@hapi/topo/-/topo-5.0.0.tgz#c19af8577fa393a06e9c77b60995af959be721e7"
+  integrity sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -2491,6 +2503,23 @@
   integrity sha512-aiPss8hQMOz/NV3L9yl3r2brLMpYV76yB2HhqbhB0EstbNMb6a2eDUBo+mOVFhOdKDxlNJmqHdwz/aiBh8GP6Q==
   dependencies:
     tslib "^1.10.0"
+
+"@sideway/address@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@sideway/address/-/address-4.1.0.tgz#0b301ada10ac4e0e3fa525c90615e0b61a72b78d"
+  integrity sha512-wAH/JYRXeIFQRsxerIuLjgUu2Xszam+O5xKeatJ4oudShOOirfmsQ1D6LL54XOU2tizpCYku+s1wmU0SYdpoSA==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+
+"@sideway/formula@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/formula/-/formula-3.0.0.tgz#fe158aee32e6bd5de85044be615bc08478a0a13c"
+  integrity sha512-vHe7wZ4NOXVfkoRb8T5otiENVlT7a3IAiw7H5M2+GO+9CDgcVUUsX1zalAztCmwyOr2RUTGJdgB+ZvSVqmdHmg==
+
+"@sideway/pinpoint@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
+  integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -4600,7 +4629,7 @@ axe-core@^3.5.4:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
   integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
 
-axios@^0.19.0, axios@^0.19.1:
+axios@^0.19.0:
   version "0.19.2"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
   integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
@@ -4611,6 +4640,13 @@ axios@^0.20.0:
   version "0.20.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.20.0.tgz#057ba30f04884694993a8cd07fa394cff11c50bd"
   integrity sha512-ANA4rr2BDcmmAQLOKft2fufrtuvlqR+cXNNinUmvfeSNCOF98PZL+7M/v1zIdGo7OLjEA9J2gXJL+j4zGsl0bA==
+  dependencies:
+    follow-redirects "^1.10.0"
+
+axios@^0.21.0:
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.0.tgz#26df088803a2350dff2c27f96fef99fe49442aca"
+  integrity sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==
   dependencies:
     follow-redirects "^1.10.0"
 
@@ -6559,12 +6595,12 @@ contentful-sdk-core@^6.4.0, contentful-sdk-core@^6.4.5:
     lodash "^4.17.10"
     qs "^6.5.2"
 
-contentful@^7.14.6:
-  version "7.14.6"
-  resolved "https://registry.yarnpkg.com/contentful/-/contentful-7.14.6.tgz#da692d68f361ceec14045c6114425579cddbfab9"
-  integrity sha512-7/Xqw/UT0/zW9DeVGAwtW4twGbThIc6rbLATrhUn7AXt/xTCFzgPiJxHgRU9gmr733q/Wckv663B51abDMS9Nw==
+contentful@^7.14.8:
+  version "7.14.8"
+  resolved "https://registry.yarnpkg.com/contentful/-/contentful-7.14.8.tgz#cdda293323501c4d576b24dbcd247e2eda1148ef"
+  integrity sha512-q0Y/1rNOxF13W3KLe+WxaT3+oDdxCbKiuHF+l0TlQXcVcFeLUhXXJn72noefsH8aWXMF6/rkDQ+Fl6szIMF5qw==
   dependencies:
-    axios "^0.19.1"
+    axios "^0.20.0"
     contentful-resolve-response "^1.2.2"
     contentful-sdk-core "^6.4.5"
     json-stringify-safe "^5.0.1"
@@ -7179,14 +7215,6 @@ d3-time@1, d3-time@^1.1.0:
   resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-2.0.0.tgz#ad7c127d17c67bd57a4c61f3eaecb81108b1e0ab"
   integrity sha512-2mvhstTFcMvwStWd9Tj3e6CEqtOivtD8AUiHT8ido/xmzrI9ijrUUihZ6nHuf/vsScRBonagOdj0Vv+SEL5G3Q==
 
-d@1, d@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/d/-/d-1.0.1.tgz#8698095372d58dbee346ffd0c7093f99f8f9eb5a"
-  integrity sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==
-  dependencies:
-    es5-ext "^0.10.50"
-    type "^1.0.1"
-
 damerau-levenshtein@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz#143c1641cb3d85c60c32329e26899adea8701791"
@@ -7407,15 +7435,6 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
-
-deep-map@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/deep-map/-/deep-map-1.5.0.tgz#eaa595cb81783ca2800f26a42e09f16e7d4fb890"
-  integrity sha1-6qWVy4F4PKKADyakLgnxbn1PuJA=
-  dependencies:
-    es6-weak-map "^2.0.2"
-    lodash "^4.17.4"
-    tslib "^1.6.0"
 
 deep-object-diff@^1.1.0:
   version "1.1.0"
@@ -8281,28 +8300,10 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5-ext@^0.10.35, es5-ext@^0.10.46, es5-ext@^0.10.50:
-  version "0.10.53"
-  resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
-  integrity sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==
-  dependencies:
-    es6-iterator "~2.0.3"
-    es6-symbol "~3.1.3"
-    next-tick "~1.0.0"
-
 es5-shim@^4.5.13:
   version "4.5.14"
   resolved "https://registry.yarnpkg.com/es5-shim/-/es5-shim-4.5.14.tgz#90009e1019d0ea327447cb523deaff8fe45697ef"
   integrity sha512-7SwlpL+2JpymWTt8sNLuC2zdhhc+wrfe5cMPI2j0o6WsPdfAiPwmFy2f0AocPB4RQVBOZ9kNTgi5YF7TdhkvEg==
-
-es6-iterator@^2.0.3, es6-iterator@~2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-iterator/-/es6-iterator-2.0.3.tgz#a7de889141a05a94b0854403b2d0a0fbfa98f3b7"
-  integrity sha1-p96IkUGgWpSwhUQDstCg+/qY87c=
-  dependencies:
-    d "1"
-    es5-ext "^0.10.35"
-    es6-symbol "^3.1.1"
 
 es6-promise@^4.0.3, es6-promise@^4.1.0:
   version "4.2.8"
@@ -8320,24 +8321,6 @@ es6-shim@^0.35.5:
   version "0.35.5"
   resolved "https://registry.yarnpkg.com/es6-shim/-/es6-shim-0.35.5.tgz#46f59dc0a84a1c5029e8ff1166ca0a902077a9ab"
   integrity sha512-E9kK/bjtCQRpN1K28Xh4BlmP8egvZBGJJ+9GtnzOwt7mdqtrjHFuVGr7QJfdjBIKqrlU5duPf3pCBoDrkjVYFg==
-
-es6-symbol@^3.1.1, es6-symbol@~3.1.3:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/es6-symbol/-/es6-symbol-3.1.3.tgz#bad5d3c1bcdac28269f4cb331e431c78ac705d18"
-  integrity sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==
-  dependencies:
-    d "^1.0.1"
-    ext "^1.1.2"
-
-es6-weak-map@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/es6-weak-map/-/es6-weak-map-2.0.3.tgz#b6da1f16cc2cc0d9be43e6bdbfc5e7dfcdf31d53"
-  integrity sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==
-  dependencies:
-    d "1"
-    es5-ext "^0.10.46"
-    es6-iterator "^2.0.3"
-    es6-symbol "^3.1.1"
 
 escalade@^3.1.0:
   version "3.1.0"
@@ -8918,13 +8901,6 @@ ext-name@^5.0.0:
   dependencies:
     ext-list "^2.0.0"
     sort-keys-length "^1.0.0"
-
-ext@^1.1.2:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/ext/-/ext-1.4.0.tgz#89ae7a07158f79d35517882904324077e4379244"
-  integrity sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==
-  dependencies:
-    type "^2.0.0"
 
 extend-shallow@^2.0.1:
   version "2.0.1"
@@ -9739,10 +9715,36 @@ gatsby-cli@^2.12.101:
     yargs "^15.4.1"
     yurnalist "^1.1.2"
 
+gatsby-core-utils@1.3.23:
+  version "1.3.23"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-1.3.23.tgz#5d99e86178b2aa3561f58fde4fdffbebecb0dd0c"
+  integrity sha512-H6n6dDeRZ22HAJaBUIt5YjB/BSaE8Jq+kayMUv/YzL1RL2yFZ5lqcLwIL1OE2vWk1mQjMUBZCRxLODU0q1i3bQ==
+  dependencies:
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    fs-extra "^8.1.0"
+    node-object-hash "^2.0.0"
+    proper-lockfile "^4.1.1"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
+
 gatsby-core-utils@^1.1.4, gatsby-core-utils@^1.3.21:
   version "1.3.21"
   resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-1.3.21.tgz#fa988d04683527b1713c41df10c081712994781c"
   integrity sha512-oaHdrfnip0u1pMVkO5O+R6YxJ6XBi662YCAPVj4G6DCQG9ngJOKNdaHXU1G9Mjalq6Kb/rNWNRMjOU5u78BdKQ==
+  dependencies:
+    ci-info "2.0.0"
+    configstore "^5.0.1"
+    fs-extra "^8.1.0"
+    node-object-hash "^2.0.0"
+    proper-lockfile "^4.1.1"
+    tmp "^0.2.1"
+    xdg-basedir "^4.0.0"
+
+gatsby-core-utils@^1.3.23:
+  version "1.3.24"
+  resolved "https://registry.yarnpkg.com/gatsby-core-utils/-/gatsby-core-utils-1.3.24.tgz#4da8dd3000c25f946bfd6020ee2773f5577a7583"
+  integrity sha512-SlK7rJv/8NBYC8FodYvTINamBHadXNSv//a2uRwh44N1GSSujuCMvtUcpEuAdg9BUQHc54NbbmFuoqf8p85kgA==
   dependencies:
     ci-info "2.0.0"
     configstore "^5.0.1"
@@ -10002,6 +10004,13 @@ gatsby-plugin-typescript@^2.4.21:
     "@babel/runtime" "^7.11.2"
     babel-plugin-remove-graphql-queries "^2.9.20"
 
+gatsby-plugin-utils@0.2.40:
+  version "0.2.40"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-utils/-/gatsby-plugin-utils-0.2.40.tgz#20e997d10efb9a0368270f79ce2e6001346f6336"
+  integrity sha512-RKjmpPhmi8TDR9hAKxmD4ZJMje3BLs6nt6mxMWT0F8gf5giCYEywplJikyCvaPfuyaFlq1hMmFaVvzmeZNussg==
+  dependencies:
+    joi "^17.2.1"
+
 gatsby-react-router-scroll@^3.0.14:
   version "3.0.14"
   resolved "https://registry.yarnpkg.com/gatsby-react-router-scroll/-/gatsby-react-router-scroll-3.0.14.tgz#18cf9c5b8421e41f270a3c40f43db377a1c2cb26"
@@ -10120,28 +10129,50 @@ gatsby-remark-smartypants@^2.3.12:
     retext-smartypants "^3.0.3"
     unist-util-visit "^1.4.1"
 
-gatsby-source-contentful@^2.3.48:
-  version "2.3.48"
-  resolved "https://registry.yarnpkg.com/gatsby-source-contentful/-/gatsby-source-contentful-2.3.48.tgz#b0ea54073bba4ef74bdd77f37979c9ca8db18626"
-  integrity sha512-AmMbtb0yO7vXIhX2uHvdRZ+7NNrNA6N2YhTnmCxJCMJjJ8kPlLj2Ur+F8iypVBPuEPzcP+R+w3BnWBqGR/XZpQ==
+gatsby-source-contentful@4.0.0-4.0.0-rc.0.20:
+  version "4.0.0-4.0.0-rc.0.20"
+  resolved "https://registry.yarnpkg.com/gatsby-source-contentful/-/gatsby-source-contentful-4.0.0-4.0.0-rc.0.20.tgz#6addf40cb62e51f58a153d06fe8f15f7cb5314ae"
+  integrity sha512-3oK4SgRvoPKEyw+AysxlPUzFSKUOC48euLkdHZ2ibCR1VF8uvM+ATPXog6VU/txzsJM7ym9bo7kUHaM/VZICiQ==
   dependencies:
     "@babel/runtime" "^7.11.2"
-    "@contentful/rich-text-types" "^13.4.0"
+    "@contentful/rich-text-react-renderer" "^14.1.1"
+    "@contentful/rich-text-types" "^14.1.1"
     "@hapi/joi" "^15.1.1"
-    axios "^0.20.0"
+    axios "^0.21.0"
     base64-img "^1.0.4"
     bluebird "^3.7.2"
-    chalk "^2.4.2"
-    contentful "^7.14.6"
-    deep-map "^1.5.0"
-    fs-extra "^8.1.0"
-    gatsby-core-utils "^1.3.21"
-    gatsby-plugin-sharp "^2.6.37"
-    gatsby-source-filesystem "^2.3.31"
-    is-online "^8.4.0"
+    chalk "^4.1.0"
+    contentful "^7.14.8"
+    fs-extra "^9.0.1"
+    gatsby-core-utils "1.3.23"
+    gatsby-plugin-utils "0.2.40"
+    gatsby-source-filesystem "2.3.37"
+    is-online "^8.5.1"
     json-stringify-safe "^5.0.1"
     lodash "^4.17.20"
+    node-fetch "^2.6.1"
+    progress "^2.0.3"
     qs "^6.9.4"
+
+gatsby-source-filesystem@2.3.37:
+  version "2.3.37"
+  resolved "https://registry.yarnpkg.com/gatsby-source-filesystem/-/gatsby-source-filesystem-2.3.37.tgz#730c844c482690f615e25301c3cd399166c54213"
+  integrity sha512-yzR3FAzx12V5sjJRx2y7+XH/NXJE4M5XiV2ZmOnZczpCOaXcdZ4tZ6Mn8KClnbVgIKa5kgKnUX0pUYOkcDnidw==
+  dependencies:
+    "@babel/runtime" "^7.11.2"
+    better-queue "^3.8.10"
+    chokidar "^3.4.2"
+    file-type "^12.4.2"
+    fs-extra "^8.1.0"
+    gatsby-core-utils "^1.3.23"
+    got "^9.6.0"
+    md5-file "^5.0.0"
+    mime "^2.4.6"
+    pretty-bytes "^5.4.1"
+    progress "^2.0.3"
+    read-chunk "^3.2.0"
+    valid-url "^1.0.9"
+    xstate "^4.13.0"
 
 gatsby-source-filesystem@^2.3.31:
   version "2.3.31"
@@ -12454,10 +12485,10 @@ is-object@^1.0.1:
   resolved "https://registry.yarnpkg.com/is-object/-/is-object-1.0.1.tgz#8952688c5ec2ffd6b03ecc85e769e02903083470"
   integrity sha1-iVJojF7C/9awPsyF52ngKQMINHA=
 
-is-online@^8.4.0:
-  version "8.4.0"
-  resolved "https://registry.yarnpkg.com/is-online/-/is-online-8.4.0.tgz#8639af9657413fcfd9f81fced3263d532e0b1cee"
-  integrity sha512-i0qGRbtUaQEU5Z7O3LmOnH3yorhG1lnygqY2cv3InlQKKm3nx6XiGXZk49lATR3N7hyxoiuHMR0pKwRuB+s5lg==
+is-online@^8.5.1:
+  version "8.5.1"
+  resolved "https://registry.yarnpkg.com/is-online/-/is-online-8.5.1.tgz#bcc6970c6a3fad552a41738c0f0d0737b0ce6e63"
+  integrity sha512-RKyTQx/rJqw2QOXHwy7TmXdlkpe0Hhj7GBsr6TQJaj4ebNOfameZCMspU5vYbwBBzJ2brWArdSvNVox6T6oCTQ==
   dependencies:
     got "^9.6.0"
     p-any "^2.0.0"
@@ -13325,6 +13356,17 @@ jimp@^0.14.0:
     "@jimp/plugins" "^0.14.0"
     "@jimp/types" "^0.14.0"
     regenerator-runtime "^0.13.3"
+
+joi@^17.2.1:
+  version "17.3.0"
+  resolved "https://registry.yarnpkg.com/joi/-/joi-17.3.0.tgz#f1be4a6ce29bc1716665819ac361dfa139fff5d2"
+  integrity sha512-Qh5gdU6niuYbUIUV5ejbsMiiFmBdw8Kcp8Buj2JntszCkCfxJ9Cz76OtHxOZMPXrt5810iDIXs+n1nNVoquHgg==
+  dependencies:
+    "@hapi/hoek" "^9.0.0"
+    "@hapi/topo" "^5.0.0"
+    "@sideway/address" "^4.1.0"
+    "@sideway/formula" "^3.0.0"
+    "@sideway/pinpoint" "^2.0.0"
 
 jpeg-js@^0.4.0:
   version "0.4.2"
@@ -14379,6 +14421,11 @@ md5-file@^3.2.3:
   dependencies:
     buffer-alloc "^1.1.0"
 
+md5-file@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-5.0.0.tgz#e519f631feca9c39e7f9ea1780b63c4745012e20"
+  integrity sha512-xbEFXCYVWrSx/gEKS1VPlg84h/4L20znVIulKw6kMfmBUAZNAnF00eczz9ICMl+/hjQGo5KSXRxbL/47X3rmMw==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"
@@ -15038,11 +15085,6 @@ next-tick@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.1.0.tgz#1836ee30ad56d67ef281b22bd199f709449b35eb"
   integrity sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==
-
-next-tick@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-tick/-/next-tick-1.0.0.tgz#ca86d1fe8828169b0120208e3dc8424b9db8342c"
-  integrity sha1-yobR/ogoFpsBICCOPchCS524NCw=
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -20574,7 +20616,7 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.0.0, tslib@^1.10.0, tslib@^1.11.2, tslib@^1.6.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.0.0, tslib@^1.10.0, tslib@^1.11.2, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
@@ -20662,16 +20704,6 @@ type-of@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/type-of/-/type-of-2.0.1.tgz#e72a1741896568e9f628378d816d6912f7f23972"
   integrity sha1-5yoXQYllaOn2KDeNgW1pEvfyOXI=
-
-type@^1.0.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-1.2.0.tgz#848dd7698dafa3e54a6c479e759c4bc3f18847a0"
-  integrity sha512-+5nt5AAniqsCnu2cEQQdpzCAh33kVx8n0VoFidKpB1dVVLAN/F+bgVOqOJqOnEnrhp222clB5p3vUlD+1QAnfg==
-
-type@^2.0.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/type/-/type-2.1.0.tgz#9bdc22c648cf8cf86dd23d32336a41cfb6475e3f"
-  integrity sha512-G9absDWvhAWCV2gmF1zKud3OyC61nZDwWvBL2DApaVFogI07CprggiQAOOjvp2NRjYWFzPyu7vwtDrQFq8jeSA==
 
 typed-styles@^0.0.7:
   version "0.0.7"


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
To solve caching issues with Contentful rich text fields, this PR:

- Hard sets `gatsby-source-contentful` to `4.0.0-4.0.0-rc.0.20` - we'll have to update later and I'll make a note of that in Airtable
- Uses the new [references format](https://github.com/gatsbyjs/gatsby/pull/25249), which means no `en-US` field names, and no pre-fetching blog images 🎉 
- Updates all block and inline blocks to the new format
- Refactor the footnote area