### PR TITLE
Update state-contact.js

### DIFF
--- a/src/components/pages/race/get-better-data/state-contact.js
+++ b/src/components/pages/race/get-better-data/state-contact.js
@@ -58,8 +58,8 @@ const StateContact = ({ currentState, governors }) => {
         </li>
       </ul>
       <DetailText className={stateContactStyle.detail}>
-        Source:{' '}
-        <a href="https://civilserviceusa.github.io/us-governors/">
+        Source:
+        <a href="https://civilserviceusa.github.io/us-governors/" style="padding-left: 4px;">
           Civil Services
         </a>
       </DetailText>


### PR DESCRIPTION
This Pull request is in response to the Issue #1608 , adding 
 {
  padding-left: 4px;
}
fulfills the requiring gap.

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
