### PR TITLE
fix(a11y): Better color contrast

### DIFF
--- a/src/components/pages/data/charts/map.js
+++ b/src/components/pages/data/charts/map.js
@@ -171,7 +171,7 @@ const ChartMap = ({ history, current }) => {
                     mapStyles.state,
                     state && mapStyles.hasState,
                     stateStatus[state] > 0.1 && mapStyles.rising,
-                    stateStatus[state] < 0.1 && mapStyles.falling,
+                    stateStatus[state] < -0.1 && mapStyles.falling,
                   )}
                 >
                   {state && (

--- a/src/components/pages/data/charts/map.module.scss
+++ b/src/components/pages/data/charts/map.module.scss
@@ -1,5 +1,5 @@
-$color-falling: #8ae8c2;
-$color-rising: #fead82;
+$color-falling: $qualitative-color-palette-200;
+$color-rising: $qualitative-color-palette-400;
 $color-unchanged: #d3d7d7;
 
 .row {

--- a/src/components/pages/data/charts/map.module.scss
+++ b/src/components/pages/data/charts/map.module.scss
@@ -32,7 +32,6 @@ $color-unchanged: #d3d7d7;
     vertical-align: top;
     &.has-state {
       background: $color-unchanged;
-      text-align: center;
     }
     &.rising {
       background: $color-rising;


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Fixes color contrast problems with the US map