### PR TITLE
fix(a11y): Missing focus style on dropdown menus

### DIFF
--- a/src/components/layout/header/navigation.module.scss
+++ b/src/components/layout/header/navigation.module.scss
@@ -93,7 +93,8 @@
     padding: spacer(8);
     cursor: pointer;
     &:hover,
-    &:focus {
+    &:focus,
+    &[data-selected] {
       color: white;
       background: black;
     }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
