### PR TITLE
Chore(ACS year): Update Census year

### DIFF
--- a/src/pages/race/index.js
+++ b/src/pages/race/index.js
@@ -90,7 +90,7 @@ const RacePage = () => {
               do have: the latest infection and death rates for each county,
               from a <cite>New York Times</cite> dataset, paired with the
               largest racial or ethnic group in that county, based on the Census
-              Bureau&apos;s 2018 ACS 5-Year estimates. The results are
+              Bureau&apos;s 2019 ACS 5-Year estimates. The results are
               staggering.
             </RacialDataParagraph>
           </LandingPageContainer>


### PR DESCRIPTION
Updated 2018 to 2019 for referenced ACS demographic data

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
