### PR TITLE
fix(data): content spacing for states

### DIFF
--- a/src/components/pages/data/summary.module.scss
+++ b/src/components/pages/data/summary.module.scss
@@ -22,5 +22,6 @@
 
   @media (max-width: $viewport-md) {
     grid-template-columns: 1fr;
+    margin-bottom: 0;
   }
 }

--- a/src/components/pages/state/preamble.module.scss
+++ b/src/components/pages/state/preamble.module.scss
@@ -2,6 +2,10 @@
   @include margin(16, bottom);
   @include type-size(300);
   line-height: 1.3;
+  @media (max-width: $viewport-md) {
+    margin-top: spacer(8);
+    margin-bottom: spacer(8);
+  }
 }
 
 .preamble {


### PR DESCRIPTION
fixes #1615

New:
![image](https://user-images.githubusercontent.com/18607205/100000787-54b24d80-2d7f-11eb-9b4b-d773e220c662.png)


<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
