### PR TITLE
feat: Switch off CSS hashing in development

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -87,9 +87,12 @@ const gatsbyConfig = {
       resolve: 'gatsby-plugin-sass',
       options: {
         data: sassImports,
-        cssLoaderOptions: {
-          localIdentName: '[sha1:hash:hex:5]',
-        },
+        cssLoaderOptions:
+          process.env.NODE_ENV === 'production'
+            ? {
+                localIdentName: '[sha1:hash:hex:5]',
+              }
+            : {},
       },
     },
     {


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Turns off CSS hashing in development