### PR TITLE
chore: Add highlight, full widtht to content tables

### DIFF
--- a/src/components/pages/blog/content-blocks/table-content-block.module.scss
+++ b/src/components/pages/blog/content-blocks/table-content-block.module.scss
@@ -1,6 +1,9 @@
 .table {
   width: 100%;
   border-collapse: collapse;
+  @include margin(8, bottom);
+  flex-basis: 100% !important;
+  max-width: 100% !important;
   tr,
   td,
   th {
@@ -11,6 +14,11 @@
   }
   th {
     font-weight: bolder;
+    background: $color-slate-100;
+  }
+  th,
+  td {
+    @include padding(16);
   }
 }
 
@@ -50,13 +58,6 @@
     border: 0;
     @media (min-width: $viewport-lg) {
       display: table-cell;
-      padding: 1rem;
-      &:first-child {
-        padding-left: 0;
-      }
-      &:last-child {
-        padding-right: 0;
-      }
     }
   }
 }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds shading to content table headers
- Makes content tables full width
- Adds margin to base of table