### PR TITLE
chore: Sort tweet by only pinned status

### DIFF
--- a/src/components/pages/data/daily-tweet.js
+++ b/src/components/pages/data/daily-tweet.js
@@ -7,11 +7,7 @@ import Tweet from '~components/common/tweet'
 const DailyTweet = () => {
   const data = useStaticQuery(graphql`
     {
-      allTweets(
-        filter: { is_pinned: { eq: true } }
-        sort: { fields: date, order: DESC }
-        limit: 1
-      ) {
+      allTweets(filter: { is_pinned: { eq: true } }, limit: 1) {
         nodes {
           id_str
           created_at


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fix issue with timezones in pinned tweets