### PR TITLE
 fix(tweets): regex and highlighting

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -141,7 +141,7 @@ exports.createPages = async ({ graphql, actions }) => {
       component: path.resolve(`./src/templates/state/index.js`),
       context: {
         ...node,
-        nameRegex: `/${node.name}| ${node.state.toUpperCase()}/g`,
+        nameRegex: `/${node.name}|${node.state.toUpperCase()}[-.,/;:() ]/g`,
         slug,
       },
     })

--- a/src/components/common/tweet.js
+++ b/src/components/common/tweet.js
@@ -22,9 +22,10 @@ const Tweet = ({
     if (!stateAbbreviation && !stateName) {
       return content
     }
-    const patternAsString = `(${stateName}|${stateAbbreviation})`
+    // match the state name or abbreviation, followed by a space or punctuation
+    const patternAsString = `(${stateName}|${stateAbbreviation})([-.,/;:() ])`
     const statePattern = new RegExp(patternAsString)
-    return content.replace(statePattern, '**$1**')
+    return content.replace(statePattern, '**$1**$2')
   }
 
   const highlightedTweet = getBoldedText(text)


### PR DESCRIPTION
- only matches "CO" instead of "COVID" for Colorado
- also matches "CA," and "CA." as well as "CA"
- also applies to full state names i.e. California
- fixes #1621 

