### PR TITLE
Add antigen tests card, historical page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -158,6 +158,11 @@ exports.createPages = async ({ graphql, actions }) => {
       context: node,
     })
     createPage({
+      path: `/data/state/${slug}/tests-antigen`,
+      component: path.resolve(`./src/templates/state/tests-antigen.js`),
+      context: node,
+    })
+    createPage({
       path: `/data/state/${slug}/tests-viral`,
       component: path.resolve(`./src/templates/state/tests-viral.js`),
       context: node,

--- a/src/components/pages/data/cards/tests-antigen.js
+++ b/src/components/pages/data/cards/tests-antigen.js
@@ -45,7 +45,13 @@ const TestsAntigenCard = ({
             label="Total antigen tests in people"
           />
         </Statistic>
-        <CardNote>TKTK</CardNote>
+        <CardNote>
+          <b>Warning</b>: Antigen reporting may{' '}
+          <a href="https://covidtracking.com/analysis-updates/antigen-testing-reporting">
+            significantly understate
+          </a>{' '}
+          the true number of tests administered
+        </CardNote>
       </CardBody>
     </Card>
   )

--- a/src/components/pages/data/cards/tests-antigen.js
+++ b/src/components/pages/data/cards/tests-antigen.js
@@ -1,0 +1,54 @@
+import React, { useContext } from 'react'
+import { Link } from 'gatsby'
+import { Card, CardNote, CardBody } from '~components/common/card'
+import { DefinitionPanelContext } from './definitions-panel'
+import { Statistic, DefinitionLink } from '~components/common/statistic'
+
+const TestsAntigenCard = ({
+  stateSlug,
+  stateName,
+  totalTestsAntigen,
+  totalTestsPeopleAntigen,
+}) => {
+  const definitionContext = useContext(DefinitionPanelContext)
+  const definitionFields = ['totalTestsAntigen', 'totalTestsPeopleAntigen']
+  return (
+    <Card
+      title="Antigen tests"
+      link={
+        <Link to={`/data/state/${stateSlug}/tests-antigen`}>
+          <span className="a11y-only">{stateName} antigen testing </span>
+          Historical data
+        </Link>
+      }
+    >
+      <CardBody>
+        <Statistic title="Total tests (specimens)" value={totalTestsAntigen}>
+          <DefinitionLink
+            onDefinitionsToggle={() => {
+              definitionContext({
+                fields: definitionFields,
+                highlight: 'totalTestsAntigen',
+              })
+            }}
+            label="Total antigen tests in specimens"
+          />
+        </Statistic>
+        <Statistic title="Total tests (people)" value={totalTestsPeopleAntigen}>
+          <DefinitionLink
+            onDefinitionsToggle={() => {
+              definitionContext({
+                fields: definitionFields,
+                highlight: 'totalTestsPeopleAntigen',
+              })
+            }}
+            label="Total antigen tests in people"
+          />
+        </Statistic>
+        <CardNote>TKTK</CardNote>
+      </CardBody>
+    </Card>
+  )
+}
+
+export default TestsAntigenCard

--- a/src/components/pages/data/summary.js
+++ b/src/components/pages/data/summary.js
@@ -11,6 +11,7 @@ import CasesCard from './cards/cases-card'
 import HospitalizationCard from './cards/hospitalization-card'
 import OutcomesCard from './cards/outcomes-card'
 import TestsAntibodyCard from './cards/tests-antibody'
+import TestsAntigenCard from './cards/tests-antigen'
 import TestsViralCard from './cards/tests-viral'
 import NationalTestsCard from './cards/tests-national'
 import LongTermCareCard from './cards/long-term-care'
@@ -166,7 +167,7 @@ const StateSummary = ({
             sevenDayIncrease={sevenDayPositiveIncrease}
             national={national}
           />
-          {national && (
+          {national ? (
             <NationalTestsCard
               totalTestResults={data.totalTestResults}
               totalTestResultsIncrease={data.totalTestResultsIncrease}
@@ -175,8 +176,7 @@ const StateSummary = ({
                 sevenDaysAgo.totalTestResults
               }
             />
-          )}
-          {!national && (
+          ) : (
             <>
               <TestsViralCard
                 stateSlug={stateSlug}
@@ -190,6 +190,12 @@ const StateSummary = ({
                 stateSlug={stateSlug}
                 stateName={stateName}
                 totalTestsAntibody={data.totalTestsAntibody}
+              />
+              <TestsAntigenCard
+                stateSlug={stateSlug}
+                stateName={stateName}
+                totalTestsAntigen={data.totalTestsAntigen}
+                totalTestsPeopleAntigen={data.totalTestsPeopleAntigen}
               />
             </>
           )}

--- a/src/components/pages/data/summary.js
+++ b/src/components/pages/data/summary.js
@@ -190,6 +190,7 @@ const StateSummary = ({
                 stateSlug={stateSlug}
                 stateName={stateName}
                 totalTestsAntibody={data.totalTestsAntibody}
+                totalTestsPeopleAntibody={data.totalTestsPeopleAntibody}
               />
               <TestsAntigenCard
                 stateSlug={stateSlug}

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -192,6 +192,8 @@ export const query = graphql`
         totalTestResults
         totalTestsAntibody
         totalTestsPeopleAntibody
+        totalTestsAntigen
+        totalTestsPeopleAntigen
         totalTestsPeopleViral
         totalTestsViral
       }

--- a/src/templates/state/index.js
+++ b/src/templates/state/index.js
@@ -172,6 +172,8 @@ export const query = graphql`
       totalTestEncountersViral
       totalTestsAntibody
       totalTestsPeopleAntibody
+      totalTestsAntigen
+      totalTestsPeopleAntigen
       totalTestResultsSource
     }
     allCovidStateDaily(

--- a/src/templates/state/tests-antigen.js
+++ b/src/templates/state/tests-antigen.js
@@ -1,0 +1,99 @@
+import React from 'react'
+import { graphql } from 'gatsby'
+import TableResponsive from '~components/common/table-responsive'
+import Definitions from '~components/pages/data/definitions'
+import Layout from '~components/layout'
+
+const StateTestAntigenTemplate = ({ pageContext, path, data }) => {
+  const state = pageContext
+  const { slug } = state.childSlug
+
+  return (
+    <Layout
+      title={`${state.name}: Antigen tests`}
+      returnLinks={[
+        { link: '/data', title: 'Our Data' },
+        { link: `/data/state/${slug}`, title: state.name },
+      ]}
+      path={path}
+      description={`Data definitions and time series of data on total and positive antigen tests in units of specimens or people for ${state.name}.`}
+      showWarning
+    >
+      <Definitions
+        definitions={data.allContentfulDataDefinition.nodes}
+        order={[
+          'totalTestsPeopleAntigen',
+          'totalTestsAntigen',
+          'positiveTestsPeopleAntigen',
+          'positiveTestsAntigen',
+        ]}
+      />
+      <TableResponsive
+        labels={[
+          {
+            field: 'date',
+            noWrap: true,
+          },
+          {
+            field: 'totalTestsPeopleAntigen',
+            isNumeric: true,
+          },
+          {
+            field: 'totalTestsAntigen',
+            isNumeric: true,
+          },
+          {
+            field: 'positiveTestsPeopleAntigen',
+            isNumeric: true,
+          },
+          {
+            field: 'positiveTestsAntigen',
+            isNumeric: true,
+          },
+        ]}
+        data={data.allCovidStateDaily.nodes}
+      />
+    </Layout>
+  )
+}
+
+export default StateTestAntigenTemplate
+
+export const query = graphql`
+  query($state: String!) {
+    allCovidStateDaily(
+      filter: { state: { eq: $state } }
+      sort: { fields: date, order: DESC }
+    ) {
+      nodes {
+        date(formatString: "MMMM D, YYYY")
+        positiveTestsPeopleAntigen
+        positiveTestsAntigen
+        totalTestsPeopleAntigen
+        totalTestsAntigen
+      }
+    }
+    allContentfulDataDefinition(
+      filter: {
+        fieldName: {
+          in: [
+            "totalTestsPeopleAntigen"
+            "totalTestsAntigen"
+            "positiveTestsPeopleAntigen"
+            "positiveTestsAntigen"
+          ]
+        }
+      }
+    ) {
+      nodes {
+        fieldName
+        name
+        childContentfulDataDefinitionDefinitionTextNode {
+          childMarkdownRemark {
+            html
+          }
+        }
+      }
+    }
+  }
+`


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
