### PR TITLE
chore: Add cache control for race dashboard

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -25,4 +25,8 @@
 [[headers]]
   for = "/images/race-dashboard/*"
   [headers.values]
-    Cache-Control = "public, max-age=3600"
+  cache-control = '''
+    max-age=3600,
+    no-cache,
+    no-store,
+    must-revalidate'''

--- a/netlify.toml
+++ b/netlify.toml
@@ -21,4 +21,8 @@
   for = "/api/*"
   [headers.values]
     Access-Control-Allow-Origin = "*"
-    
+
+[[headers]]
+  for = "/images/race-dashboard/*"
+  [headers.values]
+    Cache-Control = "public, max-age=3600"


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Add explicit cache control to race data images.