### PR TITLE
chore: Fix align items in mobile national charts

### DIFF
--- a/src/components/pages/homepage/visualization-gallery/items/national-chart.js
+++ b/src/components/pages/homepage/visualization-gallery/items/national-chart.js
@@ -85,7 +85,7 @@ const NationalChart = ({ item }) => {
           <Title title="National COVID-19 topline metrics">
             Data updated {data.lastUpdate.nodes[0].date}
           </Title>
-          <Row>
+          <Row className={nationalChartStyle.row}>
             <Col width={[2, 3, 3]}>
               <h3 className={nationalChartStyle.label}>New tests</h3>
               <Chart

--- a/src/components/pages/homepage/visualization-gallery/items/national-charts.module.scss
+++ b/src/components/pages/homepage/visualization-gallery/items/national-charts.module.scss
@@ -1,3 +1,7 @@
 .label {
   @include type-size(200);
 }
+
+.row {
+  align-items: flex-end;
+}

--- a/src/data/navigation/header.yml
+++ b/src/data/navigation/header.yml
@@ -1,6 +1,6 @@
 name: header
 items:
-  - title: Our Data
+  - title: The Data
     link: /data
     subNavigation: data
   - title: About the Data

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -20,7 +20,7 @@ const DataPage = ({ data }) => {
   const pageDescription = 'Our most up-to-date data on COVID-19 in the US.'
   return (
     <Layout
-      title="Our Data"
+      title="The Data"
       description={pageDescription}
       socialCard={{
         description: pageDescription,

--- a/src/templates/state/preprocess-annotations.js
+++ b/src/templates/state/preprocess-annotations.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React, { useContext } from 'react'
 import {
   AnnotationButton,


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Makes national charts on the homepage visualization `align-items: flex-end`