### PR TITLE
chore: Fix keep size and mobile settings from CMS

### DIFF
--- a/src/components/pages/blog/blog-content.js
+++ b/src/components/pages/blog/blog-content.js
@@ -88,8 +88,8 @@ const BlogContent = ({ content }) => {
             <ImageContentBlock
               image={image}
               caption={caption}
-              keepSize={keepSize && keepSize['en-US']}
-              fullWidthMobile={fullWidthMobile && fullWidthMobile['en-US']}
+              keepSize={keepSize}
+              fullWidthMobile={fullWidthMobile}
               className={blogContentStyles.image}
               imageUrl={image.url}
               linkToImage={imageLink}


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Fixes doubly-set language localization in image block size settings