### PR TITLE
fix(a11y): Add skiplink to visuzation gallery, remove tabindex from map legends

### DIFF
--- a/src/components/pages/homepage/visualization-gallery/index.js
+++ b/src/components/pages/homepage/visualization-gallery/index.js
@@ -62,7 +62,10 @@ const HomepageGallery = () => {
     }
   `)
   return (
-    <>
+    <div className={galleryStyle.wrapper}>
+      <a href="#skip-visualization" className={galleryStyle.skipLink}>
+        Skip visualiations
+      </a>
       <Tabs>
         <div className={galleryStyle.tabContainer}>
           <TabList className={galleryStyle.tabs}>
@@ -89,7 +92,8 @@ const HomepageGallery = () => {
           </Container>
         </div>
       </Tabs>
-    </>
+      <div id="skip-visualization" />
+    </div>
   )
 }
 

--- a/src/components/pages/homepage/visualization-gallery/items/us-map/map.js
+++ b/src/components/pages/homepage/visualization-gallery/items/us-map/map.js
@@ -18,7 +18,6 @@ const MapLegend = ({ legend }) => {
           <svg
             className={mapStyle.legendHex}
             viewBox={`0 0 ${hexRadius * 2 + 10} ${hexRadius * 2 + 10}`}
-            tabIndex="0"
             aria-hidden
           >
             <Legend r={hexRadius} className={item.style} />

--- a/src/components/pages/homepage/visualization-gallery/visualization-gallery.module.scss
+++ b/src/components/pages/homepage/visualization-gallery/visualization-gallery.module.scss
@@ -54,7 +54,7 @@
 .skip-link {
   @include a11y-only();
   &:focus {
-    padding: 1rem;
+    @include padding(16);
     position: absolute;
     top: 10px;
     left: 10px;

--- a/src/components/pages/homepage/visualization-gallery/visualization-gallery.module.scss
+++ b/src/components/pages/homepage/visualization-gallery/visualization-gallery.module.scss
@@ -50,3 +50,22 @@
     outline: none;
   }
 }
+
+.skip-link {
+  @include a11y-only();
+  &:focus {
+    padding: 1rem;
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    background: white;
+    z-index: 1;
+    width: auto;
+    height: auto;
+    clip: auto;
+  }
+}
+
+.wrapper {
+  position: relative;
+}


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
