### PR TITLE
feat:Chart page redesign

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -341,8 +341,15 @@ const gatsbyConfig = {
       resolve: 'gatsby-plugin-global-context',
       options: {
         context: {
+          latestDate: DateTime.fromISO(latestDate).toISODate(),
           sevenDaysAgo: DateTime.fromISO(latestDate)
             .minus({ days: 7 })
+            .toISODate(),
+          fourteenDaysAgo: DateTime.fromISO(latestDate)
+            .minus({ days: 14 })
+            .toISODate(),
+          ninetyDaysAgo: DateTime.fromISO(latestDate)
+            .minus({ days: 90 })
             .toISODate(),
         },
       },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -348,6 +348,9 @@ const gatsbyConfig = {
           fourteenDaysAgo: DateTime.fromISO(latestDate)
             .minus({ days: 14 })
             .toISODate(),
+          twentyEightDaysAgo: DateTime.fromISO(latestDate)
+            .minus({ days: 28 })
+            .toISODate(),
           ninetyDaysAgo: DateTime.fromISO(latestDate)
             .minus({ days: 90 })
             .toISODate(),

--- a/src/components/pages/data/charts/chart-list.js
+++ b/src/components/pages/data/charts/chart-list.js
@@ -13,32 +13,45 @@ const DataChartsPage = () => {
           charts {
             title
             slug
+            thumbnail {
+              resize(width: 300) {
+                src
+              }
+            }
           }
         }
       }
     }
   `)
   return (
-    <Row className={chartListStyles.charts}>
+    <>
+      <h2 className="a11y-only">All charts</h2>
       {data.allContentfulChartCategory.nodes.map(({ name, charts }) => (
-        <Col
-          width={[4, 3, 3]}
-          paddingRight={[0, 8, 32]}
-          paddingLeft={[0, 0, 0]}
-        >
-          <h2>{name}</h2>
+        <>
           {charts && charts.length > 0 && (
-            <ul className={chartListStyles.list}>
-              {charts.map(item => (
-                <li>
-                  <Link to={`/data/charts/${item.slug}`}>{item.title}</Link>
-                </li>
-              ))}
-            </ul>
+            <>
+              <h3>{name}</h3>
+              <Row className={chartListStyles.list}>
+                {charts.map(item => (
+                  <Col width={[2, 2, 2]}>
+                    <Link to={`/data/charts/${item.slug}`}>
+                      {item.thumbnail && (
+                        <img
+                          src={item.thumbnail.resize.src}
+                          alt=""
+                          aria-hidden
+                        />
+                      )}
+                    </Link>
+                    <Link to={`/data/charts/${item.slug}`}>{item.title}</Link>
+                  </Col>
+                ))}
+              </Row>
+            </>
           )}
-        </Col>
+        </>
       ))}
-    </Row>
+    </>
   )
 }
 

--- a/src/components/pages/data/charts/chart-list.js
+++ b/src/components/pages/data/charts/chart-list.js
@@ -16,7 +16,12 @@ const ChartCarousel = ({ charts }) => {
     }
   }
   return (
-    <ul className={chartListStyles.carousel}>
+    <ul
+      className={classnames(
+        chartListStyles.carousel,
+        charts.length <= carouselLength && chartListStyles.noCarousel,
+      )}
+    >
       {charts.length > carouselLength && (
         <li className={chartListStyles.navigation}>
           <button
@@ -99,7 +104,7 @@ const DataChartsPage = () => {
         <>
           {charts && charts.length > 0 && (
             <>
-              <h3>{name}</h3>
+              <h3 className={chartListStyles.heading}>{name}</h3>
               <ChartCarousel charts={charts} />
             </>
           )}

--- a/src/components/pages/data/charts/chart-list.js
+++ b/src/components/pages/data/charts/chart-list.js
@@ -16,14 +16,9 @@ const ChartCarousel = ({ charts }) => {
     }
   }
   return (
-    <ul
-      className={classnames(
-        chartListStyles.carousel,
-        charts.length <= carouselLength && chartListStyles.noCarousel,
-      )}
-    >
-      {charts.length > carouselLength && (
-        <li className={chartListStyles.navigation}>
+    <ul className={classnames(chartListStyles.carousel)}>
+      <li className={chartListStyles.navigation}>
+        {charts.length > carouselLength && (
           <button
             type="button"
             aria-hidden
@@ -35,8 +30,8 @@ const ChartCarousel = ({ charts }) => {
           >
             ←<span className="a11y-only">Prior charts</span>
           </button>
-        </li>
-      )}
+        )}
+      </li>
       {charts.map((item, index) => (
         <li
           className={classnames(
@@ -54,8 +49,8 @@ const ChartCarousel = ({ charts }) => {
           <Link to={`/data/charts/${item.slug}`}>{item.title}</Link>
         </li>
       ))}
-      {charts.length > carouselLength && (
-        <li className={chartListStyles.navigation}>
+      <li className={chartListStyles.navigation}>
+        {charts.length > carouselLength && (
           <button
             type="button"
             aria-hidden
@@ -71,8 +66,8 @@ const ChartCarousel = ({ charts }) => {
           >
             →<span className="a11y-only">Next charts</span>
           </button>
-        </li>
-      )}
+        )}
+      </li>
     </ul>
   )
 }

--- a/src/components/pages/data/charts/chart-list.js
+++ b/src/components/pages/data/charts/chart-list.js
@@ -1,7 +1,70 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Link, useStaticQuery, graphql } from 'gatsby'
-import { Row, Col } from '~components/common/grid'
+import classnames from 'classnames'
 import chartListStyles from './chart-list.module.scss'
+
+const ChartCarousel = ({ charts }) => {
+  const [activeItem, setActiveItem] = useState(0)
+  const carouselLength = 5
+
+  const updateActiveItem = add => {
+    if (
+      typeof charts[activeItem + add + carouselLength] !== 'undefined' &&
+      activeItem + add >= 0
+    ) {
+      setActiveItem(activeItem + add)
+    }
+  }
+  return (
+    <ul className={chartListStyles.carousel}>
+      {charts.length > carouselLength && (
+        <li className={chartListStyles.navigation}>
+          <button
+            type="button"
+            aria-hidden
+            onClick={event => {
+              event.preventDefault()
+              updateActiveItem(-1)
+            }}
+          >
+            ←<span className="a11y-only">Prior charts</span>
+          </button>
+        </li>
+      )}
+      {charts.map((item, index) => (
+        <li
+          className={classnames(
+            chartListStyles.chart,
+            index >= activeItem &&
+              index < activeItem + carouselLength &&
+              chartListStyles.active,
+          )}
+        >
+          <Link to={`/data/charts/${item.slug}`}>
+            {item.thumbnail && (
+              <img src={item.thumbnail.resize.src} alt="" aria-hidden />
+            )}
+          </Link>
+          <Link to={`/data/charts/${item.slug}`}>{item.title}</Link>
+        </li>
+      ))}
+      {charts.length > carouselLength && (
+        <li className={chartListStyles.navigation}>
+          <button
+            type="button"
+            aria-hidden
+            onClick={event => {
+              event.preventDefault()
+              updateActiveItem(1)
+            }}
+          >
+            →<span className="a11y-only">Next charts</span>
+          </button>
+        </li>
+      )}
+    </ul>
+  )
+}
 
 const DataChartsPage = () => {
   const data = useStaticQuery(graphql`
