### PR TITLE
chore: Add LTC current schemas

### DIFF
--- a/src/utilities/schema.js
+++ b/src/utilities/schema.js
@@ -1,6 +1,14 @@
 module.exports = ({ actions }) => {
   const { createTypes } = actions
   const typeDefs = `
+    type ltcCurrent implements Node {
+      total_cases: Int
+      total_death: Int
+      outbrkfac_alf: Int
+      outbrkfac_ltc: Int
+      outbrkfac_other: Int
+      outbrkfac_nh: Int
+    }
     type CovidLtcStates implements Node {
       data_timestamp: String
       data_type: String


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Adds static schema definition for `ltcCurrent`