### PR TITLE
chore: Add flippable cards

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -276,7 +276,6 @@ const gatsbyConfig = {
       options: {
         spaceId: process.env.CONTENTFUL_SPACE,
         accessToken: process.env.CONTENTFUL_TOKEN,
-        environment: 'card-card',
         host: process.env.CONTENTFUL_PREVIEW
           ? 'preview.contentful.com'
           : 'cdn.contentful.com',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -276,6 +276,7 @@ const gatsbyConfig = {
       options: {
         spaceId: process.env.CONTENTFUL_SPACE,
         accessToken: process.env.CONTENTFUL_TOKEN,
+        environment: 'card-card',
         host: process.env.CONTENTFUL_PREVIEW
           ? 'preview.contentful.com'
           : 'cdn.contentful.com',

--- a/src/components/pages/blog/blog-content.js
+++ b/src/components/pages/blog/blog-content.js
@@ -8,6 +8,7 @@ import TableContentBlock from './content-blocks/table-content-block'
 import ImageContentBlock from './content-blocks/image-content-block'
 import FootnoteContentBlock from './content-blocks/footnote-content-block'
 import RelatedPostsContentBlock from './content-blocks/related-posts-block'
+import FlippableCard from './content-blocks/flippable-card'
 import TableauChart from '~components/charts/tableau'
 import blogContentStyles from './blog-content.module.scss'
 
@@ -40,6 +41,17 @@ const BlogContent = ({ content }) => {
           return null
         }
         const { __typename } = target
+        if (__typename === 'ContentfulContentBlockFlippableCard') {
+          return (
+            <FlippableCard
+              width={target.width}
+              height={target.height}
+              front={target.cardFront}
+              back={target.cardBack}
+              alternateText={target.alternateText}
+            />
+          )
+        }
         if (__typename === 'ContentfulContentBlockTable') {
           return <TableContentBlock table={target.table.table} />
         }

--- a/src/components/pages/blog/content-blocks/flippable-card.js
+++ b/src/components/pages/blog/content-blocks/flippable-card.js
@@ -1,0 +1,41 @@
+import React, { useState } from 'react'
+import classnames from 'classnames'
+import cardStyles from './flippable-card.module.scss'
+
+const FlippableCard = ({ width, height, front, back, alternateText }) => {
+  const [isFlipped, setIsFlipped] = useState(false)
+  return (
+    <div className={cardStyles.card}>
+      <button
+        className={cardStyles.button}
+        type="button"
+        onClick={() => {
+          setIsFlipped(!isFlipped)
+        }}
+      >
+        <div
+          style={{ width: `${width}px`, height: `${height}px` }}
+          className={classnames(
+            cardStyles.flipCard,
+            isFlipped && cardStyles.flipped,
+          )}
+        >
+          <div className={cardStyles.inner}>
+            <div className={cardStyles.front}>
+              <img src={front.fixed.src} aria-hidden alt="" />
+            </div>
+            <div className={cardStyles.back}>
+              <img src={back.fixed.src} aria-hidden alt="" />
+            </div>
+          </div>
+        </div>
+      </button>
+      <div className="a11y-only">{alternateText}</div>
+      <p aria-hidden className={cardStyles.directions}>
+        Click or tap card to flip it.
+      </p>
+    </div>
+  )
+}
+
+export default FlippableCard

--- a/src/components/pages/blog/content-blocks/flippable-card.js
+++ b/src/components/pages/blog/content-blocks/flippable-card.js
@@ -30,8 +30,12 @@ const FlippableCard = ({ width, height, front, back, alternateText }) => {
           </div>
         </div>
       </button>
+      <img src={back.fixed.src} className="js-disabled" aria-hidden alt="" />
       <div className="a11y-only">{alternateText}</div>
-      <p aria-hidden className={cardStyles.directions}>
+      <p
+        aria-hidden
+        className={classnames('js-enabled-block', cardStyles.directions)}
+      >
         Click or tap card to flip it.
       </p>
     </div>

--- a/src/components/pages/blog/content-blocks/flippable-card.module.scss
+++ b/src/components/pages/blog/content-blocks/flippable-card.module.scss
@@ -1,0 +1,42 @@
+.card {
+  @include margin(16, top bottom);
+}
+
+.button {
+  @include remove-button-style();
+  cursor: pointer;
+}
+
+.directions {
+  text-align: center;
+  @include type-size(100);
+}
+
+.flip-card {
+  background-color: transparent;
+  margin: 0 auto;
+  perspective: 1000px;
+  &.flipped {
+    .inner {
+      transform: rotateY(180deg);
+    }
+  }
+  .back {
+    transform: rotateY(180deg);
+  }
+  .inner {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    transition: transform 0.8s;
+    transform-style: preserve-3d;
+  }
+  .front,
+  .back {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    -webkit-backface-visibility: hidden;
+    backface-visibility: hidden;
+  }
+}

--- a/src/components/pages/blog/content-blocks/flippable-card.module.scss
+++ b/src/components/pages/blog/content-blocks/flippable-card.module.scss
@@ -1,5 +1,6 @@
 .card {
   @include margin(16, top bottom);
+  text-align: center;
 }
 
 .button {

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -227,6 +227,25 @@ export const query = graphql`
               footnote
             }
           }
+          ... on ContentfulContentBlockFlippableCard {
+            id
+            contentful_id
+            width
+            height
+            cardFront {
+              fixed(width: 900) {
+                src
+                srcSet
+              }
+            }
+            cardBack {
+              fixed(width: 900) {
+                src
+                srcSet
+              }
+            }
+            alternateText
+          }
         }
       }
       featuredImage {


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds a flippable card type to blog posts

## todo
- [x] Move content type to Contentful
- [x] Remove environment