### PR TITLE
chore: Add warning to API/charts/download page

### DIFF
--- a/src/pages/data/api.js
+++ b/src/pages/data/api.js
@@ -8,7 +8,7 @@ import Layout from '~components/layout'
 
 const DataApiPage = ({ data }) => {
   return (
-    <Layout title="Data API" path="/data/api">
+    <Layout title="Data API" path="/data/api" showWarning>
       <LongContent>
         <ChangeLog />
         <ContentfulContent

--- a/src/pages/data/charts.js
+++ b/src/pages/data/charts.js
@@ -8,7 +8,7 @@ import ChartTweet from '~components/pages/data/charts/tweet'
 import ChartPreamble from '~components/pages/data/charts/preamble'
 
 const ChartsPage = ({ data }) => (
-  <Layout title="Charts" returnLinks={[{ link: '/data' }]}>
+  <Layout title="Charts" returnLinks={[{ link: '/data' }]} showWarning>
     <h2>United States Overview</h2>
     <ChartPreamble
       usHistory={data.allCovidUsDaily.nodes}

--- a/src/pages/data/download.js
+++ b/src/pages/data/download.js
@@ -8,6 +8,7 @@ const DataDownloadPage = ({ data }) => (
     title="Data Download"
     path="/data/download"
     returnLinks={[{ link: '/data' }]}
+    showWarning
   >
     <ContentfulContent
       content={


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
