### PR TITLE
feat(a11y): Better link text in cards

### DIFF
--- a/src/__tests__/components/pages/data/__snapshots__/cards.js.snap
+++ b/src/__tests__/components/pages/data/__snapshots__/cards.js.snap
@@ -18,12 +18,12 @@ exports[`Components : Pages : Data : Cards : Antibody tests renders correctly 1`
       <a
         href="/data/state/california/tests-antibody"
       >
-        Historical data 
         <span
           className="a11y-only"
         >
-           for antibody tests
+           antibody testing 
         </span>
+        Historical data
       </a>
     </span>
   </div>
@@ -112,12 +112,13 @@ exports[`Components : Pages : Data : Cards : Cases renders correctly 1`] = `
       <a
         href="/data/state/california/cases"
       >
-        Historical data 
         <span
           className="a11y-only"
         >
-           for cases
+           cases
+           
         </span>
+        Historical data
       </a>
     </span>
   </div>
@@ -279,12 +280,14 @@ exports[`Components : Pages : Data : Cards : Cases renders correctly 2`] = `
       <a
         href="/data/national/cases"
       >
-        Historical data 
         <span
           className="a11y-only"
         >
-           for cases
+          national
+           cases
+           
         </span>
+        Historical data
       </a>
     </span>
   </div>
@@ -386,13 +389,13 @@ exports[`Components : Pages : Data : Cards : Hospitalization renders correctly 1
       <a
         href="/data/state/california/hospitalization"
       >
-        Historical data
-         
         <span
           className="a11y-only"
         >
-           for hospitalization
+           hospitalization
+           
         </span>
+        Historical data
       </a>
     </span>
   </div>
@@ -601,13 +604,14 @@ exports[`Components : Pages : Data : Cards : Hospitalization renders correctly 2
       <a
         href="/data/national/hospitalization"
       >
-        Historical data
-         
         <span
           className="a11y-only"
         >
-           for hospitalization
+          National
+           hospitalization
+           
         </span>
+        Historical data
       </a>
     </span>
   </div>
@@ -726,12 +730,12 @@ exports[`Components : Pages : Data : Cards : National tests renders correctly 1`
       <a
         href="/data/national/tests"
       >
-        Historical data 
         <span
           className="a11y-only"
         >
-           for national tests
+          National testing 
         </span>
+        Historical data
       </a>
     </span>
   </div>
@@ -833,12 +837,13 @@ exports[`Components : Pages : Data : Cards : Outcomes renders correctly 1`] = `
       <a
         href="/data/state/california/outcomes"
       >
-        Historical data 
         <span
           className="a11y-only"
         >
-           for outcomes
+           outcomes
+           
         </span>
+        Historical data
       </a>
     </span>
   </div>
@@ -987,12 +992,14 @@ exports[`Components : Pages : Data : Cards : Outcomes renders correctly 2`] = `
       <a
         href="/data/national/outcomes"
       >
-        Historical data 
         <span
           className="a11y-only"
         >
-           for outcomes
+          national
+           outcomes
+           
         </span>
+        Historical data
       </a>
     </span>
   </div>
@@ -1141,13 +1148,13 @@ exports[`Components : Pages : Data : Cards : Viral tests renders correctly 1`] =
       <a
         href="/data/state/california/tests-viral"
       >
-        Historical data
-         
         <span
           className="a11y-only"
         >
-           for viral (PCR) tests
+           viral (PCR) testing 
         </span>
+        Historical data
+         
       </a>
     </span>
   </div>
@@ -1272,13 +1279,13 @@ exports[`Components : Pages : Data : Cards : Viral tests renders correctly 2`] =
       <a
         href="/data/state/california/tests-viral"
       >
-        Historical data
-         
         <span
           className="a11y-only"
         >
-           for viral (PCR) tests
+           viral (PCR) testing 
         </span>
+        Historical data
+         
       </a>
     </span>
   </div>

--- a/src/components/pages/data/cards/cases-card.js
+++ b/src/components/pages/data/cards/cases-card.js
@@ -10,6 +10,7 @@ import {
 
 const CasesCard = ({
   stateSlug,
+  stateName,
   positive,
   positiveIncrease,
   sevenDayIncrease,
@@ -36,7 +37,10 @@ const CasesCard = ({
             national ? '/data/national/cases' : `/data/state/${stateSlug}/cases`
           }
         >
-          Historical data <span className="a11y-only"> for cases</span>
+          <span className="a11y-only">
+            {national ? 'national' : stateName} cases{' '}
+          </span>
+          Historical data
         </Link>
       }
     >

--- a/src/components/pages/data/cards/hospitalization-card.js
+++ b/src/components/pages/data/cards/hospitalization-card.js
@@ -6,6 +6,7 @@ import { Statistic, DefinitionLink } from '~components/common/statistic'
 
 const HospitalizationCard = ({
   stateSlug,
+  stateName,
   hospitalizedCumulative,
   inIcuCumulative,
   onVentilatorCumulative,
@@ -35,8 +36,10 @@ const HospitalizationCard = ({
               : `/data/state/${stateSlug}/hospitalization`
           }
         >
-          Historical data{' '}
-          <span className="a11y-only"> for hospitalization</span>
+          <span className="a11y-only">
+            {national ? 'National' : stateName} hospitalization{' '}
+          </span>
+          Historical data
         </Link>
       }
     >

--- a/src/components/pages/data/cards/long-term-care.js
+++ b/src/components/pages/data/cards/long-term-care.js
@@ -9,7 +9,7 @@ import {
 import { DefinitionPanelContext } from './definitions-panel'
 import { FormatDate, formatDateToString } from '~components/utils/format'
 
-export default ({ data, stateDeaths, stateSlug }) => {
+export default ({ data, stateName, stateDeaths, stateSlug }) => {
   const { current, last, facilities } = data
   const definitionContext = useContext(DefinitionPanelContext)
   const definitionFields = ['ltc_cases', 'ltc_deaths', 'ltc_facilities']
@@ -33,7 +33,10 @@ export default ({ data, stateDeaths, stateSlug }) => {
     <Card
       title="Long-Term Care (LTC)"
       link={
-        <Link to={`/data/state/${stateSlug}/long-term-care`}>More data</Link>
+        <Link to={`/data/state/${stateSlug}/long-term-care`}>
+          <span className="a11y-only">{stateName} long-term care data </span>
+          <span aria-hidden>More data</span>
+        </Link>
       }
     >
       <CardBody>

--- a/src/components/pages/data/cards/outcomes-card.js
+++ b/src/components/pages/data/cards/outcomes-card.js
@@ -6,6 +6,7 @@ import { Statistic, DefinitionLink } from '~components/common/statistic'
 
 const OutcomesCard = ({
   stateSlug,
+  stateName,
   onDefinitionsToggle,
   deathsLabel,
   death,
@@ -35,7 +36,10 @@ const OutcomesCard = ({
               : `/data/state/${stateSlug}/outcomes`
           }
         >
-          Historical data <span className="a11y-only"> for outcomes</span>
+          <span className="a11y-only">
+            {national ? 'national' : stateName} outcomes{' '}
+          </span>
+          Historical data
         </Link>
       }
     >

--- a/src/components/pages/data/cards/tests-antibody.js
+++ b/src/components/pages/data/cards/tests-antibody.js
@@ -6,6 +6,7 @@ import { Statistic, DefinitionLink } from '~components/common/statistic'
 
 const TestAntibodyCard = ({
   stateSlug,
+  stateName,
   totalTestsAntibody,
   totalTestsPeopleAntibody,
 }) => {
@@ -16,7 +17,8 @@ const TestAntibodyCard = ({
       title="Antibody tests"
       link={
         <Link to={`/data/state/${stateSlug}/tests-antibody`}>
-          Historical data <span className="a11y-only"> for antibody tests</span>
+          <span className="a11y-only">{stateName} antibody testing </span>
+          Historical data
         </Link>
       }
     >

--- a/src/components/pages/data/cards/tests-national.js
+++ b/src/components/pages/data/cards/tests-national.js
@@ -22,7 +22,7 @@ const TestNationalCard = ({
       title="Tests"
       link={
         <Link to="/data/national/tests">
-          Historical data <span className="a11y-only"> for national tests</span>
+          <span className="a11y-only">National testing </span>Historical data
         </Link>
       }
     >

--- a/src/components/pages/data/cards/tests-viral.js
+++ b/src/components/pages/data/cards/tests-viral.js
@@ -10,6 +10,7 @@ import { Statistic, DefinitionLink } from '~components/common/statistic'
 
 const TestsViralCard = ({
   stateSlug,
+  stateName,
   totalTestEncountersViral,
   totalTestsViral,
   totalTestsPeopleViral,
@@ -33,8 +34,8 @@ const TestsViralCard = ({
       title="Viral (PCR) tests"
       link={
         <Link to={`/data/state/${stateSlug}/tests-viral`}>
+          <span className="a11y-only">{stateName} viral (PCR) testing </span>
           Historical data{' '}
-          <span className="a11y-only"> for viral (PCR) tests</span>
         </Link>
       }
     >

--- a/src/components/pages/data/summary.js
+++ b/src/components/pages/data/summary.js
@@ -126,6 +126,7 @@ const StateSummary = ({
         >
           <CasesCard
             stateSlug={stateSlug}
+            stateName={stateName}
             positive={data.positive}
             positiveIncrease={data.positiveIncrease}
             probableCases={data.probableCases}
@@ -147,6 +148,7 @@ const StateSummary = ({
             <>
               <TestsViralCard
                 stateSlug={stateSlug}
+                stateName={stateName}
                 totalTestEncountersViral={data.totalTestEncountersViral}
                 totalTestsViral={data.totalTestsViral}
                 totalTestsPeopleViral={data.totalTestsPeopleViral}
@@ -154,12 +156,14 @@ const StateSummary = ({
               />
               <TestsAntibodyCard
                 stateSlug={stateSlug}
+                stateName={stateName}
                 totalTestsAntibody={data.totalTestsAntibody}
               />
             </>
           )}
           <HospitalizationCard
             stateSlug={stateSlug}
+            stateName={stateName}
             hospitalizedCumulative={data.hospitalizedCumulative}
             inIcuCumulative={data.inIcuCumulative}
             onVentilatorCumulative={data.onVentilatorCumulative}
@@ -170,6 +174,7 @@ const StateSummary = ({
           />
           <OutcomesCard
             stateSlug={stateSlug}
+            stateName={stateName}
             deathsLabel={deathsLabel}
             death={data.death}
             deathConfirmed={data.deathConfirmed}
@@ -180,6 +185,7 @@ const StateSummary = ({
           {!national && (
             <LongTermCareCard
               data={longTermCare}
+              stateName={stateName}
               stateDeaths={data.death}
               stateSlug={stateSlug}
             />


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
From user feedback, adds state names and data name to "more info" links in state cards so the link rotor doesn't keep repeating itself.