### PR TITLE
chore: Allow metrics to define a subtitle

### DIFF
--- a/src/__tests__/components/layout/__snapshots__/footer.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/footer.js.snap
@@ -104,7 +104,7 @@ exports[`Components : Layout : Footer renders correctly 1`] = `
   >
     <span>
       CovidTracking.com Copyright © 
-      2020
+      2021
        by The Atlantic Monthly Group. 
       <a
         href="/license"

--- a/src/__tests__/components/layout/__snapshots__/index.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/index.js.snap
@@ -608,7 +608,7 @@ Array [
     >
       <span>
         CovidTracking.com Copyright © 
-        2020
+        2021
          by The Atlantic Monthly Group. 
         <a
           href="/license"
@@ -1242,7 +1242,7 @@ Array [
     >
       <span>
         CovidTracking.com Copyright © 
-        2020
+        2021
          by The Atlantic Monthly Group. 
         <a
           href="/license"

--- a/src/components/pages/homepage/visualization-gallery/items/us-map/index.js
+++ b/src/components/pages/homepage/visualization-gallery/items/us-map/index.js
@@ -120,7 +120,7 @@ const USMap = ({ configuration, item }) => {
         relatedPost={item.relatedPost}
         title={
           <Title title={metrics[metric].title}>
-            From {sevenDaysAgo} to {lastUpdate}
+            {metrics[metric].subTitle(lastUpdate, sevenDaysAgo)}
           </Title>
         }
         disclaimer={

--- a/src/components/pages/homepage/visualization-gallery/items/us-map/metrics.js
+++ b/src/components/pages/homepage/visualization-gallery/items/us-map/metrics.js
@@ -9,6 +9,7 @@ const getAverage = (history, state, value) =>
 export default {
   casesPer100k: {
     title: 'Average daily new COVID-19 cases per 100k people (past 7 days)',
+    subTitle: (now, sevenDaysAgo) => `From ${sevenDaysAgo} to ${now}`,
     getValue: (history, state) =>
       getAverage(
         history,
@@ -56,6 +57,7 @@ export default {
   },
   sevenDayPositive: {
     title: 'Average daily new COVID-19 cases (past 7 days)',
+    subTitle: (now, sevenDaysAgo) => `From ${sevenDaysAgo} to ${now}`,
     getValue: (history, state) =>
       getAverage(history, state.state, item => item.positiveIncrease),
 
@@ -96,6 +98,7 @@ export default {
   },
   hospitalizationPer1m: {
     title: 'Currently hospitalized per 1 million people',
+    subTitle: now => `Data updated ${now}`,
     getValue: (history, state) =>
       history.find(group => group.nodes[0].state === state.state).nodes[0]
         .childPopulation.hospitalizedCurrently.percent * 1000000,


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fixes subtitle for hospitalization map