### PR TITLE
chore: Swap out june1 chart

### DIFF
--- a/src/pages/data/longtermcare.js
+++ b/src/pages/data/longtermcare.js
@@ -94,7 +94,7 @@ const LongTermCarePage = ({ data }) => {
       </Container>
       <TableauChart
         id="ltc-2"
-        height={525}
+        height={650}
         mobileHeight={450}
         viewUrl="https://public.tableau.com/views/LTCDataObservations/0_AllKeys?:language=en&:display_count=y&:origin=viz_share_link"
         viewUrlMobile="https://public.tableau.com/views/LTCDataObservations/0_AllKeys?:language=en&:display_count=y&:origin=viz_share_link"

--- a/src/pages/data/longtermcare.js
+++ b/src/pages/data/longtermcare.js
@@ -96,8 +96,8 @@ const LongTermCarePage = ({ data }) => {
         id="ltc-2"
         height={650}
         mobileHeight={450}
-        viewUrl="https://public.tableau.com/views/LTCDataObservations/0_AllKeys?:language=en&:display_count=y&:origin=viz_share_link"
-        viewUrlMobile="https://public.tableau.com/views/LTCDataObservations/0_AllKeys?:language=en&:display_count=y&:origin=viz_share_link"
+        viewUrl="https://public.tableau.com/views/LTCDataObservations/0_AllKeyssmall?:language=en&:display_count=y&:origin=viz_share_link"
+        viewUrlMobile="https://public.tableau.com/views/LTCDataObservations/0_AllKeyssmall?:language=en&:display_count=y&:origin=viz_share_link"
       />
       <Container centered>
         <LongContent>

--- a/src/pages/data/longtermcare.js
+++ b/src/pages/data/longtermcare.js
@@ -96,8 +96,8 @@ const LongTermCarePage = ({ data }) => {
         id="ltc-2"
         height={525}
         mobileHeight={450}
-        viewUrl="https://public.tableau.com/views/WebsiteCharts-CTPLong-TermCare/deathsbydate?:language=en&:display_count=y&:origin=viz_share_link"
-        viewUrlMobile="https://public.tableau.com/views/WebsiteCharts-CTPLong-TermCare/deathsbydate?:language=en&:display_count=y&:origin=viz_share_link"
+        viewUrl="https://public.tableau.com/views/LTCDataObservations/0_AllKeys?:language=en&:display_count=y&:origin=viz_share_link"
+        viewUrlMobile="https://public.tableau.com/views/LTCDataObservations/0_AllKeys?:language=en&:display_count=y&:origin=viz_share_link"
       />
       <Container centered>
         <LongContent>

--- a/src/pages/data/longtermcare.js
+++ b/src/pages/data/longtermcare.js
@@ -94,7 +94,7 @@ const LongTermCarePage = ({ data }) => {
       </Container>
       <TableauChart
         id="ltc-2"
-        height={650}
+        height={700}
         mobileHeight={450}
         viewUrl="https://public.tableau.com/views/LTCDataObservations/0_AllKeyssmall?:language=en&:display_count=y&:origin=viz_share_link"
         viewUrlMobile="https://public.tableau.com/views/LTCDataObservations/0_AllKeyssmall?:language=en&:display_count=y&:origin=viz_share_link"


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Swaps out a tableau chart in the LTC landing page.