### PR TITLE
HHS map: Hide date range if missing

### DIFF
--- a/src/components/pages/data/hhs-facilities/map/legend.js
+++ b/src/components/pages/data/hhs-facilities/map/legend.js
@@ -36,8 +36,7 @@ const Legend = ({ mapLayer, setLayer, date }) => (
         <p className={legendStyles.dates}>
           {date ? (
             <>
-              Data for
-              <FormatDate date={date} format="LLLL d, yyyy" /> to{' '}
+              Data for <FormatDate date={date} format="LLLL d, yyyy" /> to{' '}
               <FormatDate
                 date={DateTime.fromISO(date)
                   .plus({ days: 6 })

--- a/src/components/pages/data/hhs-facilities/map/legend.js
+++ b/src/components/pages/data/hhs-facilities/map/legend.js
@@ -33,15 +33,17 @@ const Legend = ({ mapLayer, setLayer, date }) => (
             ICU patients
           </button>
         </div>
-        <p className={legendStyles.dates}>
-          Data for <FormatDate date={date} format="LLLL d, yyyy" /> to{' '}
-          <FormatDate
-            date={DateTime.fromISO(date)
-              .plus({ days: 6 })
-              .toISO()}
-            format="LLLL d, yyyy"
-          />
-        </p>
+        {date && (
+          <p className={legendStyles.dates}>
+            Data for <FormatDate date={date} format="LLLL d, yyyy" /> to{' '}
+            <FormatDate
+              date={DateTime.fromISO(date)
+                .plus({ days: 6 })
+                .toISO()}
+              format="LLLL d, yyyy"
+            />
+          </p>
+        )}
       </Col>
       <Col width={[4, 6, 6]} paddingLeft={[0, 0, 16]}>
         <div className={legendStyles.legend} aria-hidden>

--- a/src/components/pages/data/hhs-facilities/map/legend.js
+++ b/src/components/pages/data/hhs-facilities/map/legend.js
@@ -33,17 +33,22 @@ const Legend = ({ mapLayer, setLayer, date }) => (
             ICU patients
           </button>
         </div>
-        {date && (
-          <p className={legendStyles.dates}>
-            Data for <FormatDate date={date} format="LLLL d, yyyy" /> to{' '}
-            <FormatDate
-              date={DateTime.fromISO(date)
-                .plus({ days: 6 })
-                .toISO()}
-              format="LLLL d, yyyy"
-            />
-          </p>
-        )}
+        <p className={legendStyles.dates}>
+          {date ? (
+            <>
+              Data for
+              <FormatDate date={date} format="LLLL d, yyyy" /> to{' '}
+              <FormatDate
+                date={DateTime.fromISO(date)
+                  .plus({ days: 6 })
+                  .toISO()}
+                format="LLLL d, yyyy"
+              />
+            </>
+          ) : (
+            <>&nbsp;</>
+          )}
+        </p>
       </Col>
       <Col width={[4, 6, 6]} paddingLeft={[0, 0, 16]}>
         <div className={legendStyles.legend} aria-hidden>


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Remove date range in map until the date is inferred