@@ -31,22 +94,7 @@ const DataChartsPage = () => {
           {charts && charts.length > 0 && (
             <>
               <h3>{name}</h3>
-              <Row className={chartListStyles.list}>
-                {charts.map(item => (
-                  <Col width={[2, 2, 2]}>
-                    <Link to={`/data/charts/${item.slug}`}>
-                      {item.thumbnail && (
-                        <img
-                          src={item.thumbnail.resize.src}
-                          alt=""
-                          aria-hidden
-                        />
-                      )}
-                    </Link>
-                    <Link to={`/data/charts/${item.slug}`}>{item.title}</Link>
-                  </Col>
-                ))}
-              </Row>
+              <ChartCarousel charts={charts} />
             </>
           )}
         </>

--- a/src/components/pages/data/charts/chart-list.js
+++ b/src/components/pages/data/charts/chart-list.js
@@ -22,6 +22,7 @@ const ChartCarousel = ({ charts }) => {
           <button
             type="button"
             aria-hidden
+            disabled={activeItem === 0 ? true : undefined}
             onClick={event => {
               event.preventDefault()
               updateActiveItem(-1)
@@ -53,6 +54,11 @@ const ChartCarousel = ({ charts }) => {
           <button
             type="button"
             aria-hidden
+            disabled={
+              activeItem >= charts.length - carouselLength - 1
+                ? true
+                : undefined
+            }
             onClick={event => {
               event.preventDefault()
               updateActiveItem(1)

--- a/src/components/pages/data/charts/chart-list.js
+++ b/src/components/pages/data/charts/chart-list.js
@@ -98,7 +98,7 @@ const DataChartsPage = () => {
     }
   `)
   return (
-    <>
+    <div className={chartListStyles.lists}>
       <h2 className="a11y-only">All charts</h2>
       {data.allContentfulChartCategory.nodes.map(({ name, charts }) => (
         <>
@@ -110,7 +110,7 @@ const DataChartsPage = () => {
           )}
         </>
       ))}
-    </>
+    </div>
   )
 }
 

--- a/src/components/pages/data/charts/chart-list.module.scss
+++ b/src/components/pages/data/charts/chart-list.module.scss
@@ -53,3 +53,7 @@
     margin-left: 8.33333%;
   }
 }
+
+.lists {
+  @include margin(64, bottom);
+}

--- a/src/components/pages/data/charts/chart-list.module.scss
+++ b/src/components/pages/data/charts/chart-list.module.scss
@@ -11,6 +11,10 @@
   li {
     &.chart {
       @include col(2 2 2);
+
+      &:last-child {
+        padding-right: 0.5rem !important;
+      }
       @media (min-width: $viewport-lg) {
         @include a11y-only();
         &.active {

--- a/src/components/pages/data/charts/chart-list.module.scss
+++ b/src/components/pages/data/charts/chart-list.module.scss
@@ -5,7 +5,7 @@
   padding: 0;
   &.no-carousel {
     @media (min-width: $viewport-lg) {
-      margin-left: 8.33333%;
+      margin-left: 8.33333%; // ignore-style-rule
     }
   }
   li {
@@ -14,7 +14,7 @@
       @include col(2 2 2);
 
       &:last-child {
-        padding-right: 0.5rem !important;
+        padding-right: 0.5rem !important; // ignore-style-rule
       }
       @media (min-width: $viewport-lg) {
         @include a11y-only();
@@ -55,7 +55,7 @@
 
 .heading {
   @media (min-width: $viewport-lg) {
-    margin-left: 8.33333%;
+    margin-left: 8.33333%; // ignore-style-rule
   }
 }
 

--- a/src/components/pages/data/charts/chart-list.module.scss
+++ b/src/components/pages/data/charts/chart-list.module.scss
@@ -1,14 +1,6 @@
 .list {
-  list-style-type: none;
-  padding: 0;
-  li {
-    @include margin(8, top bottom);
-  }
-}
-
-.charts {
-  @include margin(64, bottom);
-  h2 {
-    @include type-size(400);
+  img {
+    display: block;
+    border: 1px solid $color-slate-700;
   }
 }

--- a/src/components/pages/data/charts/chart-list.module.scss
+++ b/src/components/pages/data/charts/chart-list.module.scss
@@ -1,6 +1,40 @@
-.list {
-  img {
-    display: block;
-    border: 1px solid $color-slate-700;
+.carousel {
+  @include row();
+  list-style-type: none;
+  margin: 0;
+  padding: 0;
+  li {
+    &.chart {
+      @include col(2 2 2);
+      @media (min-width: $viewport-lg) {
+        @include a11y-only();
+        &.active {
+          @include a11y-only-off();
+          @include padding(8, right);
+          &:last-child {
+            padding: 0;
+          }
+        }
+      }
+      img {
+        display: block;
+        border: 1px solid $color-slate-700;
+        padding: 1px; // ignore-style-rule
+      }
+    }
+    &.navigation {
+      display: none;
+      @include col(1 1 1);
+      @media (min-width: $viewport-lg) {
+        display: list-item;
+        vertical-align: middle;
+      }
+      button {
+        @include remove-button-style();
+        @include type-size(700);
+        color: $color-plum-700;
+        @include margin(16, top);
+      }
+    }
   }
 }

--- a/src/components/pages/data/charts/chart-list.module.scss
+++ b/src/components/pages/data/charts/chart-list.module.scss
@@ -34,6 +34,10 @@
         @include type-size(700);
         color: $color-plum-700;
         @include margin(16, top);
+        &[disabled] {
+          color: $color-slate-300;
+          cursor: not-allowed;
+        }
       }
     }
   }

--- a/src/components/pages/data/charts/chart-list.module.scss
+++ b/src/components/pages/data/charts/chart-list.module.scss
@@ -3,6 +3,11 @@
   list-style-type: none;
   margin: 0;
   padding: 0;
+  &.no-carousel {
+    @media (min-width: $viewport-lg) {
+      margin-left: 8.33333%;
+    }
+  }
   li {
     &.chart {
       @include col(2 2 2);
@@ -40,5 +45,11 @@
         }
       }
     }
+  }
+}
+
+.heading {
+  @media (min-width: $viewport-lg) {
+    margin-left: 8.33333%;
   }
 }

--- a/src/components/pages/data/charts/chart-list.module.scss
+++ b/src/components/pages/data/charts/chart-list.module.scss
@@ -9,6 +9,7 @@
     }
   }
   li {
+    @include margin(16, bottom);
     &.chart {
       @include col(2 2 2);
 

--- a/src/components/pages/data/charts/map.js
+++ b/src/components/pages/data/charts/map.js
@@ -198,9 +198,9 @@ const ChartMap = ({ history, current }) => {
           <span className={classnames(mapStyles.legend, mapStyles.rising)}>
             rising
           </span>{' '}
-          in {totalRising} states,
+          in {totalRising} states,{' '}
           <span className={mapStyles.legend}>staying the same</span> in{' '}
-          {totalUnchanged} states, and
+          {totalUnchanged} states, and{' '}
           <span className={classnames(mapStyles.legend, mapStyles.falling)}>
             falling
           </span>{' '}

--- a/src/components/pages/data/charts/map.js
+++ b/src/components/pages/data/charts/map.js
@@ -155,7 +155,7 @@ const ChartMap = ({ history, current }) => {
   const totalUnchanged =
     Object.keys(stateStatus).length - totalRising - totalFalling
   return (
-    <Row>
+    <Row className={mapStyles.row}>
       <Col width={[4, 6, 8]}>
         <Link to="#skip-map" className={mapStyles.skipLink}>
           Skip state map

--- a/src/components/pages/data/charts/map.js
+++ b/src/components/pages/data/charts/map.js
@@ -196,13 +196,13 @@ const ChartMap = ({ history, current }) => {
         <p className={mapStyles.mapLegend} id="skip-map">
           Cases are{' '}
           <span className={classnames(mapStyles.legend, mapStyles.rising)}>
-            rising{' '}
+            rising
           </span>{' '}
           in {totalRising} states,
-          <span className={mapStyles.legend}>staying the same </span> in{' '}
+          <span className={mapStyles.legend}>staying the same</span> in{' '}
           {totalUnchanged} states, and
           <span className={classnames(mapStyles.legend, mapStyles.falling)}>
-            falling{' '}
+            falling
           </span>{' '}
           in {totalFalling} states.
         </p>

--- a/src/components/pages/data/charts/map.js
+++ b/src/components/pages/data/charts/map.js
@@ -1,5 +1,6 @@
 import React from 'react'
 import classnames from 'classnames'
+import { Link } from 'gatsby'
 import { Row, Col } from '~components/common/grid'
 import mapStyles from './map.module.scss'
 
@@ -156,7 +157,11 @@ const ChartMap = ({ history, current }) => {
   return (
     <Row>
       <Col width={[4, 6, 8]}>
+        <Link to="#skip-map" className={mapStyles.skipLink}>
+          Skip state map
+        </Link>
         <div className={mapStyles.map}>
+          <h3 className={mapStyles.heading}>New cases 14-day average</h3>
           {states.map(line => (
             <div>
               {line.map(state => (
@@ -168,7 +173,19 @@ const ChartMap = ({ history, current }) => {
                     stateStatus[state] < 0 && mapStyles.falling,
                   )}
                 >
-                  {state}
+                  {state && (
+                    <>
+                      <span className="a11y-only">In </span>
+                      {state}
+                      <span className="a11y-only">
+                        , cases are{' '}
+                        {stateStatus[state] > 0 &&
+                          stateStatus[state] <= 0.1 && <>rising</>}
+                        {stateStatus[state] > 0.1 && <>rising</>}{' '}
+                        {stateStatus[state] < 0 && <>falling</>}
+                      </span>
+                    </>
+                  )}
                 </div>
               ))}
             </div>
@@ -176,7 +193,7 @@ const ChartMap = ({ history, current }) => {
         </div>
       </Col>
       <Col width={[4, 6, 4]}>
-        <p className={mapStyles.mapLegend}>
+        <p className={mapStyles.mapLegend} id="skip-map">
           Cases are{' '}
           <span className={classnames(mapStyles.legend, mapStyles.rising)}>
             rising{' '}

--- a/src/components/pages/data/charts/map.js
+++ b/src/components/pages/data/charts/map.js
@@ -1,0 +1,197 @@
+import React from 'react'
+import classnames from 'classnames'
+import { Row, Col } from '~components/common/grid'
+import mapStyles from './map.module.scss'
+
+const states = [
+  [
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    'ME',
+  ],
+  [
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    'WI',
+    null,
+    null,
+    null,
+    'VT',
+    'NH',
+  ],
+  [
+    null,
+    null,
+    'WA',
+    'ID',
+    'MT',
+    'ND',
+    'MN',
+    'IL',
+    'MI',
+    null,
+    'NY',
+    'MA',
+    null,
+  ],
+  [
+    null,
+    null,
+    'OR',
+    'NV',
+    'WY',
+    'SD',
+    'IA',
+    'IN',
+    'OH',
+    'PA',
+    'NJ',
+    'CT',
+    'RI',
+  ],
+  [
+    null,
+    null,
+    'CA',
+    'UT',
+    'CO',
+    'NE',
+    'MO',
+    'KY',
+    'WV',
+    'VA',
+    'MD',
+    'DE',
+    null,
+  ],
+  [
+    null,
+    null,
+    null,
+    'AZ',
+    'NM',
+    'KS',
+    'AR',
+    'TN',
+    'NC',
+    'SC',
+    'DC',
+    null,
+    null,
+  ],
+  [
+    null,
+    null,
+    null,
+    null,
+    null,
+    'OK',
+    'LA',
+    'MS',
+    'AL',
+    'GA',
+    null,
+    null,
+    null,
+  ],
+  [
+    'GU',
+    'MP',
+    'HI',
+    'AK',
+    null,
+    'TX',
+    null,
+    null,
+    null,
+    null,
+    'FL',
+    'PR',
+    'VI',
+  ],
+  [
+    null,
+    null,
+    'AS',
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  ],
+]
+
+const ChartMap = ({ history, current }) => {
+  const stateStatus = {}
+  history.forEach(row => {
+    const today = current.find(item => item.state === row.state)
+    stateStatus[row.state] = (today.positive - row.positive) / row.positive
+  })
+  const totalRising = Object.values(stateStatus).filter(item => item > 0.1)
+    .length
+  const totalFalling = Object.values(stateStatus).filter(item => item < 0)
+    .length
+  const totalUnchanged =
+    Object.keys(stateStatus).length - totalRising - totalFalling
+  return (
+    <Row>
+      <Col width={[4, 6, 8]}>
+        <div className={mapStyles.map}>
+          {states.map(line => (
+            <div>
+              {line.map(state => (
+                <div
+                  className={classnames(
+                    mapStyles.state,
+                    state && mapStyles.hasState,
+                    stateStatus[state] > 0.1 && mapStyles.rising,
+                    stateStatus[state] < 0 && mapStyles.falling,
+                  )}
+                >
+                  {state}
+                </div>
+              ))}
+            </div>
+          ))}
+        </div>
+      </Col>
+      <Col width={[4, 6, 4]}>
+        <p className={mapStyles.mapLegend}>
+          Cases are{' '}
+          <span className={classnames(mapStyles.legend, mapStyles.rising)}>
+            rising{' '}
+          </span>{' '}
+          in {totalRising} states,
+          <span className={mapStyles.legend}>staying the same </span> in{' '}
+          {totalUnchanged} states, and
+          <span className={classnames(mapStyles.legend, mapStyles.falling)}>
+            falling{' '}
+          </span>{' '}
+          in {totalFalling} states.
+        </p>
+      </Col>
+    </Row>
+  )
+}
+
+export default ChartMap

--- a/src/components/pages/data/charts/map.module.scss
+++ b/src/components/pages/data/charts/map.module.scss
@@ -51,8 +51,7 @@ $color-unchanged: #d3d7d7;
     margin-bottom: 0;
   }
   .legend {
-    display: inline-block;
-    @include padding(4, left right);
+    @include padding(4);
     background: $color-unchanged;
     &.rising {
       background: $color-rising;

--- a/src/components/pages/data/charts/map.module.scss
+++ b/src/components/pages/data/charts/map.module.scss
@@ -2,6 +2,13 @@ $color-falling: #8ae8c2;
 $color-rising: #fead82;
 $color-unchanged: #d3d7d7;
 
+.row {
+  flex-direction: column-reverse;
+  @media (min-width: $viewport-lg) {
+    flex-direction: row;
+  }
+}
+
 .map {
   @include type-size(100);
   width: 442px;
@@ -39,6 +46,10 @@ $color-unchanged: #d3d7d7;
   @include type-size(400);
   line-height: 2.5rem;
   font-weight: bold;
+  @include margin(32, bottom);
+  @media (min-width: $viewport-lg) {
+    margin-bottom: 0;
+  }
   .legend {
     display: inline-block;
     @include padding(4, left right);

--- a/src/components/pages/data/charts/map.module.scss
+++ b/src/components/pages/data/charts/map.module.scss
@@ -1,0 +1,43 @@
+$color-falling: #8ae8c2;
+$color-rising: #fead82;
+$color-unchanged: #d3d7d7;
+
+.map {
+  @include type-size(100);
+  width: 442px;
+  .state {
+    width: 30px;
+    height: 30px;
+    display: inline-block;
+    text-align: center;
+    @include margin(4, right bottom);
+    @include padding(4, top);
+    vertical-align: top;
+    &.has-state {
+      background: $color-unchanged;
+      text-align: center;
+    }
+    &.rising {
+      background: $color-rising;
+    }
+    &.falling {
+      background: $color-falling;
+    }
+  }
+}
+.map-legend {
+  @include type-size(400);
+  line-height: 2.5rem;
+  font-weight: bold;
+  .legend {
+    display: inline-block;
+    @include padding(4, left right);
+    background: $color-unchanged;
+    &.rising {
+      background: $color-rising;
+    }
+    &.falling {
+      background: $color-falling;
+    }
+  }
+}

--- a/src/components/pages/data/charts/map.module.scss
+++ b/src/components/pages/data/charts/map.module.scss
@@ -5,12 +5,22 @@ $color-unchanged: #d3d7d7;
 .map {
   @include type-size(100);
   width: 442px;
+  position: relative;
+  .heading {
+    position: absolute;
+    z-index: 1;
+    color: $color-slate-700;
+    text-transform: uppercase;
+    margin: 0;
+    @include type-size(200);
+    font-weight: normal;
+  }
   .state {
-    width: 30px;
-    height: 30px;
+    width: 32px;
+    height: 32px;
     display: inline-block;
     text-align: center;
-    @include margin(4, right bottom);
+    margin: 0 2px 2px 0; // ignore-style-rules
     @include padding(4, top);
     vertical-align: top;
     &.has-state {
@@ -39,5 +49,15 @@ $color-unchanged: #d3d7d7;
     &.falling {
       background: $color-falling;
     }
+  }
+}
+
+.skip-link {
+  @include a11y-only();
+  &:focus {
+    overflow: auto;
+    margin: 0;
+    height: auto;
+    position: relative;
   }
 }

--- a/src/components/pages/data/charts/map.module.scss
+++ b/src/components/pages/data/charts/map.module.scss
@@ -55,9 +55,6 @@ $color-unchanged: #d3d7d7;
 .skip-link {
   @include a11y-only();
   &:focus {
-    overflow: auto;
-    margin: 0;
-    height: auto;
-    position: relative;
+    @include a11y-only-off();
   }
 }

--- a/src/components/pages/data/charts/preamble.js
+++ b/src/components/pages/data/charts/preamble.js
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Row, Col } from '~components/common/grid'
+import ChartSparklines from './sparklines'
+import ChartMap from './map'
+import preambleStyles from './preamble.module.scss'
+
+const ChartPreamble = ({ current, history, usHistory }) => (
+  <Row className={preambleStyles.preamble}>
+    <Col
+      width={[4, 6, 4]}
+      paddingRight={[0, 0, 32]}
+      className={preambleStyles.column}
+    >
+      <ChartSparklines history={usHistory} />
+    </Col>
+
+    <Col width={[4, 6, 8]} paddingLeft={[0, 0, 32]}>
+      <ChartMap history={history} current={current} />
+    </Col>
+  </Row>
+)
+
+export default ChartPreamble

--- a/src/components/pages/data/charts/preamble.module.scss
+++ b/src/components/pages/data/charts/preamble.module.scss
@@ -1,0 +1,10 @@
+.preamble {
+  @include margin(16, bottom);
+  @include padding(32, bottom);
+  border-bottom: 1px solid $color-slate-500;
+}
+.column {
+  @media (min-width: $viewport-lg) {
+    border-right: 1px solid $color-slate-500;
+  }
+}

--- a/src/components/pages/data/charts/preamble.module.scss
+++ b/src/components/pages/data/charts/preamble.module.scss
@@ -4,7 +4,13 @@
   border-bottom: 1px solid $color-slate-500;
 }
 .column {
+  @include margin(16, bottom);
+  @include padding(16, bottom);
+  border-bottom: 1px solid $color-slate-500;
   @media (min-width: $viewport-lg) {
+    border-bottom: none;
+    padding-bottom: 0;
+    margin-bottom: 0;
     border-right: 1px solid $color-slate-500;
   }
 }

--- a/src/components/pages/data/charts/sparklines.js
+++ b/src/components/pages/data/charts/sparklines.js
@@ -124,7 +124,7 @@ const ChartSparklines = ({ history }) => {
             color={colors.colorStrawberry200}
           />
         </li>
-        <li className={sparklineStyles.hosptialization}>
+        <li className={sparklineStyles.hospitalization}>
           <span>
             <FormatNumber number={covidUs.hospitalizedCurrently} /> currently{' '}
             <abbr title="hospitalized">hosp.</abbr>

--- a/src/components/pages/data/charts/sparklines.js
+++ b/src/components/pages/data/charts/sparklines.js
@@ -12,6 +12,7 @@ const StatisticSparkline = ({ data, field, color }) => {
   const height = 40
   const width = 120
   const marginTop = 5
+  const marginRight = 20
   const dates = []
   const values = []
   data.forEach(item => {
@@ -41,11 +42,30 @@ const StatisticSparkline = ({ data, field, color }) => {
   return (
     <svg
       className={sparklineStyles.sparkline}
-      viewBox={`0 0 ${width} ${height - marginTop}`}
+      viewBox={`0 0 ${width + marginRight} ${height - marginTop}`}
       aria-hidden
     >
       <g transform={`translate(0 ${marginTop})`}>
-        <path d={lineFn(data)} stroke={color} strokeWidth={3} fill="none" />
+        <defs>
+          <marker
+            id={`triangle-${field}`}
+            refX="10"
+            refY="6"
+            markerWidth="30"
+            markerHeight="30"
+            markerUnits="userSpaceOnUse"
+            orient="auto"
+          >
+            <path d="M 0 0 12 6 0 12 3 6" style={{ fill: color }} />
+          </marker>
+        </defs>
+        <path
+          d={lineFn(data)}
+          stroke={color}
+          strokeWidth={3}
+          fill="none"
+          markerEnd={`url(#triangle-${field})`}
+        />
       </g>
     </svg>
   )

--- a/src/components/pages/data/charts/sparklines.js
+++ b/src/components/pages/data/charts/sparklines.js
@@ -67,7 +67,10 @@ const ChartSparklines = ({ history }) => {
   return (
     <>
       <h3 className={sparklineStyles.heading}>
-        On <FormatDate date={covidUs.date} format="LLLL d" />
+        <span>
+          On <FormatDate date={covidUs.date} format="LLLL d" />
+        </span>
+        <span>14 day trend</span>
       </h3>
       <ul className={sparklineStyles.list}>
         <li className={sparklineStyles.tests}>

--- a/src/components/pages/data/charts/sparklines.js
+++ b/src/components/pages/data/charts/sparklines.js
@@ -105,7 +105,7 @@ const ChartSparklines = ({ history }) => {
         <span>
           On <FormatDate date={covidUs.date} format="LLLL d" />
         </span>
-        <span>14 day trend</span>
+        <span>14-day trend</span>
       </h3>
       <ul className={sparklineStyles.list}>
         <li className={sparklineStyles.tests}>

--- a/src/components/pages/data/charts/sparklines.js
+++ b/src/components/pages/data/charts/sparklines.js
@@ -1,0 +1,113 @@
+import React from 'react'
+import { useStaticQuery, graphql } from 'gatsby'
+import { DateTime } from 'luxon'
+import { extent, max } from 'd3-array'
+import { scaleLinear, scaleTime } from 'd3-scale'
+import { line, curveNatural } from 'd3-shape'
+import { FormatDate, FormatNumber } from '~components/utils/format'
+import colors from '~scss/colors.module.scss'
+import sparklineStyles from './sparklines.module.scss'
+
+const StatisticSparkline = ({ data, field, color }) => {
+  const height = 40
+  const width = 120
+  const marginTop = 5
+  const dates = []
+  const values = []
+  data.forEach(item => {
+    dates.push(DateTime.fromISO(item.date).toJSDate())
+    values.push(item[field])
+  })
+
+  const dateDomain = extent(dates)
+
+  const xScaleTime = scaleTime()
+    .domain(dateDomain)
+    .range([0, width])
+
+  const yMaxEffective = max(values)
+
+  const yScale = scaleLinear()
+    .domain([0, yMaxEffective])
+    .nice()
+    .range([height, 0])
+
+  const lineFn = line()
+    .defined(d => !Number.isNaN(d[field]) && d[field] !== null)
+    .curve(curveNatural)
+    .x(d => xScaleTime(DateTime.fromISO(d.date).toJSDate()))
+    .y(d => yScale(d[field]))
+
+  return (
+    <svg
+      className={sparklineStyles.sparkline}
+      viewBox={`0 0 ${width} ${height - marginTop}`}
+      aria-hidden
+    >
+      <g transform={`translate(0 ${marginTop})`}>
+        <path d={lineFn(data)} stroke={color} strokeWidth={3} fill="none" />
+      </g>
+    </svg>
+  )
+}
+
+const ChartSparklines = ({ history }) => {
+  const { covidUs } = useStaticQuery(graphql`
+    {
+      covidUs {
+        date
+        totalTestResultsIncrease
+        positiveIncrease
+        hospitalizedCurrently
+        deathIncrease
+      }
+    }
+  `)
+
+  return (
+    <>
+      <h3 className={sparklineStyles.heading}>
+        On <FormatDate date={covidUs.date} format="LLLL d" />
+      </h3>
+      <ul className={sparklineStyles.list}>
+        <li className={sparklineStyles.tests}>
+          <FormatNumber number={covidUs.totalTestResultsIncrease} /> new tests
+          <StatisticSparkline
+            data={history}
+            field="totalTestResultsIncrease"
+            color={colors.colorPlum500}
+          />
+        </li>
+        <li className={sparklineStyles.cases}>
+          <FormatNumber number={covidUs.positiveIncrease} /> new cases
+          <StatisticSparkline
+            data={history}
+            field="positiveIncrease"
+            color={colors.colorStrawberry200}
+          />
+        </li>
+        <li className={sparklineStyles.hosptialization}>
+          <span>
+            <FormatNumber number={covidUs.hospitalizedCurrently} /> currently{' '}
+            <abbr title="hospitalized">hosp.</abbr>
+          </span>
+          <StatisticSparkline
+            data={history}
+            field="hospitalizedCurrently"
+            color={colors.colorBlueberry400}
+          />
+        </li>
+        <li className={sparklineStyles.deaths}>
+          <FormatNumber number={covidUs.deathIncrease} /> new deaths
+          <StatisticSparkline
+            data={history}
+            field="deathIncrease"
+            color={colors.colorSlate600}
+          />
+        </li>
+      </ul>
+    </>
+  )
+}
+
+export default ChartSparklines

--- a/src/components/pages/data/charts/sparklines.js
+++ b/src/components/pages/data/charts/sparklines.js
@@ -21,7 +21,7 @@ const StatisticSparkline = ({ data, field, color }) => {
       return
     }
     let sum = 0
-    for (let i = key; i > key - 14; i -= 1) {
+    for (let i = key; i > key - 7; i -= 1) {
       sum += data[i][field]
     }
     averages.push({

--- a/src/components/pages/data/charts/sparklines.js
+++ b/src/components/pages/data/charts/sparklines.js
@@ -25,7 +25,7 @@ const StatisticSparkline = ({ data, field, color }) => {
       sum += data[i][field]
     }
     averages.push({
-      value: sum / 14,
+      value: sum / 7,
       date: DateTime.fromISO(item.date).toJSDate(),
     })
   })

--- a/src/components/pages/data/charts/sparklines.module.scss
+++ b/src/components/pages/data/charts/sparklines.module.scss
@@ -5,6 +5,7 @@
   font-weight: bold;
   abbr {
     border-bottom: 0;
+    text-decoration: none;
   }
   li {
     @include margin(16, bottom);

--- a/src/components/pages/data/charts/sparklines.module.scss
+++ b/src/components/pages/data/charts/sparklines.module.scss
@@ -1,0 +1,35 @@
+.list {
+  @include type-size(300);
+  list-style-type: none;
+  padding: 0;
+  font-weight: bold;
+  li {
+    @include margin(16, bottom);
+    display: flex;
+    object-position: center;
+    justify-content: space-between;
+  }
+  .tests {
+    color: $color-plum-500;
+  }
+  .cases {
+    color: $color-strawberry-200;
+  }
+  .hospitalization {
+    color: $color-blueberry-400;
+  }
+  .deaths {
+    color: $color-slate-600;
+  }
+}
+
+.heading {
+  text-transform: uppercase;
+  margin: 0;
+  @include type-size(400);
+}
+
+.sparkline {
+  width: 120px;
+  height: 40px;
+}

--- a/src/components/pages/data/charts/sparklines.module.scss
+++ b/src/components/pages/data/charts/sparklines.module.scss
@@ -29,7 +29,10 @@
 .heading {
   text-transform: uppercase;
   margin: 0;
-  @include type-size(400);
+  @include type-size(300);
+  display: flex;
+  object-position: center;
+  justify-content: space-between;
 }
 
 .sparkline {

--- a/src/components/pages/data/charts/sparklines.module.scss
+++ b/src/components/pages/data/charts/sparklines.module.scss
@@ -3,6 +3,9 @@
   list-style-type: none;
   padding: 0;
   font-weight: bold;
+  abbr {
+    border-bottom: 0;
+  }
   li {
     @include margin(16, bottom);
     display: flex;

--- a/src/components/pages/data/charts/tweet.js
+++ b/src/components/pages/data/charts/tweet.js
@@ -12,6 +12,7 @@ const ChartTweet = () => {
         limit: 1
       ) {
         nodes {
+          id_str
           entities {
             urls {
               display_url
@@ -29,7 +30,7 @@ const ChartTweet = () => {
   if (!allTweets || !allTweets.nodes[0]) {
     return null
   }
-  const { entities, full_text } = allTweets.nodes[0]
+  const { entities, full_text, id_str } = allTweets.nodes[0]
   if (!entities.media) {
     return null
   }
@@ -37,10 +38,12 @@ const ChartTweet = () => {
   return (
     <Container centered>
       <h2> The national picture over time</h2>
-      <img
-        src={entities.media[0].media_url.replace(/http(s?):\/\//g, '//')}
-        alt={full_text}
-      />
+      <a href={`https://twitter.com/COVID19Tracking/status/${id_str}`}>
+        <img
+          src={entities.media[0].media_url.replace(/http(s?):\/\//g, '//')}
+          alt={full_text}
+        />
+      </a>
     </Container>
   )
 }

--- a/src/components/pages/data/charts/tweet.js
+++ b/src/components/pages/data/charts/tweet.js
@@ -37,7 +37,10 @@ const ChartTweet = () => {
   return (
     <Container centered>
       <h2> The national picture over time</h2>
-      <img src={entities.media[0].media_url} alt={full_text} />
+      <img
+        src={entities.media[0].media_url.replace(/http(s?):\/\//g, '//')}
+        alt={full_text}
+      />
     </Container>
   )
 }

--- a/src/components/pages/data/charts/tweet.js
+++ b/src/components/pages/data/charts/tweet.js
@@ -1,0 +1,44 @@
+/* eslint-disable camelcase */
+import React from 'react'
+import { useStaticQuery, graphql } from 'gatsby'
+import Container from '~components/common/container'
+
+const ChartTweet = () => {
+  const data = useStaticQuery(graphql`
+    {
+      allTweets(
+        filter: { is_pinned: { eq: true } }
+        sort: { fields: date, order: DESC }
+        limit: 1
+      ) {
+        nodes {
+          entities {
+            urls {
+              display_url
+            }
+            media {
+              media_url
+            }
+          }
+          full_text
+        }
+      }
+    }
+  `)
+  const { allTweets } = data
+  if (!allTweets || !allTweets.nodes[0]) {
+    return null
+  }
+  const { entities, full_text } = allTweets.nodes[0]
+  if (!entities.media) {
+    return null
+  }
+
+  return (
+    <Container centered>
+      <h2> The national picture over time</h2>
+      <img src={entities.media[0].media_url} alt={full_text} />
+    </Container>
+  )
+}
+export default ChartTweet

--- a/src/pages/data/charts.js
+++ b/src/pages/data/charts.js
@@ -1,13 +1,31 @@
 import React from 'react'
 import { graphql } from 'gatsby'
 import Layout from '~components/layout'
+import { Row, Col } from '~components/common/grid'
 import Container from '~components/common/container'
 import LongContent from '~components/common/long-content'
 import ContentfulContent from '~components/common/contentful-content'
 import ChartList from '~components/pages/data/charts/chart-list'
+import ChartSparklines from '~components/pages/data/charts/sparklines'
+import ChartTweet from '~components/pages/data/charts/tweet'
+import ChartMap from '~components/pages/data/charts/map'
 
 const ChartsPage = ({ data }) => (
   <Layout title="Charts" returnLinks={[{ link: '/data' }]}>
+    <h2>United States Overview</h2>
+    <Row>
+      <Col width={[4, 6, 4]}>
+        <ChartSparklines history={data.allCovidUsDaily.nodes} />
+      </Col>
+
+      <Col width={[4, 6, 8]} paddingLeft={[0, 0, 32]}>
+        <ChartMap
+          history={data.allCovidStateDaily.nodes}
+          current={data.allCovidState.nodes}
+        />
+      </Col>
+    </Row>
+    <ChartTweet />
     <ChartList />
 
     <Container centered>
@@ -27,13 +45,40 @@ const ChartsPage = ({ data }) => (
 export default ChartsPage
 
 export const query = graphql`
-  query {
+  query($fourteenDaysAgo: Date) {
     contentfulSnippet(slug: { eq: "chart-page-content" }) {
       contentful_id
       childContentfulSnippetContentTextNode {
         childMarkdownRemark {
           html
         }
+      }
+    }
+    allCovidUsDaily(
+      sort: { fields: date }
+      filter: { date: { gte: $fourteenDaysAgo } }
+    ) {
+      nodes {
+        hospitalizedCurrently
+        deathIncrease
+        date
+        positiveIncrease
+        totalTestResultsIncrease
+      }
+    }
+    allCovidStateDaily(
+      sort: { fields: date }
+      filter: { date: { eq: $fourteenDaysAgo } }
+    ) {
+      nodes {
+        state
+        positive
+      }
+    }
+    allCovidState {
+      nodes {
+        state
+        positive
       }
     }
   }

--- a/src/pages/data/charts.js
+++ b/src/pages/data/charts.js
@@ -16,19 +16,24 @@ const ChartsPage = ({ data }) => (
       history={data.allCovidStateDaily.nodes}
       current={data.allCovidState.nodes}
     />
+    <ContentfulContent
+      content={
+        data.chartDisclaimer.childContentfulSnippetContentTextNode
+          .childMarkdownRemark.html
+      }
+      id={data.contentfulSnippet.contentful_id}
+    />
     <ChartTweet />
     <ChartList />
 
     <Container centered>
-      <LongContent>
-        <ContentfulContent
-          content={
-            data.contentfulSnippet.childContentfulSnippetContentTextNode
-              .childMarkdownRemark.html
-          }
-          id={data.contentfulSnippet.contentful_id}
-        />
-      </LongContent>
+      <ContentfulContent
+        content={
+          data.chartFooter.childContentfulSnippetContentTextNode
+            .childMarkdownRemark.html
+        }
+        id={data.contentfulSnippet.contentful_id}
+      />
     </Container>
   </Layout>
 )
@@ -37,7 +42,15 @@ export default ChartsPage
 
 export const query = graphql`
   query($fourteenDaysAgo: Date, $twentyEightDaysAgo: Date) {
-    contentfulSnippet(slug: { eq: "chart-page-content" }) {
+    chartFooter: contentfulSnippet(slug: { eq: "chart-page-content" }) {
+      contentful_id
+      childContentfulSnippetContentTextNode {
+        childMarkdownRemark {
+          html
+        }
+      }
+    }
+    chartDisclaimer: contentfulSnippet(slug: { eq: "chart-page-disclaimer" }) {
       contentful_id
       childContentfulSnippetContentTextNode {
         childMarkdownRemark {

--- a/src/pages/data/charts.js
+++ b/src/pages/data/charts.js
@@ -15,13 +15,15 @@ const ChartsPage = ({ data }) => (
       history={data.allCovidStateDaily.nodes}
       current={data.allCovidState.nodes}
     />
-    <ContentfulContent
-      content={
-        data.chartDisclaimer.childContentfulSnippetContentTextNode
-          .childMarkdownRemark.html
-      }
-      id={data.chartDisclaimer.contentful_id}
-    />
+    <Container centered>
+      <ContentfulContent
+        content={
+          data.chartDisclaimer.childContentfulSnippetContentTextNode
+            .childMarkdownRemark.html
+        }
+        id={data.chartDisclaimer.contentful_id}
+      />
+    </Container>
     <ChartTweet />
     <ChartList />
 

--- a/src/pages/data/charts.js
+++ b/src/pages/data/charts.js
@@ -2,7 +2,6 @@ import React from 'react'
 import { graphql } from 'gatsby'
 import Layout from '~components/layout'
 import Container from '~components/common/container'
-import LongContent from '~components/common/long-content'
 import ContentfulContent from '~components/common/contentful-content'
 import ChartList from '~components/pages/data/charts/chart-list'
 import ChartTweet from '~components/pages/data/charts/tweet'
@@ -21,7 +20,7 @@ const ChartsPage = ({ data }) => (
         data.chartDisclaimer.childContentfulSnippetContentTextNode
           .childMarkdownRemark.html
       }
-      id={data.contentfulSnippet.contentful_id}
+      id={data.chartDisclaimer.contentful_id}
     />
     <ChartTweet />
     <ChartList />
@@ -32,7 +31,7 @@ const ChartsPage = ({ data }) => (
           data.chartFooter.childContentfulSnippetContentTextNode
             .childMarkdownRemark.html
         }
-        id={data.contentfulSnippet.contentful_id}
+        id={data.chartFooter.contentful_id}
       />
     </Container>
   </Layout>

--- a/src/pages/data/charts.js
+++ b/src/pages/data/charts.js
@@ -1,30 +1,21 @@
 import React from 'react'
 import { graphql } from 'gatsby'
 import Layout from '~components/layout'
-import { Row, Col } from '~components/common/grid'
 import Container from '~components/common/container'
 import LongContent from '~components/common/long-content'
 import ContentfulContent from '~components/common/contentful-content'
 import ChartList from '~components/pages/data/charts/chart-list'
-import ChartSparklines from '~components/pages/data/charts/sparklines'
 import ChartTweet from '~components/pages/data/charts/tweet'
-import ChartMap from '~components/pages/data/charts/map'
+import ChartPreamble from '~components/pages/data/charts/preamble'
 
 const ChartsPage = ({ data }) => (
   <Layout title="Charts" returnLinks={[{ link: '/data' }]}>
     <h2>United States Overview</h2>
-    <Row>
-      <Col width={[4, 6, 4]}>
-        <ChartSparklines history={data.allCovidUsDaily.nodes} />
-      </Col>
-
-      <Col width={[4, 6, 8]} paddingLeft={[0, 0, 32]}>
-        <ChartMap
-          history={data.allCovidStateDaily.nodes}
-          current={data.allCovidState.nodes}
-        />
-      </Col>
-    </Row>
+    <ChartPreamble
+      usHistory={data.allCovidUsDaily.nodes}
+      history={data.allCovidStateDaily.nodes}
+      current={data.allCovidState.nodes}
+    />
     <ChartTweet />
     <ChartList />
 

--- a/src/pages/data/charts.js
+++ b/src/pages/data/charts.js
@@ -36,7 +36,7 @@ const ChartsPage = ({ data }) => (
 export default ChartsPage
 
 export const query = graphql`
-  query($fourteenDaysAgo: Date) {
+  query($fourteenDaysAgo: Date, $twentyEightDaysAgo: Date) {
     contentfulSnippet(slug: { eq: "chart-page-content" }) {
       contentful_id
       childContentfulSnippetContentTextNode {
@@ -47,7 +47,7 @@ export const query = graphql`
     }
     allCovidUsDaily(
       sort: { fields: date }
-      filter: { date: { gte: $fourteenDaysAgo } }
+      filter: { date: { gte: $twentyEightDaysAgo } }
     ) {
       nodes {
         hospitalizedCurrently

--- a/src/scss/helpers.module.scss
+++ b/src/scss/helpers.module.scss
@@ -70,6 +70,13 @@ $spacers: (
   width: 1px;
 }
 
+@mixin a11y-only-off {
+  overflow: auto;
+  margin: 0;
+  height: auto;
+  position: relative;
+}
+
 @mixin remove-button-style {
   border: 0;
   padding: 0;


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds sparklines, map, and chart images to the chart landing page