### PR TITLE
fix(contact): disable form autofill

### DIFF
--- a/src/pages/contact/data.js
+++ b/src/pages/contact/data.js
@@ -31,6 +31,7 @@ const ContactPage = ({ data }) => {
         encType="multipart/form-data"
         acceptCharset="utf-8"
         referrerPolicy="unsafe-url"
+        autocomplete="off"
       >
         <Select
           isRequired


### PR DESCRIPTION
Fixes #1591: stops autofilling state selector for contact page.
See [MDN](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion) for more.

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
