### PR TITLE
Kevee/annotation ff

### DIFF
--- a/src/components/pages/data/summary-charts.js
+++ b/src/components/pages/data/summary-charts.js
@@ -274,7 +274,7 @@ const SummaryCharts = ({
     }  COVID-19 ${field} for at least 30% of the past 90 days.`
 
   const showTodaysChartTick =
-    DateTime.fromISO(data[data.length - 1].date).day >= 15
+    DateTime.fromISO(data[data.length - 1].date).day >= 20
 
   const chartProps = {
     height: 280, // these control the dimensions used to render the svg but not the final size

--- a/src/components/pages/data/summary-charts.js
+++ b/src/components/pages/data/summary-charts.js
@@ -266,7 +266,7 @@ const SummaryCharts = ({
   const splitAnnotations = generateAnnotationNumbers(annotations.nodes)
   const flattenedAnnotations = Object.values(splitAnnotations)
     .reduce((acc, val) => [...acc, ...val], [])
-    .sort((a, b) => (a.annotationNumber > b.annotationNumber ? 1 : -1))
+    .sort((a, b) => (a.annotationSymbol > b.annotationSymbol ? 1 : -1))
 
   const getAlertMessage = (field, current = false) =>
     `${name} has not reported data on  ${


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fixes last-x values being too close to the other x ticks
- Adds better sorting for chart annotations
[airtable](https://airtable.com/tbl78phKvQLbKQvV0/viwzuvy3fZrep0aoD/reczdwPtp8I1nyTJE?blocks=hide)