### PR TITLE
chore: Deemphasize grades

### DIFF
--- a/src/__tests__/components/pages/state/__snapshots__/state-grade.js.snap
+++ b/src/__tests__/components/pages/state/__snapshots__/state-grade.js.snap
@@ -62,11 +62,3 @@ exports[`Components : Pages : State : State grade renders correctly 3`] = `
   />
 </p>
 `;
-
-exports[`Components : Pages : State : State grade renders correctly 4`] = `
-<img
-  alt="Grade a"
-  className="gradeLarge"
-  src="test-file-stub"
-/>
-`;

--- a/src/__tests__/components/pages/state/state-grade.js
+++ b/src/__tests__/components/pages/state/state-grade.js
@@ -1,9 +1,6 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import {
-  StateGrade,
-  LargeStateGrade,
-} from '~components/pages/state/state-grade'
+import StateGrade from '~components/pages/state/state-grade'
 
 describe('Components : Pages : State : State grade', () => {
   it('renders correctly', () => {
@@ -15,10 +12,5 @@ describe('Components : Pages : State : State grade', () => {
 
     const naTree = renderer.create(<StateGrade />).toJSON()
     expect(naTree).toMatchSnapshot()
-
-    const largeTree = renderer
-      .create(<LargeStateGrade letterGrade="a" />)
-      .toJSON()
-    expect(largeTree).toMatchSnapshot()
   })
 })

--- a/src/components/common/last-updated.js
+++ b/src/components/common/last-updated.js
@@ -4,11 +4,12 @@ import Timezone from './timezone'
 import lastUpdatedStyle from './last-updated.module.scss'
 
 // date format matches stats.lastUpdateEt
-const LastUpdated = ({ date, national }) => (
+const LastUpdated = ({ date, national, noMargin = false }) => (
   <p
     className={classnames(
       lastUpdatedStyle.lastUpdated,
       national && lastUpdatedStyle.national,
+      noMargin && lastUpdatedStyle.noMargin,
     )}
   >
     {national ? <>Data for</> : <>State’s dataset was last updated at</>} {date}{' '}

--- a/src/components/common/last-updated.module.scss
+++ b/src/components/common/last-updated.module.scss
@@ -3,4 +3,8 @@
   &.national {
     font-weight: bold;
   }
+  &.no-margin {
+    color: #000000;
+    margin: 0;
+  }
 }

--- a/src/components/pages/data/state-data.js
+++ b/src/components/pages/data/state-data.js
@@ -1,6 +1,5 @@
 import React, { useState } from 'react'
 import { Link } from 'gatsby'
-import { StateGrade } from '~components/pages/state/state-grade'
 import StateSummary from '~components/pages/data/summary'
 import StateNotes from '~components/pages/state/state-notes'
 import LastUpdated from '~components/common/last-updated'
@@ -21,7 +20,6 @@ const State = ({ state, metadata }) => {
         <h3 id={`state-${state.state.toLowerCase()}`}>
           <Link to={`/data/state/${slug}`}>{state.name}</Link>
         </h3>
-        <StateGrade letterGrade={state.stateData.dataQualityGrade} />
       </div>
       <StateSummary
         stateName={state.name}

--- a/src/components/pages/state/download-data.js
+++ b/src/components/pages/state/download-data.js
@@ -30,19 +30,34 @@ const DownloadData = ({ slug, hideLabel = false }) => (
   </div>
 )
 
-const DownloadDataRow = ({ slug, lastUpdateEt, national = false }) => (
-  <Row>
-    <Col width={[4, 6, 6]}>
+const DownloadDataRow = ({
+  children,
+  slug,
+  lastUpdateEt,
+  national = false,
+}) => (
+  <>
+    <Row>
+      {!children && (
+        <Col width={[4, 6, children ? 4 : 6]}>
+          <div className={downloadDataStyles.lastUpdatedContainer}>
+            <LastUpdated date={lastUpdateEt} national={national} />
+          </div>
+        </Col>
+      )}
+      <Col width={[4, 6, 6]}>
+        <div className={preambleStyle.largeDisclosure}>
+          <DownloadData slug={slug} />
+        </div>
+      </Col>
+      <Col width={[4, 6, 6]}>{children}</Col>
+    </Row>
+    {children && (
       <div className={downloadDataStyles.lastUpdatedContainer}>
         <LastUpdated date={lastUpdateEt} national={national} />
       </div>
-    </Col>
-    <Col width={[4, 6, 6]}>
-      <div className={preambleStyle.largeDisclosure}>
-        <DownloadData slug={slug} />
-      </div>
-    </Col>
-  </Row>
+    )}
+  </>
 )
 
 export default DownloadData

--- a/src/components/pages/state/download-data.js
+++ b/src/components/pages/state/download-data.js
@@ -37,26 +37,19 @@ const DownloadDataRow = ({
   national = false,
 }) => (
   <>
-    <Row>
-      {!children && (
-        <Col width={[4, 6, children ? 4 : 6]}>
-          <div className={downloadDataStyles.lastUpdatedContainer}>
-            <LastUpdated date={lastUpdateEt} national={national} />
-          </div>
-        </Col>
-      )}
+    <Row className={downloadDataStyles.row}>
       <Col width={[4, 6, 6]}>
+        <div className={downloadDataStyles.lastUpdatedContainer}>
+          <LastUpdated date={lastUpdateEt} national={national} noMargin />
+        </div>
+      </Col>
+      <Col width={[4, 6, children ? 3 : 6]}>
         <div className={preambleStyle.largeDisclosure}>
           <DownloadData slug={slug} />
         </div>
       </Col>
-      <Col width={[4, 6, 6]}>{children}</Col>
+      {children && <Col width={[4, 6, 3]}>{children}</Col>}
     </Row>
-    {children && (
-      <div className={downloadDataStyles.lastUpdatedContainer}>
-        <LastUpdated date={lastUpdateEt} national={national} />
-      </div>
-    )}
   </>
 )
 

--- a/src/components/pages/state/download-data.js
+++ b/src/components/pages/state/download-data.js
@@ -43,12 +43,16 @@ const DownloadDataRow = ({
           <LastUpdated date={lastUpdateEt} national={national} noMargin />
         </div>
       </Col>
-      <Col width={[4, 6, children ? 3 : 6]}>
+      <Col width={[4, 6, children ? 3 : 6]} paddingLeft={[0, 0, 16]}>
         <div className={preambleStyle.largeDisclosure}>
           <DownloadData slug={slug} />
         </div>
       </Col>
-      {children && <Col width={[4, 6, 3]}>{children}</Col>}
+      {children && (
+        <Col width={[4, 6, 3]} paddingLeft={[0, 0, 16]}>
+          {children}
+        </Col>
+      )}
     </Row>
   </>
 )

--- a/src/components/pages/state/download-data.module.scss
+++ b/src/components/pages/state/download-data.module.scss
@@ -30,5 +30,19 @@
 }
 
 .row {
-  @include margin(32, top);
+  @include margin(16, top);
+  @media (min-width: $viewport-lg) {
+    @include margin(32, top);
+  }
+  > div {
+    @include margin(16, bottom);
+    @media (min-width: $viewport-lg) {
+      margin: 0;
+    }
+    &:first-child {
+      @media (max-width: $viewport-lg) {
+        order: 3;
+      }
+    }
+  }
 }

--- a/src/components/pages/state/download-data.module.scss
+++ b/src/components/pages/state/download-data.module.scss
@@ -1,15 +1,6 @@
 .button {
   display: inline-block;
-  text-decoration: none;
-  font-weight: bold;
-  @include padding(8);
   @include margin(16, right);
-  background: $color-plum-100;
-  border-radius: 4px;
-  color: $color-plum-800;
-  @media (max-width: $viewport-md) {
-    @include margin(16, top);
-  }
 }
 
 .header {
@@ -27,10 +18,17 @@
   @media (min-width: $viewport-lg) {
     justify-content: right;
   }
+  p {
+    margin: 0;
+  }
 }
 
 .last-updated-container {
   display: flex;
   height: 100%;
   align-items: center;
+}
+
+.row {
+  @include margin(32, top);
 }

--- a/src/components/pages/state/preamble.js
+++ b/src/components/pages/state/preamble.js
@@ -1,28 +1,11 @@
-import React, { useState } from 'react'
-import {
-  Disclosure,
-  DisclosureButton,
-  DisclosurePanel,
-} from '@reach/disclosure'
-import classnames from 'classnames'
+import React from 'react'
 import OverviewWrapper from '~components/common/overview-wrapper'
-import { Row, Col } from '~components/common/grid'
 import StateGrade from '~components/pages/state/state-grade'
-import {
-  DownloadData,
-  DownloadDataRow,
-} from '~components/pages/state/download-data'
-import {
-  StateLinks,
-  StateLinksDisclosure,
-  StateLinksDisclosureButton,
-  StateLinksDisclosurePanel,
-} from '~components/pages/state/state-links'
+import { DownloadDataRow } from '~components/pages/state/download-data'
+import { StateLinks } from '~components/pages/state/state-links'
 import preambleStyle from './preamble.module.scss'
 
 const StatePreamble = ({ state, urls, covidState }) => {
-  const [stateLinksAreOpen, setStateLinksAreOpen] = useState(false)
-  const [downloadDataIsOpen, setDownloadDataIsOpen] = useState(false)
   const { links } = urls.childTacoYaml
   // todo make state grade wrap as a circle with the grade description
   return (
@@ -44,45 +27,6 @@ const StatePreamble = ({ state, urls, covidState }) => {
       >
         <StateGrade letterGrade={covidState.dataQualityGrade} />
       </DownloadDataRow>
-      <Row>
-        <Col width={[0, 0, 6]}>
-          <div className={preambleStyle.mobileDisclosure}>
-            <Disclosure
-              open={downloadDataIsOpen}
-              onChange={() => setDownloadDataIsOpen(!downloadDataIsOpen)}
-            >
-              <DisclosureButton className={preambleStyle.button}>
-                <h3
-                  className={classnames(
-                    preambleStyle.header,
-                    preambleStyle.hiddenHeader,
-                  )}
-                >
-                  Get the data{' '}
-                  <span className={preambleStyle.toggle}>
-                    {downloadDataIsOpen ? <>&#8593;</> : <>&#8595;</>}
-                  </span>
-                </h3>
-              </DisclosureButton>
-              <DisclosurePanel>
-                <DownloadData slug={state.childSlug.slug} hideLabel />
-              </DisclosurePanel>
-            </Disclosure>
-          </div>
-        </Col>
-      </Row>
-      <Row>
-        <Col width={[0, 0, 6]}>
-          <StateLinksDisclosure
-            stateLinksAreOpen={stateLinksAreOpen}
-            setStateLinksAreOpen={setStateLinksAreOpen}
-            mobileOnly
-          >
-            <StateLinksDisclosureButton stateLinksAreOpen={stateLinksAreOpen} />
-            <StateLinksDisclosurePanel state={state} />
-          </StateLinksDisclosure>
-        </Col>
-      </Row>
     </OverviewWrapper>
   )
 }

--- a/src/components/pages/state/preamble.js
+++ b/src/components/pages/state/preamble.js
@@ -1,5 +1,4 @@
 import React, { useState } from 'react'
-import { useStaticQuery, graphql } from 'gatsby'
 import {
   Disclosure,
   DisclosureButton,
@@ -8,11 +7,11 @@ import {
 import classnames from 'classnames'
 import OverviewWrapper from '~components/common/overview-wrapper'
 import { Row, Col } from '~components/common/grid'
+import StateGrade from '~components/pages/state/state-grade'
 import {
   DownloadData,
   DownloadDataRow,
 } from '~components/pages/state/download-data'
-import { LargeStateGrade } from '~components/pages/state/state-grade'
 import {
   StateLinks,
   StateLinksDisclosure,
@@ -22,19 +21,6 @@ import {
 import preambleStyle from './preamble.module.scss'
 
 const StatePreamble = ({ state, urls, covidState }) => {
-  const { contentfulSnippet } = useStaticQuery(
-    graphql`
-      query {
-        contentfulSnippet(slug: { eq: "state-grades-preamble" }) {
-          content {
-            childMarkdownRemark {
-              html
-            }
-          }
-        }
-      }
-    `,
-  )
   const [stateLinksAreOpen, setStateLinksAreOpen] = useState(false)
   const [downloadDataIsOpen, setDownloadDataIsOpen] = useState(false)
   const { links } = urls.childTacoYaml
@@ -42,35 +28,22 @@ const StatePreamble = ({ state, urls, covidState }) => {
   return (
     <OverviewWrapper className={preambleStyle.preamble}>
       <h2 className="a11y-only">State overview</h2>
-      <Row>
-        <Col width={[4, 3, 6]}>
-          <div className={preambleStyle.largeDisclosure}>
-            <h3 className={preambleStyle.header}>Where this data comes from</h3>
-            <StateLinks
-              twitter={state.twitter}
-              links={links}
-              stateName={state.name}
-              stateSlug={state.childSlug.slug}
-            />
-          </div>
-        </Col>
-        <Col width={[4, 3, 6]}>
-          <h3 className={preambleStyle.header}>Current data quality grade</h3>
-          <div className={preambleStyle.gradeWrapper}>
-            <div
-              className={preambleStyle.gradeDescription}
-              dangerouslySetInnerHTML={{
-                __html: contentfulSnippet.content.childMarkdownRemark.html,
-              }}
-            />
-            <LargeStateGrade letterGrade={covidState.dataQualityGrade} />
-          </div>
-        </Col>
-      </Row>
+      <div className={preambleStyle.largeDisclosure}>
+        <h3 className={preambleStyle.header}>Where this data comes from</h3>
+        <StateLinks
+          twitter={state.twitter}
+          links={links}
+          stateName={state.name}
+          stateSlug={state.childSlug.slug}
+          fullWidth
+        />
+      </div>
       <DownloadDataRow
         slug={state.childSlug.slug}
         lastUpdateEt={covidState.dateModified}
-      />
+      >
+        <StateGrade letterGrade={covidState.dataQualityGrade} />
+      </DownloadDataRow>
       <Row>
         <Col width={[0, 0, 6]}>
           <div className={preambleStyle.mobileDisclosure}>

--- a/src/components/pages/state/preamble.module.scss
+++ b/src/components/pages/state/preamble.module.scss
@@ -37,15 +37,3 @@
   @include remove-button-style();
   text-decoration: underline;
 }
-
-.mobile-disclosure {
-  @media (min-width: $viewport-md) {
-    display: none;
-  }
-}
-
-.large-disclosure {
-  @media (max-width: $viewport-md) {
-    display: none;
-  }
-}

--- a/src/components/pages/state/state-grade.js
+++ b/src/components/pages/state/state-grade.js
@@ -9,35 +9,16 @@ import gradeSmallD from '~images/state-grades/small/d.svg'
 import gradeSmallF from '~images/state-grades/small/f.svg'
 import gradeSmallNA from '~images/state-grades/small/na.svg'
 
-import gradeLargeAPlus from '~images/state-grades/large/a-plus.svg'
-import gradeLargeA from '~images/state-grades/large/a.svg'
-import gradeLargeB from '~images/state-grades/large/b.svg'
-import gradeLargeC from '~images/state-grades/large/c.svg'
-import gradeLargeD from '~images/state-grades/large/d.svg'
-import gradeLargeF from '~images/state-grades/large/f.svg'
-import gradeLargeNA from '~images/state-grades/large/na.svg'
-
 const grades = {
-  'a+': {
-    small: gradeSmallAPlus,
-    large: gradeLargeAPlus,
-  },
-  a: {
-    small: gradeSmallA,
-    large: gradeLargeA,
-  },
-  b: { small: gradeSmallB, large: gradeLargeB },
-  c: {
-    small: gradeSmallC,
-    large: gradeLargeC,
-  },
-  d: {
-    small: gradeSmallD,
-    large: gradeLargeD,
-  },
+  'a+': gradeSmallAPlus,
+  a: gradeSmallA,
+  b: gradeSmallB,
+  c: gradeSmallC,
 
-  f: { small: gradeSmallF, large: gradeLargeF },
-  na: { small: gradeSmallNA, large: gradeLargeNA },
+  d: gradeSmallD,
+
+  f: gradeSmallF,
+  na: gradeSmallNA,
 }
 
 const StateGrade = ({ letterGrade = 'na' }) => {
@@ -50,8 +31,8 @@ const StateGrade = ({ letterGrade = 'na' }) => {
         src={
           letterGrade &&
           typeof grades[letterGrade.toLowerCase()] !== 'undefined'
-            ? grades[letterGrade.toLowerCase()].small
-            : grades.na.small
+            ? grades[letterGrade.toLowerCase()]
+            : grades.na
         }
         className={stateGradeStyle.grade}
         alt={`Grade ${letterGrade}`}
@@ -60,16 +41,4 @@ const StateGrade = ({ letterGrade = 'na' }) => {
   )
 }
 
-const LargeStateGrade = ({ letterGrade = 'na' }) => (
-  <img
-    src={
-      letterGrade && typeof grades[letterGrade.toLowerCase()] !== 'undefined'
-        ? grades[letterGrade.toLowerCase()].large
-        : grades.na.large
-    }
-    alt={`Grade ${letterGrade}`}
-    className={stateGradeStyle.gradeLarge}
-  />
-)
-
-export { StateGrade, LargeStateGrade }
+export default StateGrade

--- a/src/components/pages/state/state-grade.module.scss
+++ b/src/components/pages/state/state-grade.module.scss
@@ -1,9 +1,5 @@
 .state-grade {
-  @include margin(16, bottom);
-  @media (min-width: $viewport-lg) {
-    margin-bottom: 0;
-    text-align: right;
-  }
+  margin: 0;
   img {
     display: inline;
     vertical-align: middle;

--- a/src/components/pages/state/state-grade.module.scss
+++ b/src/components/pages/state/state-grade.module.scss
@@ -2,6 +2,7 @@
   @include margin(16, bottom);
   @media (min-width: $viewport-lg) {
     margin-bottom: 0;
+    text-align: right;
   }
   img {
     display: inline;

--- a/src/components/pages/state/state-links.js
+++ b/src/components/pages/state/state-links.js
@@ -5,10 +5,17 @@ import {
   DisclosureButton,
   DisclosurePanel,
 } from '@reach/disclosure'
+import classnames from 'classnames'
 import stateLinksStyle from './state-links.module.scss'
 import preambleStyle from './preamble.module.scss'
 
-const StateLinks = ({ twitter, stateName, stateSlug, links }) => {
+const StateLinks = ({
+  twitter,
+  stateName,
+  stateSlug,
+  links,
+  fullWidth = false,
+}) => {
   const getLink = type => {
     const currentLink = links && links.find(link => link.name === type)
     if (!currentLink) {
@@ -17,7 +24,12 @@ const StateLinks = ({ twitter, stateName, stateSlug, links }) => {
     return currentLink.url
   }
   return (
-    <div className={stateLinksStyle.container}>
+    <div
+      className={classnames(
+        stateLinksStyle.container,
+        fullWidth && stateLinksStyle.fullWidth,
+      )}
+    >
       {getLink('primary') && (
         <a href={getLink('primary')} className={stateLinksStyle.link}>
           <span>Best current data source</span>

--- a/src/components/pages/state/state-links.module.scss
+++ b/src/components/pages/state/state-links.module.scss
@@ -11,6 +11,9 @@
     grid-template-columns: 1fr 1fr;
   }
   &.full-width {
+    @media (min-width: $viewport-md) {
+      grid-template-columns: 1fr 1fr 1fr;
+    }
     @media (min-width: $viewport-lg) {
       grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
     }

--- a/src/components/pages/state/state-links.module.scss
+++ b/src/components/pages/state/state-links.module.scss
@@ -10,4 +10,9 @@
   @media (min-width: $viewport-lg) {
     grid-template-columns: 1fr 1fr;
   }
+  &.full-width {
+    @media (min-width: $viewport-lg) {
+      grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+    }
+  }
 }

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -172,7 +172,6 @@ export const query = graphql`
     }
     allCovidState {
       nodes {
-        dataQualityGrade
         dateModified(formatString: "MMM D, YYYY h:mm a")
         death
         deathConfirmed

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -172,7 +172,7 @@ export const query = graphql`
     }
     allCovidState {
       nodes {
-        dateModified(formatString: "MMM D, YYYY h:mm a")
+        dateModified(formatString: "MMMM D, YYYY h:mm a")
         death
         deathConfirmed
         deathProbable


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->

- Remove grades from `/data`
- Make the grade on state pages smaller