### PR TITLE
fix (words): Update verb choice

### DIFF
--- a/src/pages/race/index.js
+++ b/src/pages/race/index.js
@@ -57,7 +57,7 @@ const RacePage = () => {
         <LandingPageSection noBorder noMargin>
           <LandingPageContainer>
             <LargeHeader center narrow>
-              Nationwide, Black people are dying at{' '}
+              Nationwide, Black people have died at{' '}
               <FormatNumber number={blackwhiteRateRatio} precision={1} /> times
               the rate of white people.
             </LargeHeader>


### PR DESCRIPTION
Changed 'are dying' to 'have died' in 
* Nationwide, Black people are dying at 1.6 times the rate of white people. 

![image](https://user-images.githubusercontent.com/3722037/103850791-345ff900-5076-11eb-8306-39523017ec27.png)

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
