### PR TITLE
feat: Add more fields to antibody tests card

### DIFF
--- a/src/__tests__/components/pages/data/__snapshots__/cards.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/cards.js.snap
@@ -39,7 +39,7 @@ exports[`Components : Pages : Data : Cards : Antibody tests renders correctly 1`
         <div
           className="title"
         >
-          Total tests
+          Total tests (specimens)
         </div>
         <div
           className="value"
@@ -50,7 +50,37 @@ exports[`Components : Pages : Data : Cards : Antibody tests renders correctly 1`
           className="info"
         >
           <button
-            aria-label="Definition of Total "
+            aria-label="Definition of Total antibody tests in specimens"
+            className="link"
+            onClick={[Function]}
+            type="button"
+          >
+            Definition
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      className="statisticWrapper"
+    >
+      <div
+        className="statistic"
+      >
+        <div
+          className="title"
+        >
+          Total tests (people)
+        </div>
+        <div
+          className="value"
+        >
+          12
+        </div>
+        <div
+          className="info"
+        >
+          <button
+            aria-label="Definition of Total antibody tests in people"
             className="link"
             onClick={[Function]}
             type="button"

--- a/src/__tests__/components/pages/data/cards.js
+++ b/src/__tests__/components/pages/data/cards.js
@@ -109,7 +109,13 @@ describe('Components : Pages : Data : Cards : Outcomes', () => {
 describe('Components : Pages : Data : Cards : Antibody tests', () => {
   it('renders correctly', () => {
     const tree = renderer
-      .create(<AntibodyCard stateSlug="california" totalTestsAntibody={14} />)
+      .create(
+        <AntibodyCard
+          stateSlug="california"
+          totalTestsAntibody={14}
+          totalTestsPeopleAntibody={12}
+        />,
+      )
       .toJSON()
     expect(tree).toMatchSnapshot()
   })

--- a/src/components/pages/data/cards/tests-antibody.js
+++ b/src/components/pages/data/cards/tests-antibody.js
@@ -4,9 +4,13 @@ import { Card, CardBody } from '~components/common/card'
 import { DefinitionPanelContext } from './definitions-panel'
 import { Statistic, DefinitionLink } from '~components/common/statistic'
 
-const TestAntibodyCard = ({ stateSlug, totalTestsAntibody }) => {
+const TestAntibodyCard = ({
+  stateSlug,
+  totalTestsAntibody,
+  totalTestsPeopleAntibody,
+}) => {
   const definitionContext = useContext(DefinitionPanelContext)
-
+  const definitionFields = ['totalTestsAntibody', 'totalTestsPeopleAntibody']
   return (
     <Card
       title="Antibody tests"
@@ -17,15 +21,29 @@ const TestAntibodyCard = ({ stateSlug, totalTestsAntibody }) => {
       }
     >
       <CardBody>
-        <Statistic title="Total tests" value={totalTestsAntibody}>
+        <Statistic title="Total tests (specimens)" value={totalTestsAntibody}>
           <DefinitionLink
             onDefinitionsToggle={() => {
               definitionContext({
-                fields: ['totalTestsAntibody'],
+                fields: definitionFields,
                 highlight: 'totalTestsAntibody',
               })
             }}
-            label="Total "
+            label="Total antibody tests in specimens"
+          />
+        </Statistic>
+        <Statistic
+          title="Total tests (people)"
+          value={totalTestsPeopleAntibody}
+        >
+          <DefinitionLink
+            onDefinitionsToggle={() => {
+              definitionContext({
+                fields: definitionFields,
+                highlight: 'totalTestsPeopleAntibody',
+              })
+            }}
+            label="Total antibody tests in people"
           />
         </Statistic>
       </CardBody>

--- a/src/components/pages/data/summary.js
+++ b/src/components/pages/data/summary.js
@@ -112,6 +112,7 @@ const StateSummary = ({
             <TestsAntibodyCard
               stateSlug={stateSlug}
               totalTestsAntibody={data.totalTestsAntibody}
+              totalTestsPeopleAntibody={data.totalTestsPeopleAntibody}
             />
           </>
         )}

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -192,6 +192,7 @@ export const query = graphql`
         totalTestEncountersViral
         totalTestResults
         totalTestsAntibody
+        totalTestsPeopleAntibody
         totalTestsPeopleViral
         totalTestsViral
       }

--- a/src/templates/state/index.js
+++ b/src/templates/state/index.js
@@ -138,6 +138,7 @@ export const query = graphql`
       totalTestsViral
       totalTestEncountersViral
       totalTestsAntibody
+      totalTestsPeopleAntibody
       totalTestResultsSource
     }
     allCovidStateDaily(


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- [Airtable card](https://airtable.com/tbl78phKvQLbKQvV0/viwzuvy3fZrep0aoD/recslAdtoX6OSGJWq)
- Adds total antibody tests in people to antibody tests card
- Clarifies units for `totalTestsAntibody`