### PR TITLE
feat(definitions-panel): style scrollbar

### DIFF
--- a/src/components/pages/data/cards/definitions-panel.module.scss
+++ b/src/components/pages/data/cards/definitions-panel.module.scss
@@ -10,6 +10,22 @@
   color: $color-plum-300;
   border-bottom: spacer(32) solid $color-plum-800;
 
+  &::-webkit-scrollbar {
+    width: initial;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: $color-plum-800;
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    background: $color-plum-700;
+  }
+  
+  &::-webkit-scrollbar-thumb:hover {
+    background: $color-plum-600;
+  }
+  
   @media (min-width: $viewport-lg) {
     height: 100%;
     right: 0%;


### PR DESCRIPTION
This adds custom styles to the scrollbar, which makes
the clash in #1644 less prominent.

Note that this obscures the scrollbar buttons.
(See [this Stack Overflow post](https://stackoverflow.com/questions/47576815/how-to-add-arrows-with-webkit-scrollbar-button))

@kevee how do you feel about the buttons from an a11y standpoint?

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
