### PR TITLE
chore(homepage-metrics): use 'cases per 100k' instead of 'cases'

### DIFF
--- a/src/components/pages/homepage/visualization-gallery/items/us-map/metrics.js
+++ b/src/components/pages/homepage/visualization-gallery/items/us-map/metrics.js
@@ -50,7 +50,7 @@ export default {
       },
       {
         style: mapStyle.level4,
-        label: 'Over 75 cases',
+        label: 'Over 75 cases per 100k',
       },
     ],
   },


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
