### PR TITLE
fix(contact): Edit id and name values for form on data contact page

### DIFF
--- a/src/pages/contact/data.js
+++ b/src/pages/contact/data.js
@@ -47,8 +47,8 @@ const ContactPage = ({ data }) => {
         <Input
           type="date"
           label="Date when issue began"
-          id="contact-date"
-          name="contact-date"
+          id="contact-issue-start-date"
+          name="contact-issue-start-date"
           isRequired
           onChange={event => setDate(event.target.value)}
         />


### PR DESCRIPTION
fixes #1638
The name and id for contact-date appear to only have relevance for the webhook the form is submitting to. It does not appear to affect anything else in the website code, but I cannot say if it is being used in whatever is receiving the JSON. I hope this was useful!