### PR TITLE
feat: Add automatic map date to legend

### DIFF
--- a/src/components/pages/data/hhs-facilities/map/index.js
+++ b/src/components/pages/data/hhs-facilities/map/index.js
@@ -26,6 +26,7 @@ const HHSFacilitiesMap = ({ center, zoom }) => {
   const [revealedFacility, setRevealedFacility] = useState(false)
   const [currentZoom, setCurrentZoom] = useState(0)
   const [highlighedMarker, setHighlightedMarker] = useState(false)
+  const [mapDate, setMapDate] = useState(false)
   const layers = {
     patients: ['hospitals', 'hospitals-not-reported'],
     icu: ['icu', 'icu-not-reported'],
@@ -141,6 +142,17 @@ const HHSFacilitiesMap = ({ center, zoom }) => {
     map.addControl(new mapboxgl.NavigationControl(), 'top-left')
 
     map.on('load', () => {
+      const featureDates = map
+        .queryRenderedFeatures({
+          layers: [...layers.patients, ...layers.icu],
+        })
+        .map(feature => feature.properties.collection_week)
+      setMapDate(
+        featureDates
+          .filter((date, index) => featureDates.indexOf(date) === index)
+          .sort((a, b) => (a > b ? 1 : -1))
+          .pop(),
+      )
       if (window.location.hash && hash.length > 2) {
         const features = map.queryRenderedFeatures({
           layers: [...layers.patients, ...layers.icu],
@@ -203,7 +215,11 @@ const HHSFacilitiesMap = ({ center, zoom }) => {
 
   return (
     <>
-      <Legend mapLayer={layer} setLayer={newLayer => setLayer(newLayer)} />
+      <Legend
+        mapLayer={layer}
+        setLayer={newLayer => setLayer(newLayer)}
+        date={mapDate}
+      />
       <div className={facilitiesMapStyles.container} aria-hidden>
         <div className={facilitiesMapStyles.sidebar}>
           <Form

--- a/src/components/pages/data/hhs-facilities/map/legend.js
+++ b/src/components/pages/data/hhs-facilities/map/legend.js
@@ -1,9 +1,11 @@
 import React from 'react'
+import { DateTime } from 'luxon'
+import { FormatDate } from '~components/utils/format'
 import Container from '~components/common/container'
 import { Row, Col } from '~components/common/grid'
 import legendStyles from './legend.module.scss'
 
-const Legend = ({ mapLayer, setLayer }) => (
+const Legend = ({ mapLayer, setLayer, date }) => (
   <Container>
     <Row className={legendStyles.wrapper}>
       <Col width={[4, 6, 6]}>
@@ -31,6 +33,15 @@ const Legend = ({ mapLayer, setLayer }) => (
             ICU patients
           </button>
         </div>
+        <p className={legendStyles.dates}>
+          Data for <FormatDate date={date} format="LLLL d, yyyy" /> to{' '}
+          <FormatDate
+            date={DateTime.fromISO(date)
+              .plus({ days: 6 })
+              .toISO()}
+            format="LLLL d, yyyy"
+          />
+        </p>
       </Col>
       <Col width={[4, 6, 6]}>
         <div className={legendStyles.legend} aria-hidden>

--- a/src/components/pages/data/hhs-facilities/map/legend.js
+++ b/src/components/pages/data/hhs-facilities/map/legend.js
@@ -8,7 +8,7 @@ import legendStyles from './legend.module.scss'
 const Legend = ({ mapLayer, setLayer, date }) => (
   <Container>
     <Row className={legendStyles.wrapper}>
-      <Col width={[4, 6, 6]}>
+      <Col width={[4, 6, 6]} paddingRight={[0, 0, 0]}>
         <div
           className={legendStyles.toggle}
           role="group"
@@ -43,7 +43,7 @@ const Legend = ({ mapLayer, setLayer, date }) => (
           />
         </p>
       </Col>
-      <Col width={[4, 6, 6]}>
+      <Col width={[4, 6, 6]} paddingLeft={[0, 0, 16]}>
         <div className={legendStyles.legend} aria-hidden>
           <div>
             <div className={legendStyles.label}>

--- a/src/components/pages/data/hhs-facilities/map/legend.module.scss
+++ b/src/components/pages/data/hhs-facilities/map/legend.module.scss
@@ -6,11 +6,13 @@
 }
 
 .legend {
-  @include margin(32, top);
   @include padding(8, top bottom);
   @include type-size(100);
   display: flex;
   justify-content: flex-end;
+  @media (min-width: $viewport-md) {
+    @include margin(32, top);
+  }
   > div {
     flex-wrap: wrap;
   }

--- a/src/components/pages/data/hhs-facilities/map/legend.module.scss
+++ b/src/components/pages/data/hhs-facilities/map/legend.module.scss
@@ -7,7 +7,7 @@
 
 .legend {
   @include margin(32, top);
-  @include padding(8);
+  @include padding(8, top bottom);
   @include type-size(100);
   display: flex;
   justify-content: flex-end;
@@ -20,6 +20,7 @@
   }
   .scale {
     display: flex;
+    flex-wrap: wrap;
     @include margin(8, bottom);
     > div {
       width: 60px;

--- a/src/components/pages/data/hhs-facilities/map/legend.module.scss
+++ b/src/components/pages/data/hhs-facilities/map/legend.module.scss
@@ -61,9 +61,14 @@
   }
 }
 
+.dates {
+  @include type-size(100);
+  @include margin(8, bottom top);
+}
+
 .toggle {
   cursor: pointer;
-  @include margin(16, bottom);
+  @include margin(8, bottom);
   display: flex;
   width: fit-content;
   button {

--- a/src/pages/data/hospital-facilities/index.js
+++ b/src/pages/data/hospital-facilities/index.js
@@ -23,7 +23,7 @@ const HHSHospitalization = ({ data }) => {
 
   return (
     <Layout
-      title="Hospital facilities"
+      title="Hospital Facilities"
       returnLinks={[{ link: '/data' }]}
       path="/data/hospital-facilities"
       showWarning


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds an indicator of date range to the HHS map