### PR TITLE
chore(get-involved): add name fields

### DIFF
--- a/src/components/pages/get-involved/form.js
+++ b/src/components/pages/get-involved/form.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Row } from '~components/common/grid'
+import { Col } from '~components/common/grid'
 import { Form, Input } from '~components/common/form'
 import formStyle from './form.module.scss'
 
@@ -10,18 +10,29 @@ const GetInvolvedForm = () => (
     target="_blank"
     noValidate
   >
-    <Row>
-      <div className={formStyle.grid}>
-        <Input
-          label="Email address"
-          type="email"
-          name="EMAIL"
-          id="action-form-email"
-          isRequired
-        />
-      </div>
-    </Row>
-
+    <Col width={[4, 6, 6]} paddingRight={[0, 0, 0]} className={formStyle.grid}>
+      <Input
+        label="First name"
+        type="text"
+        name="FNAME"
+        id="action-form-first-name"
+        isRequired
+      />
+      <Input
+        label="Last name"
+        type="text"
+        name="LNAME"
+        id="action-form-last-name"
+        isRequired
+      />
+      <Input
+        label="Email address"
+        type="email"
+        name="EMAIL"
+        id="action-form-email"
+        isRequired
+      />
+    </Col>
     <input
       type="text"
       name="b_0921fdd380ed1e2245d87c3b6_14a2b6d1bd"

--- a/src/components/pages/get-involved/form.js
+++ b/src/components/pages/get-involved/form.js
@@ -10,7 +10,7 @@ const GetInvolvedForm = () => (
     target="_blank"
     noValidate
   >
-    <Col width={[4, 6, 6]} padding={[0, 0, 0]} className={formStyle.grid}>
+    <Col width={[4, 6, 12]} padding={[0, 0, 0]} className={formStyle.grid}>
       <Input
         label="First name"
         type="text"

--- a/src/components/pages/get-involved/form.js
+++ b/src/components/pages/get-involved/form.js
@@ -10,7 +10,7 @@ const GetInvolvedForm = () => (
     target="_blank"
     noValidate
   >
-    <Col width={[4, 6, 6]} paddingRight={[0, 0, 0]} className={formStyle.grid}>
+    <Col width={[4, 6, 6]} padding={[0, 0, 0]} className={formStyle.grid}>
       <Input
         label="First name"
         type="text"

--- a/src/components/pages/get-involved/form.module.scss
+++ b/src/components/pages/get-involved/form.module.scss
@@ -3,7 +3,3 @@
     max-width: 10rem;
   }
 }
-
-.grid {
-  @include col(4 3 8);
-}


### PR DESCRIPTION
fixes #1589
Added name fields back to the get involved page. I used the Col component to organize the input fields into one column since three fields are better organized as a single column rather than the original four in a 2x2 grid. Attached is a screenshot of the final look. It looks similar if implemented with the Row component or without a grid if that's a preferable frame for it to be in, so I can change it to those if need be.

<img width="1285" alt="Newsletter with name fields" src="https://user-images.githubusercontent.com/55467415/101090819-3c171400-3585-11eb-9b18-5d4005842600.png">