### PR TITLE
chore: Shorten notes to an expandable block

### DIFF
--- a/src/__tests__/components/pages/state/__snapshots__/state-notes.js.snap
+++ b/src/__tests__/components/pages/state/__snapshots__/state-notes.js.snap
@@ -12,30 +12,37 @@ exports[`Components : Pages : State : State notes renders correctly 1`] = `
     >
       Notes: 
     </span>
-    <p
-      className="state-note-expandable"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "This is the first paragraph for <strong>June 13</strong>.",
+    <div
+      className="fadeWrapper"
+    >
+      <p
+        className="state-note-expandable"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "This is the first paragraph for <strong>June 13</strong>.",
+          }
         }
-      }
-    />
-    <p
-      className="state-note-expandable"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "This second line tests years, as in <strong>July 14, 2020</strong>.",
+      />
+      <p
+        className="state-note-expandable"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "This second line tests years, as in <strong>July 14, 2020</strong>.",
+          }
         }
-      }
-    />
-    <p
-      className="state-note-expandable expandable"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "You can also format with <strong>August 18 2020</strong>, I guess that is fine too.",
+      />
+      <p
+        className="state-note-expandable expandable"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "You can also format with <strong>August 18 2020</strong>, I guess that is fine too.",
+          }
         }
-      }
-    />
+      />
+      <div
+        className="js-enabled fader"
+      />
+    </div>
     <button
       aria-hidden={true}
       className="expand"

--- a/src/__tests__/components/pages/state/__snapshots__/state-notes.js.snap
+++ b/src/__tests__/components/pages/state/__snapshots__/state-notes.js.snap
@@ -7,63 +7,42 @@ exports[`Components : Pages : State : State notes renders correctly 1`] = `
   <div
     className="full"
   >
-    <div
-      className="notes-expandable expandable"
+    <span
+      className="label"
     >
-      <span
-        className="label"
-      >
-        Notes: 
-      </span>
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>This is the first paragraph for <strong>June 13</strong>.</p>
-",
-          }
+      Notes: 
+    </span>
+    <p
+      className="state-note-expandable"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "This is the first paragraph for <strong>June 13</strong>.",
         }
-      />
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "",
-          }
+      }
+    />
+    <p
+      className="state-note-expandable"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "This second line tests years, as in <strong>July 14, 2020</strong>.",
         }
-      />
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>This second line tests years, as in <strong>July 14, 2020</strong>.</p>
-",
-          }
+      }
+    />
+    <p
+      className="state-note-expandable expandable"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "You can also format with <strong>August 18 2020</strong>, I guess that is fine too.",
         }
-      />
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "",
-          }
-        }
-      />
-      <div
-        dangerouslySetInnerHTML={
-          Object {
-            "__html": "<p>You can also format with <strong>August 18 2020</strong>, I guess that is fine too.</p>
-",
-          }
-        }
-      />
-      <div
-        className="fader"
-      />
-    </div>
+      }
+    />
     <button
       aria-hidden={true}
       className="expand"
       onClick={[Function]}
       type="button"
     >
-      Read more
+      Read more state notes
        
       <span
         className="arrow"

