### PR TITLE
chore: Fix date format for sitemap

### DIFF
--- a/src/pages/about/sitemap.js
+++ b/src/pages/about/sitemap.js
@@ -111,7 +111,7 @@ export const query = graphql`
     allContentfulBlogPost(sort: { fields: publishDate, order: DESC }) {
       nodes {
         title
-        publishDate(formatString: "MMMM d yyyy")
+        publishDate(formatString: "MMMM D yyyy")
         slug
       }
     }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fixes date format in sitemap