### PR TITLE
chore: Change to use single-value for field for annotations

### DIFF
--- a/src/components/pages/data/cards/definitions-panel.js
+++ b/src/components/pages/data/cards/definitions-panel.js
@@ -55,11 +55,7 @@ const Annotation = ({ key, annotation, highlighted }) => {
         highlighted && definitionsPanelStyles.highlight,
       )}
     >
-      <h3 className={definitionsPanelStyles.title}>
-        {annotation.field.map(field => (
-          <>{field}</>
-        ))}
-      </h3>
+      <h3 className={definitionsPanelStyles.title}>{annotation.field}</h3>
       <p>{annotation.warning}</p>
       {annotation.lastChecked && <p>Last updated {annotation.lastChecked}</p>}
     </div>
@@ -120,9 +116,7 @@ const DefinitionPanel = ({
               <Annotation
                 annotation={annotation}
                 key={annotation.airtable_id}
-                highlighted={
-                  annotation.field.indexOf(highlightedDefinition) > -1
-                }
+                highlighted={annotation.field === highlightedDefinition}
               />
             ))}
           </>
@@ -139,7 +133,7 @@ const AnnotationButton = ({ field, children }) => {
   }
   if (
     annotationContext.annotations.filter(
-      annotation => annotation.field.indexOf(field) > -1,
+      annotation => annotation.field === field,
     ).length > 0
   ) {
     return children

--- a/src/components/pages/data/states.js
+++ b/src/components/pages/data/states.js
@@ -24,8 +24,7 @@ const States = ({
       }
     })
     state.annotations = annotations.filter(
-      annotation =>
-        annotation.state && annotation.state.indexOf(state.state) > -1,
+      annotation => annotation.state && annotation.state === state.state,
     )
     stateList.push(state)
   })


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
This supports a format change in our Airtable annotations