### PR TITLE
Update CRDT combobox behavior

### DIFF
--- a/src/components/pages/race/dashboard/state-nav.js
+++ b/src/components/pages/race/dashboard/state-nav.js
@@ -30,7 +30,7 @@ const selectFirstItemOnKeyDown = (
     return
   }
   if (results && results.length > 0 && typeof window !== 'undefined') {
-    // select the first state result 
+    // select the first state result
     setWindowLocationFn(`state-${results[0].state.toLowerCase()}`)
     return
   }

--- a/src/components/pages/race/dashboard/state-nav.js
+++ b/src/components/pages/race/dashboard/state-nav.js
@@ -26,11 +26,11 @@ const selectFirstItemOnKeyDown = (
   setWindowLocationFn = setWindowLocation,
 ) => {
   if (event.key !== 'Enter') {
-    // ignore keypresses that 'Enter'
+    // ignore key presses that are not 'Enter'
     return
   }
-  if (results && results.length === 1 && typeof window !== 'undefined') {
-    // update the selected stat if there is only one state
+  if (results && results.length > 0 && typeof window !== 'undefined') {
+    // select the first state result 
     setWindowLocationFn(`state-${results[0].state.toLowerCase()}`)
     return
   }

--- a/src/components/pages/race/dashboard/state-nav.js
+++ b/src/components/pages/race/dashboard/state-nav.js
@@ -26,10 +26,17 @@ const selectFirstItemOnKeyDown = (
   setWindowLocationFn = setWindowLocation,
 ) => {
   if (event.key !== 'Enter') {
+    // ignore keypresses that 'Enter'
     return
   }
   if (results && results.length === 1 && typeof window !== 'undefined') {
+    // update the selected stat if there is only one state
     setWindowLocationFn(`state-${results[0].state.toLowerCase()}`)
+    return
+  }
+  if (window.location.hash === '') {
+    // set hash to the top of the states list if it isn't already set
+    window.location.hash = 'states-top'
   }
 }
 
@@ -99,6 +106,7 @@ const StateNav = ({ title, stateList }) => {
                 onChange={event => {
                   setSearchTerm(event.target.value)
                 }}
+                onSubmit={event => selectFirstItemOnKeyDown(event, results)}
               />
             </form>
             {results ? (


### PR DESCRIPTION
Stops reloading the page when users press enter with more than one result

When users press enter and there is more than one
result, this will now jump to the first result.

(Previously, pressing enter with more than one result would no nothing.)