### PR TITLE
chore: Hide disclaimer for map on mobile

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -36,6 +36,11 @@ module.exports = {
   setupFilesAfterEnv: ['<rootDir>/setupTests.js'],
   collectCoverageFrom: [
     './src/**/*.js',
+    '!./src/components/pages/**/*.js',
+    '!./src/components/charts/**/*.js',
+    '!./src/components/common/**/*.js',
+    '!./src/components/layout/**/*.js',
+    '!./src/components/social-media-graphics/**/*.js',
     '!./src/pages/**/*.js',
     '!./src/templates/**/*.js',
     '!./src/stories/**',

--- a/src/components/pages/homepage/visualization-gallery/components/disclaimer.js
+++ b/src/components/pages/homepage/visualization-gallery/components/disclaimer.js
@@ -2,11 +2,11 @@ import React, { useState } from 'react'
 import classnames from 'classnames'
 import disclaimerStyle from './disclaimer.module.scss'
 
-const Disclaimer = ({ text }) => {
+const Disclaimer = ({ text, hideMobile }) => {
   const [isOpen, setIsOpen] = useState(false)
 
   return (
-    <div>
+    <div className={hideMobile && disclaimerStyle.hideMobile}>
       <button
         aria-expanded={isOpen}
         type="button"

--- a/src/components/pages/homepage/visualization-gallery/components/disclaimer.module.scss
+++ b/src/components/pages/homepage/visualization-gallery/components/disclaimer.module.scss
@@ -15,3 +15,10 @@
     display: block;
   }
 }
+
+.hide-mobile {
+  display: none;
+  @media (min-width: $viewport-md) {
+    display: block;
+  }
+}

--- a/src/components/pages/homepage/visualization-gallery/items/us-map/map.js
+++ b/src/components/pages/homepage/visualization-gallery/items/us-map/map.js
@@ -178,7 +178,7 @@ const Map = ({
           </svg>
           <MapLegend legend={metric.legend} />
           {disclaimer && (
-            <Disclaimer text={disclaimer.childMarkdownRemark.html} />
+            <Disclaimer text={disclaimer.childMarkdownRemark.html} hideMobile />
           )}
         </Col>
         <Col width={[4, 6, 3]}>


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fixes duplicate "about this data" appearing above the mobile grid