--- a/src/__tests__/components/pages/state/__snapshots__/state-notes.js.snap
+++ b/src/__tests__/components/pages/state/__snapshots__/state-notes.js.snap
@@ -7,49 +7,70 @@ exports[`Components : Pages : State : State notes renders correctly 1`] = `
   <div
     className="narrow"
   >
-    <span
-      className="label"
+    <div
+      className="notes-expandable expandable"
     >
-      Notes: 
-    </span>
-    <div
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "<p>This is the first paragraph for <strong>June 13</strong>.</p>
+      <span
+        className="label"
+      >
+        Notes: 
+      </span>
+      <div
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<p>This is the first paragraph for <strong>June 13</strong>.</p>
 ",
+          }
         }
-      }
-    />
-    <div
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "",
+      />
+      <div
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "",
+          }
         }
-      }
-    />
-    <div
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "<p>This second line tests years, as in <strong>July 14, 2020</strong>.</p>
+      />
+      <div
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<p>This second line tests years, as in <strong>July 14, 2020</strong>.</p>
 ",
+          }
         }
-      }
-    />
-    <div
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "",
+      />
+      <div
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "",
+          }
         }
-      }
-    />
-    <div
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "<p>You can also format with <strong>August 18 2020</strong>, I guess that is fine too.</p>
+      />
+      <div
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "<p>You can also format with <strong>August 18 2020</strong>, I guess that is fine too.</p>
 ",
+          }
         }
-      }
-    />
+      />
+      <div
+        className="fader"
+      />
+    </div>
+    <button
+      aria-hidden={true}
+      className="expand"
+      onClick={[Function]}
+      type="button"
+    >
+      Read more
+       
+      <span
+        className="arrow"
+      >
+        ↓
+      </span>
+    </button>
   </div>
 </div>
 `;

