### PR TITLE
chore: Fix preamble stacking in mobile

### DIFF
--- a/src/components/pages/state/preamble.js
+++ b/src/components/pages/state/preamble.js
@@ -28,18 +28,18 @@ const StatePreamble = ({ state, covidState, hideNotesLink = false }) => {
           </a>
         </li>
       </ul>
-      <Row>
+      <Row className={preambleStyle.row}>
         <Col width={[4, 6, 4]}>
           Last updated {covidState.dateModified} <Timezone />
         </Col>
-        <Col width={[4, 6, 4]}>
+        <Col width={[4, 6, 4]} paddingLeft={[0, 0, 16]}>
           Download data as a{' '}
           <a href={`/data/download/${state.childSlug.slug}-history.csv`}>
             CSV file
           </a>{' '}
           or with our <Link to="/data/api">API</Link>.
         </Col>
-        <Col width={[4, 6, 4]}>
+        <Col width={[4, 6, 4]} paddingLeft={[0, 0, 16]}>
           <StateGrade letterGrade={covidState.dataQualityGrade} />
         </Col>
       </Row>

--- a/src/components/pages/state/preamble.module.scss
+++ b/src/components/pages/state/preamble.module.scss
@@ -38,3 +38,12 @@
   @include remove-button-style();
   text-decoration: underline;
 }
+
+.row {
+  > div {
+    @include margin(16, bottom);
+    @media (min-width: $viewport-lg) {
+      margin-bottom: 0;
+    }
+  }
+}


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
