### PR TITLE
fix: Long term care facility totals

### DIFF
--- a/src/components/pages/data/cards/long-term-care.js
+++ b/src/components/pages/data/cards/long-term-care.js
@@ -64,7 +64,7 @@ export default ({ data, stateName, stateDeaths, stateSlug }) => {
                 label="Long-term care deaths"
               />
             </Statistic>
-            <Statistic title="Facilities tracked" value={facilities}>
+            <Statistic title="Number of facilities affected" value={facilities}>
               <DefinitionLink
                 onDefinitionsToggle={() => {
                   definitionContext({

--- a/src/components/pages/data/cards/long-term-care.js
+++ b/src/components/pages/data/cards/long-term-care.js
@@ -10,7 +10,13 @@ import { DefinitionPanelContext } from './definitions-panel'
 import { FormatDate, formatDateToString } from '~components/utils/format'
 
 export default ({ data, stateName, stateDeaths, stateSlug }) => {
-  const { current, last, facilities } = data
+  const { current, last } = data
+  let facilities = 0
+  Object.keys(current).forEach(key => {
+    if (key.search('outbrkfac') > -1) {
+      facilities += current[key]
+    }
+  })
   const definitionContext = useContext(DefinitionPanelContext)
   const definitionFields = ['ltc_cases', 'ltc_deaths', 'ltc_facilities']
   const getChange = field => {

--- a/src/components/pages/state/long-term-care/overview.js
+++ b/src/components/pages/state/long-term-care/overview.js
@@ -76,7 +76,7 @@ const LongTermCareOverview = ({ facilities, overview }) => {
         </Col>
         <Col width={[4, 6, 3]}>
           <Total
-            label="Facilities tracked"
+            label="Number of facilities affected"
             number={<FormatNumber number={facilities} />}
           >
             <button

--- a/src/components/pages/state/long-term-care/overview.js
+++ b/src/components/pages/state/long-term-care/overview.js
@@ -76,7 +76,7 @@ const LongTermCareOverview = ({ facilities, overview }) => {
         </Col>
         <Col width={[4, 6, 3]}>
           <Total
-            label="Number of facilities affected"
+            label="Facilities affected"
             number={<FormatNumber number={facilities} />}
           >
             <button

--- a/src/components/pages/state/long-term-care/preamble.js
+++ b/src/components/pages/state/long-term-care/preamble.js
@@ -4,7 +4,13 @@ import LongTermCareOverview from './overview'
 import preambleStyle from '../preamble.module.scss'
 import downloadDataStyles from '../download-data.module.scss'
 
-const LongTermCarePreamble = ({ state, facilities, overview }) => {
+const LongTermCarePreamble = ({ state, overview }) => {
+  let facilities = 0
+  Object.keys(overview).forEach(key => {
+    if (key.search('outbrkfac') > -1) {
+      facilities += overview[key]
+    }
+  })
   return (
     <OverviewWrapper>
       <h2 className="a11y-only">State overview</h2>

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -131,10 +131,13 @@ export const query = graphql`
           slug
         }
         childLtc {
-          facilities
           current {
             total_cases
             total_death
+            outbrkfac_alf
+            outbrkfac_ltc
+            outbrkfac_other
+            outbrkfac_nh
             date
           }
           last {

--- a/src/templates/state/index.js
+++ b/src/templates/state/index.js
@@ -89,11 +89,14 @@ export const query = graphql`
         population
       }
       childLtc {
-        facilities
         current {
           date
           total_cases
           total_death
+          outbrkfac_alf
+          outbrkfac_ltc
+          outbrkfac_other
+          outbrkfac_nh
         }
         last {
           date

--- a/src/templates/state/long-term-care.js
+++ b/src/templates/state/long-term-care.js
@@ -26,7 +26,6 @@ export default ({ pageContext, path, data }) => {
           <LongTermCarePreamble
             state={state.state}
             stateName={state.name}
-            facilities={data.covidStateInfo.childLtc.facilities}
             overview={data.covidStateInfo.childLtc.current}
           />
           <LongTermCareBarChart data={data.aggregate.nodes} />
@@ -67,11 +66,14 @@ export const query = graphql`
     }
     covidStateInfo(state: { eq: $state }) {
       childLtc {
-        facilities
         current {
           date
           total_cases
           total_death
+          outbrkfac_alf
+          outbrkfac_ltc
+          outbrkfac_other
+          outbrkfac_nh
         }
       }
     }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->

- Use state-level data for facility totals
- Rename facility totals