### PR TITLE
chore: Change to seven-day average for map

### DIFF
--- a/src/components/pages/data/charts/map.js
+++ b/src/components/pages/data/charts/map.js
@@ -142,13 +142,29 @@ const states = [
   ],
 ]
 
-const ChartMap = ({ history, current }) => {
+const ChartMap = ({ stateHistory }) => {
   const stateStatus = {}
-  history.forEach(row => {
-    const today = current.find(item => item.state === row.state)
-    stateStatus[row.state] =
-      (today.positiveIncrease - row.positiveIncrease) / row.positiveIncrease
+  const history = {}
+  stateHistory.forEach(row => {
+    if (typeof history[row.state] === 'undefined') {
+      history[row.state] = []
+    }
+    history[row.state].push(row)
   })
+  Object.keys(history).forEach(state => {
+    let currentAverage = 0
+    let pastAverage = 0
+    for (let i = 0; i < 7; i += 1) {
+      currentAverage += history[state][i].positiveIncrease
+    }
+    for (let i = 14; i < 7 + 14; i += 1) {
+      pastAverage += history[state][i].positiveIncrease
+    }
+    currentAverage /= 7
+    pastAverage /= 7
+    stateStatus[state] = (currentAverage - pastAverage) / pastAverage
+  })
+
   const totalRising = Object.values(stateStatus).filter(item => item > 0.1)
     .length
   const totalFalling = Object.values(stateStatus).filter(item => item < -0.1)

--- a/src/components/pages/data/charts/map.module.scss
+++ b/src/components/pages/data/charts/map.module.scss
@@ -67,3 +67,18 @@ $color-unchanged: #d3d7d7;
     @include a11y-only-off();
   }
 }
+
+.disclosure-button {
+  @include remove-button-style();
+  @include margin(16, top);
+  .text {
+    text-decoration: underline;
+  }
+}
+
+.disclosure {
+  display: none;
+  &.is-open {
+    display: block;
+  }
+}

--- a/src/components/pages/data/charts/preamble.js
+++ b/src/components/pages/data/charts/preamble.js
@@ -4,7 +4,7 @@ import ChartSparklines from './sparklines'
 import ChartMap from './map'
 import preambleStyles from './preamble.module.scss'
 
-const ChartPreamble = ({ current, history, usHistory }) => (
+const ChartPreamble = ({ stateHistory, usHistory }) => (
   <Row className={preambleStyles.preamble}>
     <Col
       width={[4, 6, 4]}
@@ -15,7 +15,7 @@ const ChartPreamble = ({ current, history, usHistory }) => (
     </Col>
 
     <Col width={[4, 6, 8]} paddingLeft={[0, 0, 32]}>
-      <ChartMap history={history} current={current} />
+      <ChartMap stateHistory={stateHistory} />
     </Col>
   </Row>
 )

--- a/src/pages/data/charts.js
+++ b/src/pages/data/charts.js
@@ -12,8 +12,7 @@ const ChartsPage = ({ data }) => (
     <h2>United States Overview</h2>
     <ChartPreamble
       usHistory={data.allCovidUsDaily.nodes}
-      history={data.allCovidStateDaily.nodes}
-      current={data.allCovidState.nodes}
+      stateHistory={data.allCovidStateDaily.nodes}
     />
     <Container centered>
       <ContentfulContent
@@ -42,7 +41,7 @@ const ChartsPage = ({ data }) => (
 export default ChartsPage
 
 export const query = graphql`
-  query($fourteenDaysAgo: Date, $twentyEightDaysAgo: Date) {
+  query($twentyEightDaysAgo: Date) {
     chartFooter: contentfulSnippet(slug: { eq: "chart-page-content" }) {
       contentful_id
       childContentfulSnippetContentTextNode {
@@ -72,15 +71,9 @@ export const query = graphql`
       }
     }
     allCovidStateDaily(
-      sort: { fields: date }
-      filter: { date: { eq: $fourteenDaysAgo } }
+      sort: { order: DESC, fields: date }
+      filter: { date: { gte: $twentyEightDaysAgo } }
     ) {
-      nodes {
-        state
-        positiveIncrease
-      }
-    }
-    allCovidState {
       nodes {
         state
         positiveIncrease


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Change the US map on the charts page to be a seven-day average comparison