### PR TITLE
chore: remove notes from state index

### DIFF
--- a/src/utilities/algolia.js
+++ b/src/utilities/algolia.js
@@ -97,7 +97,6 @@ function transformStates(data) {
   return data.statesInfo.edges.map(({ node }) => ({
     ...node,
     updatedAt: stateModifiedDates[node.state],
-    notes: node.notes ? marked(node.notes) : '',
     slug: `/data/state/${node.childSlug.slug}`,
   }))
 }
@@ -203,10 +202,6 @@ function chunkBlogPosts(data) {
   }, [])
 }
 
-const stateSettings = {
-  attributesToSnippet: ['notes:50'],
-}
-
 /**
  * Settings shared (for now) amidst Page & BlogPost content types
  * in order to handle chunks + handle Snippets
@@ -224,7 +219,6 @@ export const queries = [
     query: stateQuery,
     indexName: prefixSearchIndex('state'),
     transformer: ({ data }) => transformStates(data),
-    settings: stateSettings,
   },
   {
     query: blogPostQuery,

--- a/src/utilities/algolia.js
+++ b/src/utilities/algolia.js
@@ -29,7 +29,6 @@ const stateQuery = `{
         objectID: state
         name
         state
-        notes
         childSlug {
           slug
         }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Remove notes from algolia indexing