--- a/src/__tests__/components/pages/state/__snapshots__/state-notes.js.snap
+++ b/src/__tests__/components/pages/state/__snapshots__/state-notes.js.snap
@@ -5,7 +5,7 @@ exports[`Components : Pages : State : State notes renders correctly 1`] = `
   className="container container container"
 >
   <div
-    className="narrow"
+    className="full"
   >
     <div
       className="notes-expandable expandable"

--- a/src/components/pages/data/cards/cases-card.js
+++ b/src/components/pages/data/cards/cases-card.js
@@ -52,7 +52,7 @@ const CasesCard = ({
             label="Total cases"
           />
         </Statistic>
-        {confirmedCases && (
+        {confirmedCases > 0 && confirmedCases !== null && (
           <Statistic title="Confirmed cases" value={confirmedCases} subelement>
             <DefinitionLink
               onDefinitionsToggle={() => {
@@ -65,7 +65,7 @@ const CasesCard = ({
             />
           </Statistic>
         )}
-        {probableCases && (
+        {probableCases > 0 && probableCases !== null && (
           <Statistic title="Probable cases" value={probableCases} subelement>
             <DefinitionLink
               onDefinitionsToggle={() => {

--- a/src/components/pages/data/state-data.js
+++ b/src/components/pages/data/state-data.js
@@ -47,7 +47,7 @@ const State = ({ state, metadata }) => {
         <StateLinksDisclosurePanel state={state} />
       </StateLinksDisclosure>
 
-      {state.notes && <StateNotes isNarrow={false} notes={state.notes} />}
+      {state.notes && <StateNotes notes={state.notes} />}
       <a
         className={`state-top-link ${stateDataStyles.topLink}`}
         href="#reach-skip-nav"

--- a/src/components/pages/data/summary-charts.js
+++ b/src/components/pages/data/summary-charts.js
@@ -256,7 +256,7 @@ const SummaryCharts = ({
   const deathField = useMemo(() => `${prepend}deathIncrease`, [prepend])
 
   const colProps = {
-    width: [4, 3, 3], // 1 chart per line on small, 2 on medium & 4 on large screens
+    width: [3, 3, 3], // 1 chart per line on small, 2 on medium & 4 on large screens
     paddingLeft: [0, 0, 0],
     paddingRight: [0, 0, 0],
   }

--- a/src/components/pages/data/summary-charts.module.scss
+++ b/src/components/pages/data/summary-charts.module.scss
@@ -46,7 +46,10 @@
 .summary-charts {
   h3 {
     @include type-size(300);
-    @include margin(32, top bottom);
+    @include margin(8, top bottom);
+    @media (min-width: $viewport-md) {
+      @include margin(32, top bottom);
+    }
     &.test-heading {
       @include margin(16, bottom);
     }

--- a/src/components/pages/state/state-notes.js
+++ b/src/components/pages/state/state-notes.js
@@ -21,19 +21,29 @@ const StateNotes = ({ notes }) => {
   return (
     <Container className={stateNotesStyle.container}>
       <span className={stateNotesStyle.label}>Notes: </span>
-      {notesArray.map((note, index) => (
-        <p
-          key={note}
-          dangerouslySetInnerHTML={{
-            __html: smartypants(marked.inlineLexer(note, [])),
-          }}
-          className={classnames(
-            'state-note-expandable',
-            index > 1 && stateNotesStyle.expandable,
-            isExpanded && stateNotesStyle.isExpanded,
-          )}
-        />
-      ))}
+      <div
+        className={classnames(
+          stateNotesStyle.fadeWrapper,
+          isExpanded && stateNotesStyle.isExpanded,
+        )}
+      >
+        {notesArray.map((note, index) => (
+          <p
+            key={note}
+            dangerouslySetInnerHTML={{
+              __html: smartypants(marked.inlineLexer(note, [])),
+            }}
+            className={classnames(
+              'state-note-expandable',
+              index > 1 && stateNotesStyle.expandable,
+              isExpanded && stateNotesStyle.isExpanded,
+            )}
+          />
+        ))}
+        {notesArray.length > 2 && (
+          <div className={classnames('js-enabled', stateNotesStyle.fader)} />
+        )}
+      </div>
       {notesArray.length > 2 && (
         <button
           className={stateNotesStyle.expand}

--- a/src/components/pages/state/state-notes.js
+++ b/src/components/pages/state/state-notes.js
@@ -43,7 +43,7 @@ const StateNotes = ({ notes }) => {
             setIsExpanded(!isExpanded)
           }}
         >
-          {isExpanded ? <>Collapse state note</> : <>Read more</>}{' '}
+          {isExpanded ? <>Collapse state notes</> : <>Read more state notes</>}{' '}
           <span className={stateNotesStyle.arrow}>
             {isExpanded ? <>↑</> : <>↓</>}
           </span>

--- a/src/components/pages/state/state-notes.js
+++ b/src/components/pages/state/state-notes.js
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useState } from 'react'
 import marked from 'marked'
+import classnames from 'classnames'
 import smartypants from 'smartypants'
 
 import Container from '~components/common/container'
@@ -12,17 +13,40 @@ const getBoldedText = text =>
   )
 
 const StateNotes = ({ notes, isNarrow = true }) => {
+  const [isExpanded, setIsExpanded] = useState(false)
   const highlightedNotes = getBoldedText(notes)
   const notesArray = highlightedNotes.split('\n')
   return (
     <Container narrow={isNarrow} className={stateNotesStyle.container}>
-      <span className={stateNotesStyle.label}>Notes: </span>
-      {notesArray.map(note => (
-        <div
-          key={note}
-          dangerouslySetInnerHTML={{ __html: smartypants(marked(note)) }}
-        />
-      ))}
+      <div
+        className={classnames(
+          'notes-expandable',
+          stateNotesStyle.expandable,
+          isExpanded && stateNotesStyle.isExpanded,
+        )}
+      >
+        <span className={stateNotesStyle.label}>Notes: </span>
+        {notesArray.map(note => (
+          <div
+            key={note}
+            dangerouslySetInnerHTML={{ __html: smartypants(marked(note)) }}
+          />
+        ))}
+        {!isExpanded && <div className={stateNotesStyle.fader} />}
+      </div>
+      <button
+        className={stateNotesStyle.expand}
+        type="button"
+        aria-hidden
+        onClick={() => {
+          setIsExpanded(!isExpanded)
+        }}
+      >
+        {isExpanded ? <>Collapse state note</> : <>Read more</>}{' '}
+        <span className={stateNotesStyle.arrow}>
+          {isExpanded ? <>↑</> : <>↓</>}
+        </span>
+      </button>
     </Container>
   )
 }

--- a/src/components/pages/state/state-notes.js
+++ b/src/components/pages/state/state-notes.js
@@ -12,12 +12,12 @@ const getBoldedText = text =>
     '**$1 $2$3**',
   )
 
-const StateNotes = ({ notes, isNarrow = true }) => {
+const StateNotes = ({ notes }) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const highlightedNotes = getBoldedText(notes)
   const notesArray = highlightedNotes.split('\n')
   return (
-    <Container narrow={isNarrow} className={stateNotesStyle.container}>
+    <Container className={stateNotesStyle.container}>
       <div
         className={classnames(
           'notes-expandable',

--- a/src/components/pages/state/state-notes.js
+++ b/src/components/pages/state/state-notes.js
@@ -15,38 +15,40 @@ const getBoldedText = text =>
 const StateNotes = ({ notes }) => {
   const [isExpanded, setIsExpanded] = useState(false)
   const highlightedNotes = getBoldedText(notes)
-  const notesArray = highlightedNotes.split('\n')
+  const notesArray = highlightedNotes
+    .split('\n')
+    .filter(text => text.trim().length > 0)
   return (
     <Container className={stateNotesStyle.container}>
-      <div
-        className={classnames(
-          'notes-expandable',
-          stateNotesStyle.expandable,
-          isExpanded && stateNotesStyle.isExpanded,
-        )}
-      >
-        <span className={stateNotesStyle.label}>Notes: </span>
-        {notesArray.map(note => (
-          <div
-            key={note}
-            dangerouslySetInnerHTML={{ __html: smartypants(marked(note)) }}
-          />
-        ))}
-        {!isExpanded && <div className={stateNotesStyle.fader} />}
-      </div>
-      <button
-        className={stateNotesStyle.expand}
-        type="button"
-        aria-hidden
-        onClick={() => {
-          setIsExpanded(!isExpanded)
-        }}
-      >
-        {isExpanded ? <>Collapse state note</> : <>Read more</>}{' '}
-        <span className={stateNotesStyle.arrow}>
-          {isExpanded ? <>↑</> : <>↓</>}
-        </span>
-      </button>
+      <span className={stateNotesStyle.label}>Notes: </span>
+      {notesArray.map((note, index) => (
+        <p
+          key={note}
+          dangerouslySetInnerHTML={{
+            __html: smartypants(marked.inlineLexer(note, [])),
+          }}
+          className={classnames(
+            'state-note-expandable',
+            index > 1 && stateNotesStyle.expandable,
+            isExpanded && stateNotesStyle.isExpanded,
+          )}
+        />
+      ))}
+      {notesArray.length > 2 && (
+        <button
+          className={stateNotesStyle.expand}
+          type="button"
+          aria-hidden
+          onClick={() => {
+            setIsExpanded(!isExpanded)
+          }}
+        >
+          {isExpanded ? <>Collapse state note</> : <>Read more</>}{' '}
+          <span className={stateNotesStyle.arrow}>
+            {isExpanded ? <>↑</> : <>↓</>}
+          </span>
+        </button>
+      )}
     </Container>
   )
 }

--- a/src/components/pages/state/state-notes.module.scss
+++ b/src/components/pages/state/state-notes.module.scss
@@ -1,15 +1,44 @@
 .container {
   margin-left: 0;
   @include margin(16, top bottom);
+}
 
+.label {
+  font-weight: bold;
+}
+
+.expand {
+  @include margin(16, top);
+  @include remove-button-style();
+  text-decoration: underline;
+  color: $color-honey-700;
+  .arrow {
+    display: inline-block;
+    @include margin(8, left);
+  }
+}
+
+.expandable {
+  height: 15rem;
+  overflow: hidden;
+  position: relative;
   div {
     display: inline;
     p {
       display: block;
     }
   }
-}
-
-.label {
-  font-weight: bold;
+  &.is-expanded {
+    height: auto;
+  }
+  .fader {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    text-align: center;
+    margin: 0;
+    padding: 30px 0;
+    background-image: linear-gradient(to bottom, transparent, white);
+  }
 }

--- a/src/components/pages/state/state-notes.module.scss
+++ b/src/components/pages/state/state-notes.module.scss
@@ -38,7 +38,7 @@
     width: 100%;
     text-align: center;
     margin: 0;
-    padding: 30px 0;
+    padding: 30px 0; // ignore-style-rule
     background-image: linear-gradient(to bottom, transparent, white);
   }
 }

--- a/src/components/pages/state/state-notes.module.scss
+++ b/src/components/pages/state/state-notes.module.scss
@@ -22,9 +22,29 @@
   &.is-expanded {
     clip: auto;
     height: auto;
-    margin: 0;
+    @include margin(16, top bottom);
     overflow: auto;
     position: relative;
     width: auto;
   }
+}
+
+.fade-wrapper {
+  position: relative;
+  &.is-expanded {
+    .fader {
+      display: none;
+    }
+  }
+}
+
+.fader {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  text-align: center;
+  margin: 0;
+  padding: 30px 0; // ignore-style-rule
+  background-image: linear-gradient(to bottom, transparent, white);
 }

--- a/src/components/pages/state/state-notes.module.scss
+++ b/src/components/pages/state/state-notes.module.scss
@@ -19,26 +19,13 @@
 }
 
 .expandable {
-  max-height: 10rem;
-  overflow: hidden;
-  position: relative;
-  div {
-    display: inline;
-    p {
-      display: block;
-    }
-  }
+  @include a11y-only();
   &.is-expanded {
-    max-height: initial;
-  }
-  .fader {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    text-align: center;
+    clip: auto;
+    height: auto;
     margin: 0;
-    padding: 30px 0; // ignore-style-rule
-    background-image: linear-gradient(to bottom, transparent, white);
+    overflow: auto;
+    position: relative;
+    width: auto;
   }
 }

--- a/src/components/pages/state/state-notes.module.scss
+++ b/src/components/pages/state/state-notes.module.scss
@@ -8,10 +8,9 @@
 }
 
 .expand {
-  @include margin(16, top);
+  font-weight: bold;
   @include remove-button-style();
   text-decoration: underline;
-  color: $color-honey-700;
   .arrow {
     display: inline-block;
     @include margin(8, left);

--- a/src/components/pages/state/state-notes.module.scss
+++ b/src/components/pages/state/state-notes.module.scss
@@ -19,7 +19,7 @@
 }
 
 .expandable {
-  height: 15rem;
+  max-height: 10rem;
   overflow: hidden;
   position: relative;
   div {
@@ -29,7 +29,7 @@
     }
   }
   &.is-expanded {
-    height: auto;
+    max-height: initial;
   }
   .fader {
     position: absolute;

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -120,11 +120,13 @@ select,
     }
   }
 
-  .notes-expandable {
-    height: auto !important;
-    .fader {
-      display: none;
-    }
+  .state-note-expandable {
+    clip: auto;
+    height: auto;
+    margin: 0;
+    overflow: auto;
+    position: relative;
+    width: auto;
   }
 }
 

--- a/src/scss/global.scss
+++ b/src/scss/global.scss
@@ -119,6 +119,13 @@ select,
       display: block !important;
     }
   }
+
+  .notes-expandable {
+    height: auto !important;
+    .fader {
+      display: none;
+    }
+  }
 }
 
 /*

--- a/src/templates/state/index.js
+++ b/src/templates/state/index.js
@@ -24,7 +24,6 @@ const StateTemplate = ({ pageContext, data, path }) => {
   return (
     <Layout title={state.name} returnLinks={[{ link: '/data' }]} path={path}>
       <StatePreamble state={state} covidState={covidState} />
-      {state.notes && <StateNotes notes={state.notes} />}
       <SummaryCharts
         name={state.name}
         history={allCovidStateDaily.nodes}
@@ -48,6 +47,7 @@ const StateTemplate = ({ pageContext, data, path }) => {
           lastUpdated={covidState.lastUpdateEt}
           longTermCare={data.covidStateInfo.childLtc}
         />
+        {state.notes && <StateNotes notes={state.notes} />}
         <StateTweets tweets={allTweets} name={state.name} />
       </StateNavWrapper>
     </Layout>


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Moves state notes to below the charts on the state page
- Makes state notes a maximum height of 15 rem and provides a toggle
- The notes should fail to expanded if JS is disabled