### PR TITLE
fix: Remove deprecated recovered field from US CSV

### DIFF
--- a/src/utilities/csv.js
+++ b/src/utilities/csv.js
@@ -97,7 +97,6 @@ module.exports = (graphql, reporter) => {
               onVentilatorCurrently
               positive
               positiveIncrease
-              recovered
               states
               totalTestResults
               totalTestResultsIncrease


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
