### PR TITLE
feat: Add automatic description to charts

### DIFF
--- a/src/__tests__/components/pages/data/__snapshots__/summary-chart-description.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/summary-chart-description.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Components : Pages : Data : Summary chart description renders correctly 1`] = `
+<div
+  className="a11y-only"
+>
+  Cases
+   started at 
+  1234
+   on 
+  Mar  3
+   and our most recent data on
+   
+  Mar  4
+   
+  is
+   
+  132
+  .
+  The most recent low-point in 
+  cases
+   was
+   
+  Dec 31
+   when the value was 
+  .
+  The most recent high-point in 
+  cases
+   was
+   
+  Dec 31
+   when the value was 
+  .
+</div>
+`;

--- a/src/__tests__/components/pages/data/summary-chart-description.js
+++ b/src/__tests__/components/pages/data/summary-chart-description.js
@@ -1,0 +1,13 @@
+import React from 'react'
+import renderer from 'react-test-renderer'
+import data from 'sample-chart-data'
+import SummaryChartDescription from '~components/pages/data/summary-chart-description'
+
+describe('Components : Pages : Data : Summary chart description', () => {
+  it('renders correctly', () => {
+    const tree = renderer
+      .create(<SummaryChartDescription label="Cases" data={data} />)
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/src/components/pages/data/summary-chart-description.js
+++ b/src/components/pages/data/summary-chart-description.js
@@ -1,0 +1,75 @@
+/* eslint-disable no-plusplus */
+import React from 'react'
+import { formatDate } from '~utilities/visualization'
+
+const averageSize = 14
+
+const getDataTrends = data => {
+  const spikes = []
+  const troughs = []
+  let direction = false
+  const getRange = (startIndex, endIndex) => {
+    const many = []
+
+    for (let i = startIndex; i < endIndex; i++) {
+      many.push(typeof data[i] === 'undefined' ? null : data[i])
+    }
+
+    return many
+  }
+
+  data.forEach((item, index) => {
+    if (index < averageSize) {
+      return
+    }
+    if (
+      item >=
+      Math.max(...getRange(index - averageSize / 2, index + averageSize / 2))
+    ) {
+      spikes.push({ value: item, index })
+      direction = 'up'
+    }
+    if (
+      item <=
+      Math.min(...getRange(index - averageSize / 2, index + averageSize / 2))
+    ) {
+      troughs.push({ value: item, index })
+      direction = 'down'
+    }
+  })
+  return { spikes, troughs, direction }
+}
+
+const ChartDescription = ({ label, data }) => {
+  const { spikes, troughs, direction } = getDataTrends(
+    data.map(item => item.value),
+  )
+  const startDate = formatDate(data[0].date)
+  const lastDate = formatDate(data[data.length - 1].date)
+  const start = data[0].value
+  const last = data[data.length - 1].value
+  const lowPoint = troughs.length && data[troughs.pop().index]
+  const highPoint = spikes.length && data[spikes.pop().index]
+
+  return (
+    <div className="a11y-only">
+      {label} started at {start} on {startDate} and our most recent data on{' '}
+      {lastDate} {direction !== false ? <>it is moving {direction}</> : <>is</>}{' '}
+      {last}.
+      {lowPoint.value !== false && (
+        <>
+          The most recent low-point in {label.toLowerCase()} was{' '}
+          {formatDate(lowPoint.date)} when the value was {lowPoint.value}.
+        </>
+      )}
+      {highPoint.value !== false && (
+        <>
+          The most recent high-point in {label.toLowerCase()} was{' '}
+          {formatDate(highPoint.date)} when the value was {highPoint.value}.
+        </>
+      )}
+    </div>
+  )
+}
+
+export default ChartDescription

--- a/src/components/pages/data/summary-charts.js
+++ b/src/components/pages/data/summary-charts.js
@@ -17,40 +17,13 @@ import Toggle from '~components/common/toggle'
 import ContentfulContent from '~components/common/contentful-content'
 import Alert from '~components/common/alert'
 import { FieldName } from '~components/utils/field-name'
+import ChartDescription from './summary-chart-description'
 import { ReactComponent as CtpLogo } from '~images/project-logo.svg'
 import colors from '~scss/colors.module.scss'
 
 import styles from './summary-charts.module.scss'
 
 import TooltipContents from '~components/charts/tooltip-contents'
-
-const ChartDescription = ({ label, data }) => {
-  const startDate = parseDate(data[0].date)
-  const lastDate = parseDate(data[data.length - 1].date)
-  const start = data[0].value
-  const last = data[data.length - 1].value
-  const lowPoint = {
-    date: false,
-    value: false,
-  }
-  let directionUp = 0
-  lowPoint.forEach((point, index) => {
-    if(index > 7)
-  })
-
-  return (
-    <div>
-      {label} started at {start} on {startDate} and our most recent data on{' '}
-      {lastDate} it is at {last}.
-      {lowPoint.value !== false && (
-        <>
-          The most recent low-point in {label.toLowerCase()} was {lowPoint.date} when the
-          value was {lowPoint.value}.
-        </>
-      )}
-    </div>
-  )
-}
 
 const TestFieldIndicator = ({ field, units, national }) => (
   <span className={styles.testFieldIndicator}>
@@ -391,20 +364,20 @@ const SummaryCharts = ({
           </h3>
           {hasData(positiveField) ? (
             <>
-            <BarChart
-              data={getDataForField(data, positiveField)}
-              lineData={dailyAverage(data, positiveField)}
-              refLineData={dailyAverage(usData, positiveField)}
-              fill={colors.colorStrawberry100}
-              lineColor={colors.colorStrawberry200}
-              annotations={splitAnnotations.cases}
-              renderTooltipContents={makeRenderTooltipContents('new cases')}
-              {...chartProps}
-            />
-            <ChartDescription
-              label="Cases"
-              data={getDataForField(data, positiveField)}
-            />
+              <BarChart
+                data={getDataForField(data, positiveField)}
+                lineData={dailyAverage(data, positiveField)}
+                refLineData={dailyAverage(usData, positiveField)}
+                fill={colors.colorStrawberry100}
+                lineColor={colors.colorStrawberry200}
+                annotations={splitAnnotations.cases}
+                renderTooltipContents={makeRenderTooltipContents('new cases')}
+                {...chartProps}
+              />
+              <ChartDescription
+                label="Cases"
+                data={getDataForField(data, positiveField)}
+              />
             </>
           ) : (
             <ChartAlert message={getAlertMessage('cases')} />
@@ -421,25 +394,26 @@ const SummaryCharts = ({
           </h3>
 
           {hasData(hospitalizedField) ? (
-            <><BarChart
-              data={getDataForField(data, hospitalizedField)}
-              lineData={dailyAverage(data, hospitalizedField)}
-              refLineData={dailyAverage(usData, hospitalizedField)}
-              fill={colors.colorBlueberry200}
-              lineColor={colors.colorBlueberry400}
-              annotations={splitAnnotations.hospitalizations}
-              renderTooltipContents={makeRenderTooltipContents(
-                <>
-                  current <br />
-                  hospitalizations
-                </>,
-              )}
-              {...chartProps}
-            />
-            <ChartDescription
-              label="Hospitalization"
-              data={getDataForField(data, hospitalizedField)}
-            />
+            <>
+              <BarChart
+                data={getDataForField(data, hospitalizedField)}
+                lineData={dailyAverage(data, hospitalizedField)}
+                refLineData={dailyAverage(usData, hospitalizedField)}
+                fill={colors.colorBlueberry200}
+                lineColor={colors.colorBlueberry400}
+                annotations={splitAnnotations.hospitalizations}
+                renderTooltipContents={makeRenderTooltipContents(
+                  <>
+                    current <br />
+                    hospitalizations
+                  </>,
+                )}
+                {...chartProps}
+              />
+              <ChartDescription
+                label="Hospitalization"
+                data={getDataForField(data, hospitalizedField)}
+              />
             </>
           ) : (
             <ChartAlert message={getAlertMessage('hospitalizations', true)} />
@@ -456,20 +430,21 @@ const SummaryCharts = ({
             <CalculatedIndicator />
           </h3>
           {hasData(deathField) ? (
-            <><BarChart
-              data={getDataForField(data, deathField)}
-              lineData={dailyAverage(data, deathField)}
-              refLineData={dailyAverage(usData, deathField)}
-              fill={colors.colorSlate300}
-              lineColor={colors.colorSlate700}
-              annotations={splitAnnotations.death}
-              renderTooltipContents={makeRenderTooltipContents('new deaths')}
-              {...chartProps}
-            />
-            <ChartDescription
-              label="New deaths"
-              data={getDataForField(data, deathField)}
-            />
+            <>
+              <BarChart
+                data={getDataForField(data, deathField)}
+                lineData={dailyAverage(data, deathField)}
+                refLineData={dailyAverage(usData, deathField)}
+                fill={colors.colorSlate300}
+                lineColor={colors.colorSlate700}
+                annotations={splitAnnotations.death}
+                renderTooltipContents={makeRenderTooltipContents('new deaths')}
+                {...chartProps}
+              />
+              <ChartDescription
+                label="New deaths"
+                data={getDataForField(data, deathField)}
+              />
             </>
           ) : (
             <ChartAlert message={getAlertMessage('deaths')} />

--- a/src/components/pages/data/summary-charts.js
+++ b/src/components/pages/data/summary-charts.js
@@ -24,6 +24,34 @@ import styles from './summary-charts.module.scss'
 
 import TooltipContents from '~components/charts/tooltip-contents'
 
+const ChartDescription = ({ label, data }) => {
+  const startDate = parseDate(data[0].date)
+  const lastDate = parseDate(data[data.length - 1].date)
+  const start = data[0].value
+  const last = data[data.length - 1].value
+  const lowPoint = {
+    date: false,
+    value: false,
+  }
+  let directionUp = 0
+  lowPoint.forEach((point, index) => {
+    if(index > 7)
+  })
+
+  return (
+    <div>
+      {label} started at {start} on {startDate} and our most recent data on{' '}
+      {lastDate} it is at {last}.
+      {lowPoint.value !== false && (
+        <>
+          The most recent low-point in {label.toLowerCase()} was {lowPoint.date} when the
+          value was {lowPoint.value}.
+        </>
+      )}
+    </div>
+  )
+}
+
 const TestFieldIndicator = ({ field, units, national }) => (
   <span className={styles.testFieldIndicator}>
     {national ? (
@@ -346,6 +374,10 @@ const SummaryCharts = ({
             renderTooltipContents={makeRenderTooltipContents(`new tests`)}
             {...chartProps}
           />
+          <ChartDescription
+            label="New tests"
+            data={getDataForField(data, testField)}
+          />
         </Col>
         <Col {...colProps}>
           <h3>
@@ -358,6 +390,7 @@ const SummaryCharts = ({
             <CalculatedIndicator />
           </h3>
           {hasData(positiveField) ? (
+            <>
             <BarChart
               data={getDataForField(data, positiveField)}
               lineData={dailyAverage(data, positiveField)}
@@ -368,6 +401,11 @@ const SummaryCharts = ({
               renderTooltipContents={makeRenderTooltipContents('new cases')}
               {...chartProps}
             />
+            <ChartDescription
+              label="Cases"
+              data={getDataForField(data, positiveField)}
+            />
+            </>
           ) : (
             <ChartAlert message={getAlertMessage('cases')} />
           )}
@@ -383,7 +421,7 @@ const SummaryCharts = ({
           </h3>
 
           {hasData(hospitalizedField) ? (
-            <BarChart
+            <><BarChart
               data={getDataForField(data, hospitalizedField)}
               lineData={dailyAverage(data, hospitalizedField)}
               refLineData={dailyAverage(usData, hospitalizedField)}
@@ -398,6 +436,11 @@ const SummaryCharts = ({
               )}
               {...chartProps}
             />
+            <ChartDescription
+              label="Hospitalization"
+              data={getDataForField(data, hospitalizedField)}
+            />
+            </>
           ) : (
             <ChartAlert message={getAlertMessage('hospitalizations', true)} />
           )}
@@ -413,7 +456,7 @@ const SummaryCharts = ({
             <CalculatedIndicator />
           </h3>
           {hasData(deathField) ? (
-            <BarChart
+            <><BarChart
               data={getDataForField(data, deathField)}
               lineData={dailyAverage(data, deathField)}
               refLineData={dailyAverage(usData, deathField)}
@@ -423,6 +466,11 @@ const SummaryCharts = ({
               renderTooltipContents={makeRenderTooltipContents('new deaths')}
               {...chartProps}
             />
+            <ChartDescription
+              label="New deaths"
+              data={getDataForField(data, deathField)}
+            />
+            </>
           ) : (
             <ChartAlert message={getAlertMessage('deaths')} />
           )}


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Generates an automatic description for state and national charts