### PR TITLE
chore(related-posts): fix overhanging cta arrow

### DIFF
--- a/src/components/pages/blog/footer/related-posts.module.scss
+++ b/src/components/pages/blog/footer/related-posts.module.scss
@@ -1,7 +1,7 @@
 .container {
   display: grid;
   align-items: center;
-  grid-template-columns: 3fr 1fr;
+  grid-template-columns: 3fr 2fr;
 
   @media (max-width: $viewport-md) {
     grid-template-columns: 100%;


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->

Moves this overhanging arrow (highlighted in blue) to one line
![image](https://user-images.githubusercontent.com/18607205/103939328-d4566a80-50e8-11eb-8b9e-2c94158ffff9.png)
