### PR TITLE
feat: Tweak UX/UI of API, data sections

### DIFF
--- a/src/__tests__/components/common/__snapshots__/last-updated.js.snap
+++ b/src/__tests__/components/common/__snapshots__/last-updated.js.snap
@@ -13,7 +13,7 @@ Array [
   <p
     className="lastUpdated"
   >
-    State’s dataset was last updated at
+    State’s dataset was last updated 
      
     Aug 18 2020
      

--- a/src/__tests__/components/common/__snapshots__/volunteers-list.js.snap
+++ b/src/__tests__/components/common/__snapshots__/volunteers-list.js.snap
@@ -13,6 +13,8 @@ Array [
     <li>
       <a
         href="https://example.com"
+        rel="noreferrer"
+        target="_blank"
       >
         Test With Website
       </a>
@@ -20,6 +22,8 @@ Array [
     <li>
       <a
         href="http://example.com"
+        rel="noreferrer"
+        target="_blank"
       >
         Test With Website Without Protocol
       </a>

--- a/src/__tests__/components/layout/__snapshots__/data-warning.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/data-warning.js.snap
@@ -10,6 +10,13 @@ exports[`Components : Layout : Data warning is displayed if there is content 1`]
     <div
       className="full"
     >
+      <button
+        aria-label="Hide this warning"
+        onClick={[Function]}
+        type="button"
+      >
+        ×
+      </button>
       <p
         dangerouslySetInnerHTML={
           Object {

--- a/src/__tests__/components/layout/__snapshots__/footer.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/footer.js.snap
@@ -23,9 +23,7 @@ exports[`Components : Layout : Footer renders correctly 1`] = `
       <div
         className="links"
       >
-        <ul
-          className="footerList"
-        >
+        <ul>
           <li>
             <a
               href="/contact"

--- a/src/__tests__/components/layout/__snapshots__/footer.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/footer.js.snap
@@ -109,6 +109,9 @@ exports[`Components : Layout : Footer renders correctly 1`] = `
   <div
     className="copyright"
   >
+    <p>
+      The COVID Tracking Project collects and publishes the most complete data about COVID-19 in the US.
+    </p>
     <span>
       CovidTracking.com Copyright © 
       2021

--- a/src/__tests__/components/layout/__snapshots__/index.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/index.js.snap
@@ -527,9 +527,7 @@ Array [
         <div
           className="links"
         >
-          <ul
-            className="footerList"
-          >
+          <ul>
             <li>
               <a
                 href="/contact"
@@ -1171,9 +1169,7 @@ Array [
         <div
           className="links"
         >
-          <ul
-            className="footerList"
-          >
+          <ul>
             <li>
               <a
                 href="/contact"

--- a/src/__tests__/components/layout/__snapshots__/index.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/index.js.snap
@@ -613,6 +613,9 @@ Array [
     <div
       className="copyright"
     >
+      <p>
+        The COVID Tracking Project collects and publishes the most complete data about COVID-19 in the US.
+      </p>
       <span>
         CovidTracking.com Copyright © 
         2021
@@ -1254,6 +1257,9 @@ Array [
     <div
       className="copyright"
     >
+      <p>
+        The COVID Tracking Project collects and publishes the most complete data about COVID-19 in the US.
+      </p>
       <span>
         CovidTracking.com Copyright © 
         2021

--- a/src/__tests__/components/pages/race/__snapshots__/cta-links.js.snap
+++ b/src/__tests__/components/pages/race/__snapshots__/cta-links.js.snap
@@ -21,6 +21,8 @@ exports[`Components : Race : CTA Links renders correctly 1`] = `
     className="cta centered"
     href="https://docs.google.com/spreadsheets/d/e/2PACX-1vS8SzaERcKJOD_EzrtCDK1dX1zkoMochlA9iHoHg_RSw3V8bkpfk1mpw4pfL5RdtSOyx_oScsUtyXyk/pub?gid=43720681&single=true&output=csv"
     onClick={[Function]}
+    rel="noreferrer"
+    target={false}
   >
     Get the complete dataset (CSV)
     <span

--- a/src/components/common/landing-page/call-to-action.js
+++ b/src/components/common/landing-page/call-to-action.js
@@ -10,6 +10,18 @@ const Arrow = () => (
   </span>
 )
 
+const NewWindow = () => (
+  <>
+    <span className="a11y-only">(Opens a new window)</span>
+    <span
+      className={classnames(ctaLinkStyle.newWindow, ctaLinkStyle.arrow)}
+      aria-hidden
+    >
+      {' '}
+    </span>
+  </>
+)
+
 const CtaLink = ({
   to,
   children,
@@ -38,6 +50,7 @@ const CtaAnchorLink = ({
   centered = false,
   block = false,
   bold = false,
+  newWindow = false,
 }) => (
   <a
     href={href}
@@ -47,10 +60,12 @@ const CtaAnchorLink = ({
       bold && ctaLinkStyle.bold,
       block && ctaLinkStyle.block,
     )}
+    target={newWindow && '_blank'}
+    rel="noreferrer"
     onClick={onClick}
   >
     {children}
-    <Arrow />
+    {newWindow ? <NewWindow /> : <Arrow />}
   </a>
 )
 

--- a/src/components/common/landing-page/call-to-action.module.scss
+++ b/src/components/common/landing-page/call-to-action.module.scss
@@ -8,6 +8,9 @@
   &:hover {
     @include link-hover;
   }
+  .new-window::after {
+    content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 20 20'%3E%3Cpath d='M17 17H3V3h5V1H3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-5h-2z' fill='%23924f34'/%3E%3Cpath d='M19 1h-8l3.29 3.29-5.73 5.73 1.42 1.42 5.73-5.73L19 9V1z' fill='%23924f34'/%3E%3C/svg%3E%0A");
+  }
 }
 
 .centered {

--- a/src/components/common/landing-page/call-to-action.module.scss
+++ b/src/components/common/landing-page/call-to-action.module.scss
@@ -9,7 +9,7 @@
     @include link-hover;
   }
   .new-window::after {
-    content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 20 20'%3E%3Cpath d='M17 17H3V3h5V1H3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-5h-2z' fill='%23924f34'/%3E%3Cpath d='M19 1h-8l3.29 3.29-5.73 5.73 1.42 1.42 5.73-5.73L19 9V1z' fill='%23924f34'/%3E%3C/svg%3E%0A");
+    @include new-window-icon($color-honey-700);
   }
 }
 

--- a/src/components/common/last-updated.js
+++ b/src/components/common/last-updated.js
@@ -11,7 +11,7 @@ const LastUpdated = ({ date, national }) => (
       national && lastUpdatedStyle.national,
     )}
   >
-    {national ? <>Data for</> : <>State’s dataset was last updated at</>} {date}{' '}
+    {national ? <>Data for</> : <>State’s dataset was last updated </>} {date}{' '}
     {!national && <Timezone />}
   </p>
 )

--- a/src/components/common/radio-toggle.module.scss
+++ b/src/components/common/radio-toggle.module.scss
@@ -28,6 +28,7 @@
   width: fit-content;
   button {
     @extend %toggle-inactive;
+    cursor: pointer;
     @include type-size(100);
     margin: -1px; // ignore-style-rule
     padding: 2px 15px; // ignore-style-rule

--- a/src/components/common/table-of-contents.js
+++ b/src/components/common/table-of-contents.js
@@ -14,4 +14,8 @@ const TableOfContents = ({ headings }) => (
   </div>
 )
 
+export const TableOfContentsWrapper = ({ children }) => (
+  <div className={tocStyle.tableOfContents}>{children}</div>
+)
+
 export default TableOfContents

--- a/src/components/common/table-of-contents.module.scss
+++ b/src/components/common/table-of-contents.module.scss
@@ -4,6 +4,7 @@
   background: $color-plum-100;
   h2 {
     margin: 0;
+    @include type-size(400);
   }
   ul {
     list-style-type: none;

--- a/src/components/layout/footer.js
+++ b/src/components/layout/footer.js
@@ -8,7 +8,7 @@ import githubLogo from '~images/footer/github-logo.svg'
 import twitterLogo from '~images/footer/twitter-logo.svg'
 import upArrow from '~images/footer/up-arrow.svg'
 
-const Footer = ({ noMargin = false }) => (
+const Footer = ({ noMargin = false, hideAbout = false }) => (
   <footer
     className={classnames(
       footerStyles.wrapper,
@@ -67,6 +67,12 @@ const Footer = ({ noMargin = false }) => (
     </div>
     <hr className={footerStyles.divider} />
     <div className={footerStyles.copyright}>
+      {!hideAbout && (
+        <p>
+          The COVID Tracking Project collects and publishes the most complete
+          data about COVID-19 in the US.
+        </p>
+      )}
       <span>
         CovidTracking.com Copyright &copy; {new Date().getFullYear()} by The
         Atlantic Monthly Group. <Link to="/license">(CC BY 4.0)</Link>

--- a/src/components/layout/footer.js
+++ b/src/components/layout/footer.js
@@ -25,7 +25,7 @@ const Footer = ({ noMargin = false, hideAbout = false }) => (
           />
         </Link>
         <div className={footerStyles.links}>
-          <ul className={footerStyles.footerList}>
+          <ul>
             <li>
               <Link to="/contact">Contact</Link>
             </li>

--- a/src/components/layout/footer.module.scss
+++ b/src/components/layout/footer.module.scss
@@ -79,6 +79,16 @@
         grid-template-columns: 1fr;
         grid-template-rows: repeat(7, 1fr);
       }
+      a {
+        min-height: 44px;
+        display: flex;
+        align-items: center;
+        @media (min-width: $viewport-md) {
+          display: block;
+          align-items: inherit;
+          min-height: auto;
+        }
+      }
     }
 
     @media (max-width: $viewport-lg) {

--- a/src/components/layout/footer.module.scss
+++ b/src/components/layout/footer.module.scss
@@ -14,9 +14,8 @@
   width: 71.25rem;
   max-width: calc(100vw - 4rem);
   margin: 0 auto;
-
-  a,
-  span {
+  color: white;
+  a {
     color: white;
   }
 
@@ -120,6 +119,10 @@ hr.divider {
 
   justify-content: space-between;
   align-items: center;
+
+  p {
+    @include padding(8, left);
+  }
 
   span {
     @include col(3 5 10);

--- a/src/components/layout/header/data-warning.js
+++ b/src/components/layout/header/data-warning.js
@@ -1,10 +1,13 @@
-import React from 'react'
+/* eslint-disable */
+import React, { useState, useEffect } from 'react'
 import { useStaticQuery, graphql } from 'gatsby'
 import marked from 'marked'
 import Container from '~components/common/container'
 import dataWarningStyle from './data-warning.module.scss'
 
 const DataWarning = () => {
+  const [isHidden, setIsHidden] = useState(false)
+
   const data = useStaticQuery(graphql`
     {
       contentfulSnippet(slug: { eq: "data-warning" }) {
@@ -25,20 +28,47 @@ const DataWarning = () => {
   ) {
     return null
   }
+
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return
+    }
+    if (document.cookie && document.cookie.search('ctp_warning') > -1) {
+      setIsHidden(true)
+    }
+  }, [])
+
   return (
-    <div className={dataWarningStyle.warning}>
-      <Container>
-        <p
-          role="alert"
-          dangerouslySetInnerHTML={{
-            __html: marked.inlineLexer(
-              data.contentfulSnippet.content.content,
-              [],
-            ),
-          }}
-        />
-      </Container>
-    </div>
+    <>
+      {!isHidden && (
+        <div className={dataWarningStyle.warning}>
+          <Container>
+            <button
+              aria-label="Hide this warning"
+              type="button"
+              onClick={event => {
+                event.preventDefault()
+                setIsHidden(false)
+                const date = new Date()
+                date.setTime(date.getTime() + 10 * 24 * 60 * 60 * 1000)
+                document.cookie = `ctp_warning=1; expires=${date.toISOString()}; path=/`
+              }}
+            >
+              &times;
+            </button>
+            <p
+              role="alert"
+              dangerouslySetInnerHTML={{
+                __html: marked.inlineLexer(
+                  data.contentfulSnippet.content.content,
+                  [],
+                ),
+              }}
+            />
+          </Container>
+        </div>
+      )}
+    </>
   )
 }
 

--- a/src/components/layout/header/data-warning.js
+++ b/src/components/layout/header/data-warning.js
@@ -48,7 +48,7 @@ const DataWarning = () => {
               type="button"
               onClick={event => {
                 event.preventDefault()
-                setIsHidden(false)
+                setIsHidden(true)
                 const date = new Date()
                 date.setTime(date.getTime() + 10 * 24 * 60 * 60 * 1000)
                 document.cookie = `ctp_warning=1; expires=${date.toISOString()}; path=/`

--- a/src/components/layout/header/data-warning.module.scss
+++ b/src/components/layout/header/data-warning.module.scss
@@ -7,4 +7,11 @@
   a {
     color: black;
   }
+  button {
+    @include remove-button-style();
+    display: block;
+    float: right;
+    @include type-size(400);
+    @include margin(32, left);
+  }
 }

--- a/src/components/layout/header/index.js
+++ b/src/components/layout/header/index.js
@@ -134,6 +134,7 @@ const Header = withSearch(
     return (
       <>
         <DevelopmentWarning />
+        {showWarning && <DataWarning />}
         <header
           className={classnames(
             'site-header',
@@ -251,7 +252,6 @@ const Header = withSearch(
               {hero}
             </Container>
           </div>
-          {showWarning && <DataWarning />}
         </header>
       </>
     )

--- a/src/components/layout/header/mobile-menu.module.scss
+++ b/src/components/layout/header/mobile-menu.module.scss
@@ -25,6 +25,16 @@
   nav {
     display: block;
     @include margin(16, top);
+    a {
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+    }
+    [data-reach-menu] {
+      a {
+        display: flex;
+      }
+    }
     li {
       line-height: toRem(40);
       @media (hover: none) {

--- a/src/components/layout/header/sub-navigation.module.scss
+++ b/src/components/layout/header/sub-navigation.module.scss
@@ -48,12 +48,17 @@
       font-weight: bold;
       @include type-size(200);
       color: white;
-
-      display: block;
       margin: 0 0.6rem 0 0; // ignore-style-rule
       padding: 0.4rem 0 0.2rem; // ignore-style-rule
       border-bottom: 3px solid transparent;
-
+      min-height: 44px;
+      display: flex;
+      align-items: center;
+      @media (min-width: $viewport-md) {
+        display: block;
+        align-items: inherit;
+        min-height: auto;
+      }
       &:focus {
         @include link-focus-dark-bg;
       }

--- a/src/components/pages/about/supporters.js
+++ b/src/components/pages/about/supporters.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import { useStaticQuery, graphql } from 'gatsby'
+import { Row, Col } from '~components/common/grid'
+import supportersStyle from './supporters.module.scss'
+
+const Supporters = () => {
+  const data = useStaticQuery(graphql`
+    {
+      allContentfulSupporterOrPartner(sort: { fields: order }) {
+        nodes {
+          name
+          logo {
+            fixed(width: 500) {
+              src
+              srcSet
+            }
+          }
+          link
+        }
+      }
+    }
+  `)
+  const { nodes } = data.allContentfulSupporterOrPartner
+  return (
+    <Row>
+      {nodes.map((partner, index) => (
+        <Col
+          width={[6, 3, 6]}
+          paddingRight={index % 2 ? [0, 0, 0] : [0, 32, 32]}
+          paddingLeft={index % 2 ? [0, 32, 32] : [0, 0, 0]}
+        >
+          <a
+            href={partner.link}
+            target="_blank"
+            rel="noreferrer"
+            className={supportersStyle.logo}
+          >
+            <img
+              src={partner.logo.fixed.src}
+              alt={partner.name}
+              srcSet={partner.logo.fixed.srcSet}
+            />
+          </a>
+        </Col>
+      ))}
+    </Row>
+  )
+}
+
+export default Supporters

--- a/src/components/pages/about/supporters.module.scss
+++ b/src/components/pages/about/supporters.module.scss
@@ -1,0 +1,4 @@
+.logo {
+  @include margin(64, bottom);
+  display: block;
+}

--- a/src/components/pages/about/volunteers-list.js
+++ b/src/components/pages/about/volunteers-list.js
@@ -16,7 +16,13 @@ const VolunteersList = ({ items }) => (
       {items.map(({ node }) => (
         <li key={`volunteer-${node.name}`}>
           {node.website ? (
-            <a href={fixWebsitePrefix(node.website)}>{node.name}</a>
+            <a
+              href={fixWebsitePrefix(node.website)}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {node.name}
+            </a>
           ) : (
             <span>{node.name}</span>
           )}

--- a/src/components/pages/data/api/change-log.js
+++ b/src/components/pages/data/api/change-log.js
@@ -1,41 +1,31 @@
-import React, { useEffect } from 'react'
-import Helmet from 'react-helmet'
+import React from 'react'
+import changeLogStyle from './change-log.module.scss'
 
-const ChangeLog = () => {
-  useEffect(() => {
-    if (typeof window === 'undefined') {
-      return
-    }
-    const script = document.createElement('script')
-    script.async = true
-    script.src = 'https://cdn.headwayapp.co/widget.js'
-    document.head.appendChild(script)
-    script.onload = () => {
-      window.Headway.init({
-        selector: '#headway-widget',
-        account: '7KMWgy',
-      })
-    }
-  }, [])
-
-  return (
-    <>
-      <Helmet>
-        <style>
-          {`#HW_badge_cont {
-          display: inline-block;
-          margin-bottom: -0.5rem;
-        }`}
-        </style>
-      </Helmet>
-      <p>
-        <strong>
-          <a href="https://apichanges.covidtracking.com/">Latest API changes</a>
-        </strong>
-        <span id="headway-widget" />
-      </p>
-    </>
-  )
-}
+const ChangeLog = () => (
+  <>
+    <div className={changeLogStyle.changeLog}>
+      <ul>
+        <li>
+          <a
+            href="https://apichanges.covidtracking.com/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Latest API changes<span aria-hidden>→</span>
+          </a>
+        </li>
+        <li>
+          <a
+            href="https://covidtrackingproject.statuspage.io/"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Status page<span aria-hidden>→</span>
+          </a>
+        </li>
+      </ul>
+    </div>
+  </>
+)
 
 export default ChangeLog

--- a/src/components/pages/data/api/change-log.js
+++ b/src/components/pages/data/api/change-log.js
@@ -11,7 +11,8 @@ const ChangeLog = () => (
             target="_blank"
             rel="noreferrer"
           >
-            Latest API changes<span aria-hidden>→</span>
+            Latest API changes
+            <span aria-hidden />
           </a>
         </li>
         <li>
@@ -20,7 +21,8 @@ const ChangeLog = () => (
             target="_blank"
             rel="noreferrer"
           >
-            Status page<span aria-hidden>→</span>
+            Status page
+            <span aria-hidden />
           </a>
         </li>
       </ul>

--- a/src/components/pages/data/api/change-log.module.scss
+++ b/src/components/pages/data/api/change-log.module.scss
@@ -15,9 +15,10 @@
       @include margin(16, bottom);
     }
   }
-  [aria-hidden] {
+  [aria-hidden]::after {
     text-decoration: none;
     display: inline-block;
     @include margin(4, left);
+    @include new-window-icon();
   }
 }

--- a/src/components/pages/data/api/change-log.module.scss
+++ b/src/components/pages/data/api/change-log.module.scss
@@ -1,0 +1,23 @@
+.change-log {
+  @include padding(32);
+  background: $color-plum-100;
+  @include margin(32, bottom);
+  @media (min-width: $viewport-md) {
+    width: 300px;
+    float: right;
+    @include margin(32, left);
+  }
+  ul {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+    li:first-child {
+      @include margin(16, bottom);
+    }
+  }
+  [aria-hidden] {
+    text-decoration: none;
+    display: inline-block;
+    @include margin(4, left);
+  }
+}

--- a/src/components/pages/data/charts/tweet.js
+++ b/src/components/pages/data/charts/tweet.js
@@ -36,15 +36,19 @@ const ChartTweet = () => {
   }
 
   return (
-    <Container centered>
-      <h2> The national picture over time</h2>
-      <a href={`https://twitter.com/COVID19Tracking/status/${id_str}`}>
-        <img
-          src={entities.media[0].media_url.replace(/http(s?):\/\//g, '//')}
-          alt={full_text}
-        />
-      </a>
-    </Container>
+    <>
+      <Container>
+        <h2> The national picture over time</h2>
+      </Container>
+      <Container centered>
+        <a href={`https://twitter.com/COVID19Tracking/status/${id_str}`}>
+          <img
+            src={entities.media[0].media_url.replace(/http(s?):\/\//g, '//')}
+            alt={full_text}
+          />
+        </a>
+      </Container>
+    </>
   )
 }
 export default ChartTweet

--- a/src/components/pages/data/daily-tweet.js
+++ b/src/components/pages/data/daily-tweet.js
@@ -39,7 +39,7 @@ const DailyTweet = () => {
         setZone: true,
       })
         .setZone('America/New_York')
-        .toFormat('LLLL d yyyy')}
+        .toFormat('LLLL d, yyyy')}
     />
   )
 }

--- a/src/components/pages/data/summary-charts.js
+++ b/src/components/pages/data/summary-charts.js
@@ -305,13 +305,13 @@ const SummaryCharts = ({
         <div className={styles.toggleContainer}>
           {usHistory && (
             <RadioToggle
-              options={['Totals', 'Per 1M people']}
+              options={['Total', 'Per 1M people']}
               state={usePerCap}
               setState={setUsePerCap}
             />
           )}
           <RadioToggle
-            options={['Last 90 days', 'Full range']}
+            options={['Last 90 days', 'Historical']}
             state={useFullRange}
             setState={setUseFullRange}
           />

--- a/src/components/pages/data/summary-charts.js
+++ b/src/components/pages/data/summary-charts.js
@@ -95,16 +95,6 @@ const ChartAlert = ({ message }) => (
   </div>
 )
 
-const CalculatedIndicator = ({ openDisclosure }) => (
-  <a
-    href="#summary-charts"
-    className={styles.calculated}
-    onClick={openDisclosure}
-  >
-    (Calculated)
-  </a>
-)
-
 const AnnotationIndicator = ({ annotations, dataElement, openDisclosure }) => {
   if (
     !annotations ||
@@ -330,9 +320,6 @@ const SummaryCharts = ({
               dataElement="tests"
               openDisclosure={() => setDisclosureOpen(true)}
             />
-            <CalculatedIndicator
-              openDisclosure={() => setDisclosureOpen(true)}
-            />
             <TestFieldIndicator
               field={testSource}
               units={testUnits}
@@ -361,7 +348,6 @@ const SummaryCharts = ({
               dataElement="cases"
               openDisclosure={() => setDisclosureOpen(true)}
             />
-            <CalculatedIndicator />
           </h3>
           {hasData(positiveField) ? (
             <>
@@ -428,7 +414,6 @@ const SummaryCharts = ({
               dataElement="death"
               openDisclosure={() => setDisclosureOpen(true)}
             />
-            <CalculatedIndicator />
           </h3>
           {hasData(deathField) ? (
             <>
@@ -533,7 +518,8 @@ const LegendComponent = ({ name }) => (
         strokeDasharray={!name ? '4' : undefined}
       />
     </svg>
-    {name || 'National'} 7-day average
+    {name ? <>Solid</> : <>Dashed</>} line represents {name || 'National'} 7-day
+    average
   </div>
 )
 

--- a/src/components/pages/data/summary-charts.module.scss
+++ b/src/components/pages/data/summary-charts.module.scss
@@ -2,10 +2,6 @@
 @import '~scss/colors.module.scss';
 
 .info-line {
-  display: flex;
-  @media screen and (max-width: $viewport-md) {
-    flex-direction: column;
-  }
   .toggle-container {
     flex-grow: 1;
     display: flex;
@@ -23,21 +19,8 @@
       flex-grow: initial;
     }
   }
-  .legend-container {
-    display: flex;
-    > * {
-      margin-left: spacer(8);
-    }
-    @media screen and (max-width: $viewport-lg) {
-      flex-direction: column-reverse;
-      flex-grow: initial;
-      > * {
-        margin-left: 0;
-        margin-bottom: spacer(8);
-      }
-    }
-  }
   .legend-component {
+    @include margin(16, top);
     display: flex;
     align-items: center;
   }

--- a/src/components/pages/homepage/blog-featured.js
+++ b/src/components/pages/homepage/blog-featured.js
@@ -15,7 +15,7 @@ const BlogFeatured = () => {
       ) {
         nodes {
           title
-          publishDate(formatString: "MMM D, YYYY")
+          publishDate(formatString: "MMMM D, YYYY")
           homepageImage {
             fixed(width: 800) {
               src

--- a/src/components/pages/homepage/blog-list.js
+++ b/src/components/pages/homepage/blog-list.js
@@ -14,7 +14,7 @@ const BlogFeatured = () => {
         nodes {
           title
           featureOnHomepage
-          publishDate(formatString: "MMM D, YYYY")
+          publishDate(formatString: "MMMM D, YYYY")
           homepageImage {
             fixed(width: 800) {
               src

--- a/src/components/pages/homepage/visualization-gallery/index.js
+++ b/src/components/pages/homepage/visualization-gallery/index.js
@@ -55,7 +55,7 @@ const HomepageGallery = () => {
           relatedPost {
             title
             slug
-            publishDate(formatString: "MMM D, YYYY")
+            publishDate(formatString: "MMMM D, YYYY")
           }
         }
       }

--- a/src/components/pages/state/state-tweets.js
+++ b/src/components/pages/state/state-tweets.js
@@ -40,6 +40,7 @@ const StateTweets = ({ name, stateAbbreviation, tweets }) => {
       ))}
       <CtaAnchorLink
         href={`https://twitter.com/search?q=from%3A%40COVID19Tracking%20${name}&src=typed_query`}
+        newWindow
       >
         More tweets about {name}
       </CtaAnchorLink>

--- a/src/pages/about-data/data-definitions.js
+++ b/src/pages/about-data/data-definitions.js
@@ -4,6 +4,7 @@ import slugify from 'slugify'
 import Layout from '~components/layout'
 import LongContent from '~components/common/long-content'
 import ContentfulContent from '~components/common/contentful-content'
+import { TableOfContentsWrapper } from '~components/common/table-of-contents'
 
 const DataDefintionsPage = ({ data }) => {
   const categories = [
@@ -26,13 +27,18 @@ const DataDefintionsPage = ({ data }) => {
           }
           id={data.preamble.contentful_id}
         />
-        <ul>
-          {categories.map(category => (
-            <li>
-              <a href={`#${slugify(category, { lower: true })}`}>{category}</a>
-            </li>
-          ))}
-        </ul>
+        <TableOfContentsWrapper>
+          <h2>Data categories</h2>
+          <ul>
+            {categories.map(category => (
+              <li>
+                <a href={`#${slugify(category, { lower: true })}`}>
+                  {category}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </TableOfContentsWrapper>
         {categories.map(category => (
           <>
             <h2 id={slugify(category, { lower: true })}>{category}</h2>

--- a/src/pages/about/index.js
+++ b/src/pages/about/index.js
@@ -5,6 +5,7 @@ import ContentfulContent from '~components/common/contentful-content'
 import LongContent from '~components/common/long-content'
 import Layout from '~components/layout'
 import VolunteersList from '~components/pages/about/volunteers-list'
+import Supporters from '~components/pages/about/supporters'
 
 const AboutPage = ({ data }) => (
   <Layout title="About Us" path="/about">
@@ -27,6 +28,7 @@ const AboutPage = ({ data }) => (
           }
           id={data.pastContributors.contentful_id}
         />
+        <Supporters />
       </Container>
     </LongContent>
   </Layout>

--- a/src/pages/about/newsletter.js
+++ b/src/pages/about/newsletter.js
@@ -8,7 +8,7 @@ import ContentfulContent from '~components/common/contentful-content'
 import GetInvolvedForm from '~components/pages/get-involved/form'
 
 const NewsletterPage = ({ data }) => (
-  <Layout title="Sign up for our newsletter" path="/about/newsletter" centered>
+  <Layout title="Newsletter" path="/about/newsletter" centered>
     <LongContent>
       <ContentfulContent
         content={

--- a/src/pages/contact/data.js
+++ b/src/pages/contact/data.js
@@ -17,7 +17,7 @@ const ContactPage = ({ data }) => {
 
   return (
     <Layout
-      title="Contact Us: Data"
+      title="Contact Us About the Data"
       socialCard={{
         description:
           'The COVID Tracking Project runs on the effort and diligence of hundreds of volunteers, and we welcome your contribution.',

--- a/src/pages/contact/other.js
+++ b/src/pages/contact/other.js
@@ -26,7 +26,7 @@ const ContactOtherPage = () => {
 
   return (
     <Layout
-      title="Contact Us: Other questions"
+      title="Contact Us"
       socialCard={{
         description:
           'The COVID Tracking Project runs on the effort and diligence of hundreds of volunteers, and we welcome your contribution.',

--- a/src/pages/contact/success.js
+++ b/src/pages/contact/success.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Layout from '~components/layout'
 
 const ContactSuccessPage = () => (
-  <Layout title="Thank you" centered>
+  <Layout title="Thank You" centered>
     <h2>Thank you for contacting us!</h2>
     <p>
       Thanks for contacting us! Please note that we review and log all feedback,

--- a/src/pages/contact/volunteer.js
+++ b/src/pages/contact/volunteer.js
@@ -6,11 +6,7 @@ import Layout from '~components/layout'
 import VolunteerForm from '~components/pages/contact/volunteer-form'
 
 const ContactVolunteerPage = ({ data }) => (
-  <Layout
-    title="Contact Us &mdash; Volunteering"
-    path="/contact/volunteer"
-    centered
-  >
+  <Layout title="Volunteer" path="/contact/volunteer" centered>
     <LongContent>
       <ContentfulContent
         content={

--- a/src/pages/data/charts.js
+++ b/src/pages/data/charts.js
@@ -9,11 +9,6 @@ import ChartPreamble from '~components/pages/data/charts/preamble'
 
 const ChartsPage = ({ data }) => (
   <Layout title="Charts" returnLinks={[{ link: '/data' }]} showWarning>
-    <h2>United States Overview</h2>
-    <ChartPreamble
-      usHistory={data.allCovidUsDaily.nodes}
-      stateHistory={data.allCovidStateDaily.nodes}
-    />
     <Container centered>
       <ContentfulContent
         content={
@@ -23,7 +18,14 @@ const ChartsPage = ({ data }) => (
         id={data.chartDisclaimer.contentful_id}
       />
     </Container>
+    <h2>United States Overview</h2>
+    <ChartPreamble
+      usHistory={data.allCovidUsDaily.nodes}
+      stateHistory={data.allCovidStateDaily.nodes}
+    />
+
     <ChartTweet />
+    <h2>Our chart gallery</h2>
     <ChartList />
 
     <Container centered>

--- a/src/pages/data/hospital-facilities/search.js
+++ b/src/pages/data/hospital-facilities/search.js
@@ -10,7 +10,7 @@ import HHSFacilitiesSearch from '~components/pages/data/hhs-facilities/search'
 const HHSHospitalizationSearch = ({ data }) => {
   return (
     <Layout
-      title="Hospital facilities"
+      title="Search Hospital Facilities"
       returnLinks={[{ link: '/data' }]}
       path="/data/hospital-facilities"
       noContainer

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -173,7 +173,7 @@ export const query = graphql`
     allCovidState {
       nodes {
         dataQualityGrade
-        dateModified(formatString: "MMM D, YYYY h:mm a")
+        dateModified(formatString: "MMMM D, YYYY h:mm a")
         death
         deathConfirmed
         deathProbable

--- a/src/pages/data/long-term-care/contact.js
+++ b/src/pages/data/long-term-care/contact.js
@@ -5,7 +5,7 @@ import LTCForm from '~components/pages/data/long-term-care/form'
 import ContentfulContent from '~components/common/contentful-content'
 
 const LTCContactPage = ({ data }) => (
-  <Layout title="Long term care: Contact us" centered>
+  <Layout title="Long-Term Care: Contact us" centered>
     <ContentfulContent
       content={
         data.contentfulSnippet.childContentfulSnippetContentTextNode

--- a/src/pages/data/long-term-care/history.js
+++ b/src/pages/data/long-term-care/history.js
@@ -30,7 +30,7 @@ export default ({ path, data }) => {
   })
   return (
     <Layout
-      title="Long-term-care national historic data"
+      title="Long-Term Care National Historic Data"
       returnLinks={[
         { link: '/data' },
         { link: `/data/longtermcare`, title: 'Long-term care' },

--- a/src/pages/data/long-term-care/history.js
+++ b/src/pages/data/long-term-care/history.js
@@ -89,7 +89,7 @@ export const query = graphql`
       filter: { data_type: { eq: "Aggregate" } }
     ) {
       nodes {
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         isoDate: date
         posstaff_other
         posstaff_nh

--- a/src/pages/data/national/cases.js
+++ b/src/pages/data/national/cases.js
@@ -7,7 +7,7 @@ import Layout from '~components/layout'
 const NationalDataCasesPage = ({ data }) => {
   return (
     <Layout
-      title="National data: Cases"
+      title="National Data: Cases"
       returnLinkTitle="Our Data"
       returnLink="/data"
       path="/data/national/cases"

--- a/src/pages/data/national/cases.js
+++ b/src/pages/data/national/cases.js
@@ -47,7 +47,7 @@ export const query = graphql`
   {
     allCovidUsDaily(sort: { fields: date, order: DESC }) {
       nodes {
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         positive
         positiveIncrease
       }

--- a/src/pages/data/national/chart-tables.js
+++ b/src/pages/data/national/chart-tables.js
@@ -59,7 +59,7 @@ const NationalChartTablesPage = ({ data, path }) => {
 
   return (
     <Layout
-      title="National chart data"
+      title="National Chart Data"
       returnLinks={[
         { link: '/data' },
         { link: `/data/national`, title: 'Totals for the US' },

--- a/src/pages/data/national/deaths.js
+++ b/src/pages/data/national/deaths.js
@@ -53,7 +53,7 @@ export const query = graphql`
   {
     allCovidUsDaily(sort: { fields: date, order: DESC }) {
       nodes {
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         death
         deathIncrease
       }

--- a/src/pages/data/national/deaths.js
+++ b/src/pages/data/national/deaths.js
@@ -7,7 +7,7 @@ import Layout from '~components/layout'
 const NationalDataDeathsPage = ({ data }) => {
   return (
     <Layout
-      title="National: Deaths"
+      title="National Data: Deaths"
       returnLinkTitle="Our Data"
       returnLink="/data"
       path="/data/national/deaths"

--- a/src/pages/data/national/hospitalization.js
+++ b/src/pages/data/national/hospitalization.js
@@ -7,7 +7,7 @@ import Layout from '~components/layout'
 const NationalDataHospitalizationPage = ({ data }) => {
   return (
     <Layout
-      title="National: Hospitalization"
+      title="National Data: Hospitalization"
       returnLinkTitle="Our Data"
       returnLink="/data"
       path="/data/national/hospitalization"

--- a/src/pages/data/national/hospitalization.js
+++ b/src/pages/data/national/hospitalization.js
@@ -61,7 +61,7 @@ export const query = graphql`
   {
     allCovidUsDaily(sort: { fields: date, order: DESC }) {
       nodes {
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         hospitalizedCurrently
         inIcuCurrently
         onVentilatorCurrently

--- a/src/pages/data/national/index.js
+++ b/src/pages/data/national/index.js
@@ -11,8 +11,8 @@ const formatNumber = number => <FormatNumber number={number} />
 
 const NationalDataPage = ({ data }) => (
   <Layout
-    title="US Historical Data"
-    path="/data/us-daily"
+    title="Totals for the US"
+    path="/data/national"
     returnLinks={[{ link: '/data' }]}
     socialCard={{
       description: 'Cumulative record of our daily totals.',

--- a/src/pages/data/national/index.js
+++ b/src/pages/data/national/index.js
@@ -76,7 +76,7 @@ export const query = graphql`
     }
     allCovidUsDaily(sort: { order: DESC, fields: date }) {
       nodes {
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         death
 
         hospitalizedCurrently

--- a/src/pages/data/national/tests.js
+++ b/src/pages/data/national/tests.js
@@ -56,7 +56,7 @@ export const query = graphql`
   {
     allCovidUsDaily(sort: { fields: date, order: DESC }) {
       nodes {
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         negative
         negativeIncrease
         positive

--- a/src/pages/data/national/tests.js
+++ b/src/pages/data/national/tests.js
@@ -6,7 +6,7 @@ import Layout from '~components/layout'
 
 const NationalDataTestPage = ({ data }) => (
   <Layout
-    title="National: testing"
+    title="National Data: Testing"
     returnLinkTitle="Our Data"
     returnLink="/data"
     path="/data/national/tests"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -35,7 +35,7 @@ const Homepage = () => (
         <Press />
       </Container>
     </main>
-    <Footer noMargin />
+    <Footer noMargin hideAbout />
   </>
 )
 

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -6,9 +6,9 @@ const SearchPage = () => {
   const [query, setQuery] = useState('')
   const getTitle = () => {
     if (query === '' || query === null) {
-      return 'Search results'
+      return 'Search Results'
     }
-    return `Search results for “${query}”`
+    return `Search Results for “${query}”`
   }
   return (
     <Layout title={getTitle()} centered>

--- a/src/scss/helpers.module.scss
+++ b/src/scss/helpers.module.scss
@@ -1,5 +1,14 @@
 @import './breakpoints.module.scss';
 
+@function encodecolor($string) {
+  @if type-of($string) == 'color' {
+    $hex: str-slice(ie-hex-str($string), 4);
+    $string: unquote('#{$hex}');
+  }
+  $string: '%23' + $string;
+  @return $string;
+}
+
 // Base font size. If need be, can be made responsive.
 $base-font-size: 16;
 
@@ -82,4 +91,9 @@ $spacers: (
   padding: 0;
   background: transparent;
   cursor: pointer;
+}
+
+@mixin new-window-icon($color: #000000) {
+  $image-color: encodecolor($color);
+  content: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 20 20'%3E%3Cpath d='M17 17H3V3h5V1H3a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-5h-2z' fill='#{$image-color}'/%3E%3Cpath d='M19 1h-8l3.29 3.29-5.73 5.73 1.42 1.42 5.73-5.73L19 9V1z' fill='#{$image-color}'/%3E%3C/svg%3E%0A");
 }

--- a/src/templates/state/cases.js
+++ b/src/templates/state/cases.js
@@ -102,7 +102,7 @@ export const query = graphql`
       sort: { fields: date, order: DESC }
     ) {
       nodes {
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         positive
         positiveIncrease
         positiveCasesViral
@@ -114,7 +114,7 @@ export const query = graphql`
       sort: { fields: date, order: DESC }
     ) {
       nodes {
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         childContentfulChartAnnotationDescriptionTextNode {
           childMarkdownRemark {
             html

--- a/src/templates/state/hospitalization.js
+++ b/src/templates/state/hospitalization.js
@@ -116,7 +116,7 @@ export const query = graphql`
     ) {
       nodes {
         state
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         hospitalizedCumulative
         hospitalizedCurrently
         hospitalizedIncrease
@@ -134,7 +134,7 @@ export const query = graphql`
       sort: { fields: date, order: DESC }
     ) {
       nodes {
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         childContentfulChartAnnotationDescriptionTextNode {
           childMarkdownRemark {
             html

--- a/src/templates/state/index.js
+++ b/src/templates/state/index.js
@@ -149,7 +149,7 @@ export const query = graphql`
       positiveIncrease
       negative
       lastUpdateEt
-      dateModified(formatString: "MMM D, YYYY h:mm a")
+      dateModified(formatString: "MMMM D, YYYY h:mm a")
       hospitalizedCurrently
       hospitalizedCumulative
       inIcuCurrently

--- a/src/templates/state/long-term-care/history.js
+++ b/src/templates/state/long-term-care/history.js
@@ -109,7 +109,7 @@ export const query = graphql`
       filter: { state_abbr: { eq: $state }, data_type: { eq: "Aggregate" } }
     ) {
       nodes {
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         posstaff_other
         posstaff_nh
         posstaff_ltc

--- a/src/templates/state/outcomes.js
+++ b/src/templates/state/outcomes.js
@@ -100,7 +100,7 @@ export const query = graphql`
     ) {
       nodes {
         state
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         deathProbable
         deathIncrease
         deathConfirmed
@@ -116,7 +116,7 @@ export const query = graphql`
       sort: { fields: date, order: DESC }
     ) {
       nodes {
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         childContentfulChartAnnotationDescriptionTextNode {
           childMarkdownRemark {
             html

--- a/src/templates/state/tests-antibody.js
+++ b/src/templates/state/tests-antibody.js
@@ -75,7 +75,7 @@ export const query = graphql`
       sort: { fields: date, order: DESC }
     ) {
       nodes {
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         totalTestsPeopleAntibody
         totalTestsAntibody
         negativeTestsPeopleAntibody

--- a/src/templates/state/tests-viral.js
+++ b/src/templates/state/tests-viral.js
@@ -126,7 +126,7 @@ export const query = graphql`
       sort: { fields: date, order: DESC }
     ) {
       nodes {
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         positiveTestsViral
         totalTestsPeopleViral
         totalTestsViral
@@ -139,7 +139,7 @@ export const query = graphql`
       sort: { fields: date, order: DESC }
     ) {
       nodes {
-        date(formatString: "MMM D, YYYY")
+        date(formatString: "MMMM D, YYYY")
         childContentfulChartAnnotationDescriptionTextNode {
           childMarkdownRemark {
             html


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
## To do pre-merge

- [x] Remove images of supporters from about us page content

## Changes

- Change volunteer CTA in mobile to full-width
- Make "more tweets" link on state page open in new window and add "pop out" icon
- Add a large header above gallery that says "A gallery of our charts"
- Move the first lede paragraph of our charts to above the top chart.
- Rewrite API heading content to bullets
- Embed the headway latest changes
- Remove first line of the download page that talks about our public spreadsheet.
- Data definitions page: Add blue treatment to jump to links.
- Rename contact us -volunteering to "Volunteer"
- Put the logos of partners into a grid
- About page: All external links should open a new window
- Add about us blurb to footer
- Change "Totals" to "Total" in chart toggle.
- Change "Full range" in chart toggle to "Historical"
- Remove "Calculated" links in charts
- Move legend for 7-day average and make more explicit
- Larger tap targets for sub navigation& main navigation
- Make footer tap targets bigger