### PR TITLE
fix(design): Remove style collision removing space

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -59,7 +59,7 @@ const gatsbyConfig = {
       options: {
         data: sassImports,
         cssLoaderOptions: {
-          localIdentName: '[sha1:hash:hex:4]',
+          localIdentName: '[sha1:hash:hex:5]',
         },
       },
     },

--- a/src/components/common/toggle.module.scss
+++ b/src/components/common/toggle.module.scss
@@ -22,7 +22,6 @@
 }
 
 .toggle-wrapper {
-  display: flex;
   align-items: center;
 }
 

--- a/src/components/common/toggle.module.scss
+++ b/src/components/common/toggle.module.scss
@@ -22,6 +22,7 @@
 }
 
 .toggle-wrapper {
+  display: flex;
   align-items: center;
 }
 

--- a/src/components/pages/race/get-better-data/state-contact.module.scss
+++ b/src/components/pages/race/get-better-data/state-contact.module.scss
@@ -1,7 +1,6 @@
 .detail {
-  text-align: right;
+  text-align: left;
   @media (max-width: $viewport-sm) {
-    text-align: left;
     @include margin(16, top);
   }
 }


### PR DESCRIPTION
- Test and didn't see updated snapshots 
- Noticed the react components did have the child shown of the space, but, due to collisions, wasn't rendering 
-> investigation here showed me https://github.com/COVID19Tracking/website/issues/1608#issuecomment-731599590 (thanks @ivarvong )

- see source space between `:` and `Civil services`

before: 

![Screen Shot 2020-11-23 at 6 20 01 PM](https://user-images.githubusercontent.com/5950956/100030179-87c50300-2db8-11eb-8e3c-0b7e97d7721d.png)
![Screen Shot 2020-11-23 at 6 20 35 PM](https://user-images.githubusercontent.com/5950956/100030204-96abb580-2db8-11eb-9cba-b4ffd3f9cef1.png)

after: 

![Screen Shot 2020-11-23 at 6 19 18 PM](https://user-images.githubusercontent.com/5950956/100030141-72e86f80-2db8-11eb-93ea-343ca195b3ec.png)
![Screen Shot 2020-11-23 at 6 18 41 PM](https://user-images.githubusercontent.com/5950956/100030144-72e86f80-2db8-11eb-9aed-be16d052f3ce.png)

