### PR TITLE
fix: national forEach annotation bug

### DIFF
--- a/src/components/pages/data/summary.js
+++ b/src/components/pages/data/summary.js
@@ -220,7 +220,9 @@ const StateSummary = ({
     return allDefinitions
   }
 
-  addMetricTextDefinitions(definitions, annotations)
+  if (annotations !== false) {
+    addMetricTextDefinitions(definitions, annotations)
+  }
 
   return (
     <DefinitionPanelContext.Provider
@@ -245,7 +247,11 @@ const StateSummary = ({
             definitions={definitions}
             highlightedDefinition={highlightedDefinition}
             onHide={() => setCardDefinitions(false)}
-            title={`${stateName} Definitions`}
+            title={
+              stateName === undefined
+                ? 'National Definitions'
+                : `${stateName} Definitions`
+            }
           />
         )}
         {cardAnnotations && (


### PR DESCRIPTION
Handle cases where annotations = false before attempting
to iterate over the annotations.

Also updates the national definition panel title to say
'National' instead of 'undefined'.

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
