### PR TITLE
chore: Add page descriptions to dynamic pages

### DIFF
--- a/src/components/utils/seo.js
+++ b/src/components/utils/seo.js
@@ -18,7 +18,7 @@ const getImageSrc = (socialCard, defaultSocialCard) => {
   return socialCard.image.resize.src
 }
 
-function SEO({ lang, meta, title, socialCard }) {
+function SEO({ lang, meta, title, socialCard, description }) {
   const { site, contentfulSocialCard } = useStaticQuery(
     graphql`
       query {
@@ -45,15 +45,15 @@ function SEO({ lang, meta, title, socialCard }) {
   const defaultSocialCard = contentfulSocialCard
 
   const imageSrc = getImageSrc(socialCard, defaultSocialCard)
-  let description
-
-  if (!socialCard || typeof socialCard === 'string') {
-    description = defaultSocialCard.description.description
-  } else if (socialCard.description && !socialCard.image) {
-    description = socialCard.description.description
-  } else {
-    description = socialCard.description.description
-  }
+  const pageDescription = (() => {
+    if (description) {
+      return description
+    }
+    if (socialCard && typeof socialCard !== 'string') {
+      return socialCard.description.description
+    }
+    return defaultSocialCard.description.description
+  })()
 
   const urlSchema = 'https:'
 
@@ -90,7 +90,7 @@ function SEO({ lang, meta, title, socialCard }) {
             },
             {
               property: `og:description`,
-              content: description || site.siteMetadata.description,
+              content: pageDescription || site.siteMetadata.description,
             },
             {
               name: `twitter:title`,
@@ -115,7 +115,7 @@ function SEO({ lang, meta, title, socialCard }) {
             },
             {
               name: 'description',
-              content: description || site.siteMetadata.description,
+              content: pageDescription || site.siteMetadata.description,
             },
           ].concat(meta)}
         />

--- a/src/pages/about-data/data-definitions.js
+++ b/src/pages/about-data/data-definitions.js
@@ -17,7 +17,11 @@ const DataDefintionsPage = ({ data }) => {
   ]
   const { nodes } = data.allContentfulDataDefinition
   return (
-    <Layout title="Data Definitions" centered>
+    <Layout
+      title="Data Definitions"
+      description="COVID-19 data definitions change frequently across the 56 jurisdictions we track, so we must sometimes update our data definitions to reflect the realities we find in the data."
+      centered
+    >
       <LongContent>
         <ContentfulContent
           content={

--- a/src/pages/about-data/total-tests.js
+++ b/src/pages/about-data/total-tests.js
@@ -34,6 +34,7 @@ const DataStateTotalTestsPage = ({ data }) => {
     <Layout
       title="How We Report Total Tests"
       path="/about-data/total-tests"
+      description="The 56 US states and territories we track report their total test results in three main ways: by specimens tested, by people tested, and by “test encounters,” a unit which usually counts unique people tested per day."
       returnLinks={[{ link: '/about-data' }]}
     >
       <Container centered>

--- a/src/pages/about-data/visualization-guide.js
+++ b/src/pages/about-data/visualization-guide.js
@@ -4,7 +4,11 @@ import VisualizationGuide from '~components/pages/about-data/visualization-guide
 
 const VisualizationGuidePage = () => {
   return (
-    <Layout title="Visualization Guide" path="/about-data/visualization-guide">
+    <Layout
+      title="Visualization Guide"
+      description="Explore graphics made with the COVID Tracking Project dataset along with tips to help you present the data in the clearest and most accurate way possible."
+      path="/about-data/visualization-guide"
+    >
       <VisualizationGuide />
     </Layout>
   )

--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -7,7 +7,11 @@ import Layout from '~components/layout'
 import VolunteersList from '~components/pages/about/volunteers-list'
 
 const AboutPage = ({ data }) => (
-  <Layout title="About Us" path="/about">
+  <Layout
+    title="About Us"
+    description="The COVID Tracking Project is a volunteer organization launched from The Atlantic and dedicated to collecting and publishing the data required to understand the COVID-19 outbreak in the United States."
+    path="/about"
+  >
     <LongContent>
       <Container centered>
         <ContentfulContent

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -17,14 +17,10 @@ const DataPage = ({ data }) => {
   data.allCovidStateInfo.nodes.forEach(node => {
     stateNavList.push(node)
   })
-  const pageDescription = 'Our most up-to-date data on COVID-19 in the US.'
   return (
     <Layout
       title="The Data"
-      description={pageDescription}
-      socialCard={{
-        description: pageDescription,
-      }}
+      description="Our most up-to-date data on COVID-19 in the US."
       path="/data"
       showWarning
     >

--- a/src/pages/data/long-term-care/index.js
+++ b/src/pages/data/long-term-care/index.js
@@ -29,7 +29,11 @@ const LongTermCarePage = ({ data }) => {
   }
 
   return (
-    <Layout title="The Long-Term Care COVID Tracker" path="/data/longtermcare">
+    <Layout
+      title="The Long-Term Care COVID Tracker"
+      path="/data/longtermcare"
+      description="To date, the Long-Term Care COVID Tracker is the most comprehensive dataset about COVID-19 in US long-term care facilities."
+    >
       <Paragraph>
         <span
           dangerouslySetInnerHTML={{

--- a/src/pages/data/national/cases.js
+++ b/src/pages/data/national/cases.js
@@ -11,6 +11,7 @@ const NationalDataCasesPage = ({ data }) => {
       returnLinkTitle="Our Data"
       returnLink="/data"
       path="/data/national/cases"
+      description="Numbers of new and cumulative cases for the US for each day from January 2020 to the present."
       returnLinks={[
         { link: '/data' },
         { link: `/data/national`, title: 'Totals for the US' },

--- a/src/pages/data/national/deaths.js
+++ b/src/pages/data/national/deaths.js
@@ -11,6 +11,7 @@ const NationalDataDeathsPage = ({ data }) => {
       returnLinkTitle="Our Data"
       returnLink="/data"
       path="/data/national/deaths"
+      description="COVID deaths numbers in the US for each day from January 2020 to the present."
       returnLinks={[
         { link: '/data' },
         { link: `/data/national`, title: 'Totals for the US' },

--- a/src/pages/data/national/hospitalization.js
+++ b/src/pages/data/national/hospitalization.js
@@ -11,6 +11,7 @@ const NationalDataHospitalizationPage = ({ data }) => {
       returnLinkTitle="Our Data"
       returnLink="/data"
       path="/data/national/hospitalization"
+      description="Currently hospitalized, ICU, and ventilator numbers in the US for each day from January 2020 to the present."
       returnLinks={[
         { link: '/data' },
         { link: `/data/national`, title: 'Totals for the US' },

--- a/src/pages/data/national/index.js
+++ b/src/pages/data/national/index.js
@@ -14,9 +14,7 @@ const NationalDataPage = ({ data }) => (
     title="US Historical Data"
     path="/data/us-daily"
     returnLinks={[{ link: '/data' }]}
-    socialCard={{
-      description: 'Cumulative record of our daily totals.',
-    }}
+    description="Daily totals for all metrics collected from January 2020 to the present."
   >
     <ContentfulContent
       content={

--- a/src/pages/data/national/tests.js
+++ b/src/pages/data/national/tests.js
@@ -10,6 +10,7 @@ const NationalDataTestPage = ({ data }) => (
     returnLinkTitle="Our Data"
     returnLink="/data"
     path="/data/national/tests"
+    description="Numbers of PCR tests, negative results, and cases in the US for each day from January 2020 to the present."
     returnLinks={[
       { link: '/data' },
       { link: `/data/national`, title: 'Totals for the US' },

--- a/src/templates/state/cases.js
+++ b/src/templates/state/cases.js
@@ -30,6 +30,7 @@ const StateCasesTemplate = ({ pageContext, path, data }) => {
         { link: '/data' },
         { link: `/data/state/${slug}`, title: state.name },
       ]}
+      description={`Data definitions and historical time series of data on confirmed cases, probable cases, total cases, and daily new cases in ${state.name}.`}
       path={path}
       showWarning
     >

--- a/src/templates/state/hospitalization.js
+++ b/src/templates/state/hospitalization.js
@@ -31,6 +31,7 @@ const StateHospitalizationTemplate = ({ pageContext, path, data }) => {
         { link: `/data/state/${slug}`, title: state.name },
       ]}
       path={path}
+      description={`Data definitions and historical time series of data on patients now or ever hospitalized, in ICU, or on ventilator in ${state.name}.`}
       showWarning
     >
       <AnnotationPanelContext.Provider

--- a/src/templates/state/index.js
+++ b/src/templates/state/index.js
@@ -39,6 +39,7 @@ const StateTemplate = ({ pageContext, data, path }) => {
       title={state.name}
       returnLinks={[{ link: '/data' }]}
       path={path}
+      description={`Cases, testing, hospitalization, outcomes, long-term-care, and race and ethnicity data for ${state.name}, plus data sources, notes, and grade.`}
       showWarning
     >
       <StatePreamble state={state} urls={urls} covidState={covidState} />

--- a/src/templates/state/long-term-care/index.js
+++ b/src/templates/state/long-term-care/index.js
@@ -19,6 +19,7 @@ export default ({ pageContext, path, data }) => {
         { link: '/data' },
         { link: `/data/state/${slug}`, title: state.name },
       ]}
+      description={`Cumulative and outbreak data on cases and deaths in nursing homes, assisted living, and other long-term-care facilities in ${state.name}.`}
       path={path}
     >
       {data.aggregate.nodes.length ? (

--- a/src/templates/state/outcomes.js
+++ b/src/templates/state/outcomes.js
@@ -31,6 +31,7 @@ const StateOutcomesTemplate = ({ pageContext, path, data }) => {
         { link: `/data/state/${slug}`, title: state.name },
       ]}
       path={path}
+      description={`Data definitions and historical time series of data on recovered cases and probable, confirmed, total, and daily new deaths in ${state.name}.`}
       showWarning
     >
       <AnnotationPanelContext.Provider

--- a/src/templates/state/tests-antibody.js
+++ b/src/templates/state/tests-antibody.js
@@ -16,6 +16,7 @@ const StateTestAntibodiesTemplate = ({ pageContext, path, data }) => {
         { link: `/data/state/${slug}`, title: state.name },
       ]}
       path={path}
+      description={`Data definitions and time series of data on total, positive, and negative antibody tests in units of specimens or people for ${state.name}.`}
       showWarning
     >
       <Definitions

--- a/src/templates/state/tests-viral.js
+++ b/src/templates/state/tests-viral.js
@@ -44,6 +44,7 @@ const StateTestViralTemplate = ({ pageContext, path, data }) => {
         { link: '/data', title: 'Our Data' },
         { link: `/data/state/${slug}`, title: state.name },
       ]}
+      description={`Data definitions and historical time series of data on total and positive viral (PCR) tests in units of specimens or people for ${state.name}.`}
       path={path}
       showWarning
     >


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
