### PR TITLE
chore: Remove state grade from LTC subpage

### DIFF
--- a/src/components/pages/state/long-term-care/preamble.js
+++ b/src/components/pages/state/long-term-care/preamble.js
@@ -1,64 +1,32 @@
 import React from 'react'
-import { useStaticQuery, graphql } from 'gatsby'
 import OverviewWrapper from '~components/common/overview-wrapper'
 import LongTermCareOverview from './overview'
-import { Row, Col } from '~components/common/grid'
-import { LargeStateGrade } from '~components/pages/state/state-grade'
 import preambleStyle from '../preamble.module.scss'
 import downloadDataStyles from '../download-data.module.scss'
 
-const LongTermCarePreamble = ({ state, grade, facilities, overview }) => {
-  const { contentfulSnippet } = useStaticQuery(
-    graphql`
-      query {
-        contentfulSnippet(slug: { eq: "state-grades-preamble" }) {
-          content {
-            childMarkdownRemark {
-              html
-            }
-          }
-        }
-      }
-    `,
-  )
-
+const LongTermCarePreamble = ({ state, facilities, overview }) => {
   return (
     <OverviewWrapper>
       <h2 className="a11y-only">State overview</h2>
       <LongTermCareOverview facilities={facilities} overview={overview} />
-      <Row>
-        <Col width={[4, 3, 6]}>
-          <h3 className={preambleStyle.header}>Download dataset</h3>
-          <div className={downloadDataStyles.container}>
-            <p>
-              <a
-                href="https://github.com/COVID19Tracking/long-term-care-data/blob/master/state_overview.csv"
-                className={downloadDataStyles.button}
-              >
-                State overview
-              </a>
-              <a
-                href={`https://github.com/COVID19Tracking/long-term-care-data/blob/master/facilities_${state.toLowerCase()}.csv`}
-                className={downloadDataStyles.button}
-              >
-                All facilities
-              </a>
-            </p>
-          </div>
-        </Col>
-        <Col width={[4, 3, 6]}>
-          <h3 className={preambleStyle.header}>Current data quality grade</h3>
-          <div className={preambleStyle.gradeWrapper}>
-            <div
-              className={preambleStyle.gradeDescription}
-              dangerouslySetInnerHTML={{
-                __html: contentfulSnippet.content.childMarkdownRemark.html,
-              }}
-            />
-            <LargeStateGrade letterGrade={grade} />
-          </div>
-        </Col>
-      </Row>
+
+      <h3 className={preambleStyle.header}>Download dataset</h3>
+      <div className={downloadDataStyles.container}>
+        <p>
+          <a
+            href="https://github.com/COVID19Tracking/long-term-care-data/blob/master/state_overview.csv"
+            className={downloadDataStyles.button}
+          >
+            State overview
+          </a>
+          <a
+            href={`https://github.com/COVID19Tracking/long-term-care-data/blob/master/facilities_${state.toLowerCase()}.csv`}
+            className={downloadDataStyles.button}
+          >
+            All facilities
+          </a>
+        </p>
+      </div>
     </OverviewWrapper>
   )
 }

--- a/src/templates/state/long-term-care.js
+++ b/src/templates/state/long-term-care.js
@@ -26,7 +26,6 @@ export default ({ pageContext, path, data }) => {
           <LongTermCarePreamble
             state={state.state}
             stateName={state.name}
-            grade={data.covidState.dataQualityGrade}
             facilities={data.covidStateInfo.childLtc.facilities}
             overview={data.covidStateInfo.childLtc.current}
           />


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Removes the state grades from the LTC subpages