### PR TITLE
feat: Listen to URL hash change in race/infection-and-mortality-data to update state.

### DIFF
--- a/src/components/pages/race/infection-and-mortality-data/select.js
+++ b/src/components/pages/race/infection-and-mortality-data/select.js
@@ -13,18 +13,30 @@ export default ({ separateStates, combinedStates, stateInfo }) => {
 
   const [state, setState] = useState(defaultState)
 
+  const setComponentStateFromStateAbbreviation = abbreviation => {
+    const stateObj = stateInfo.find(
+      node => node.state.toLowerCase() === abbreviation.toLowerCase(),
+    )
+    if (stateObj) {
+      setState(stateObj)
+    }
+  }
+
   useEffect(() => {
     if (
       typeof window !== 'undefined' &&
       window.location &&
       window.location.hash
     ) {
-      const stateFilter = window.location.hash.replace('#', '')
-      const foundState = stateInfo.find(
-        node => node.state.toLowerCase() === stateFilter.toLowerCase(),
-      )
-      if (foundState) {
-        setState(foundState)
+      const stateAbbreviation = window.location.hash.replace('#', '')
+      setComponentStateFromStateAbbreviation(stateAbbreviation)
+
+      window.onhashchange = () => {
+        const stateAbbreviationFromUrlChange = window.location.hash.replace(
+          '#',
+          '',
+        )
+        setComponentStateFromStateAbbreviation(stateAbbreviationFromUrlChange)
       }
     }
   }, [])


### PR DESCRIPTION
When selecting a new state in the dropdown in `/race/infection-and-mortality-data` it adds the URL with the new hash to history. Previously when navigating back after selecting two or more states, the hash would change but the state would not update. Now we listen for the hash change and update the state with backwards navigation. 