### PR TITLE
chore: limit headshots to 3 authors in blog headers

### DIFF
--- a/src/components/pages/blog/byline.js
+++ b/src/components/pages/blog/byline.js
@@ -63,7 +63,7 @@ const Byline = ({
         darkBackground && bylineStyles.darkBackground,
       )}
     >
-      {hasHeadshots && (
+      {hasHeadshots && authorsWithHeadshots.length < 4 && (
         <div
           className={classnames(
             bylineStyles.headshotContainer,


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Limit headershots to 3 in blog headers