### PR TITLE
fix(definitions-panel): include state names in header

### DIFF
--- a/src/components/pages/data/summary.js
+++ b/src/components/pages/data/summary.js
@@ -121,7 +121,7 @@ const StateSummary = ({
             definitions={definitions}
             highlightedDefinition={highlightedDefinition}
             onHide={() => setCardDefinitions(false)}
-            title="Definitions"
+            title={`${stateName} Definitions`}
           />
         )}
         {cardAnnotations && (


### PR DESCRIPTION
Fixes #1668

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
