### PR TITLE
chore(perf): Remove unused HHS data

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -246,7 +246,19 @@ const gatsbyConfig = {
       resolve: 'gatsby-source-covid-tracking-api',
       options: {
         file: './_data/hhs_hospitalization.json',
-        type: 'hhsHospitalizationCovid',
+        type: 'hhsHospitals',
+        transformItems: items => {
+          const result = {}
+          items.forEach(item => {
+            if (
+              typeof result[item.state] === 'undefined' ||
+              parseInt(item.date, 10) > parseInt(result[item.state].date, 10)
+            ) {
+              result[item.state] = item
+            }
+          })
+          return Object.values(result)
+        },
       },
     },
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -252,7 +252,8 @@ const gatsbyConfig = {
           items.forEach(item => {
             if (
               typeof result[item.state] === 'undefined' ||
-              parseInt(item.date, 10) > parseInt(result[item.state].date, 10)
+              parseInt(item.date.replace(/\D/g, ''), 10) >
+                parseInt(result[item.state].date.replace(/\D/g, ''), 10)
             ) {
               result[item.state] = item
             }

--- a/plugins/gatsby-source-covid-tracking-api/gatsby-node.js
+++ b/plugins/gatsby-source-covid-tracking-api/gatsby-node.js
@@ -8,7 +8,13 @@ exports.sourceNodes = async (
   configOptions,
 ) => {
   const { createNode } = actions
-  const { file, sortField, type, increaseFields } = configOptions
+  const {
+    file,
+    sortField,
+    type,
+    increaseFields,
+    transformItems,
+  } = configOptions
   const start = new Date()
   try {
     fs.statSync(file)
@@ -21,7 +27,10 @@ Make sure to run "npm run setup" to clone the most recent version of the COVID A
     return
   }
 
-  const items = await fs.readJson(file)
+  let items = await fs.readJson(file)
+  if (transformItems) {
+    items = transformItems(items)
+  }
   if (increaseFields && increaseFields.length) {
     items.sort((a, b) => (a.date > b.date ? 1 : -1))
   }

--- a/src/components/pages/data/state-data.js
+++ b/src/components/pages/data/state-data.js
@@ -32,9 +32,7 @@ const State = ({ state, metadata }) => {
         lastUpdate={state.dateModified}
         longTermCare={state.childLtc}
         annotations={state.annotations}
-        hhsHospitalization={
-          state.hhsHospitalization && state.hhsHospitalization.nodes[0]
-        }
+        hhsHospitalization={state.hhsHospitalization}
       />
 
       <a

--- a/src/components/pages/data/states.js
+++ b/src/components/pages/data/states.js
@@ -55,7 +55,7 @@ const States = ({
     )
 
     state.hhsHospitalization = hhsHospitalization
-      ? hhsHospitalization.find(record => record.nodes[0].state === state.state)
+      ? hhsHospitalization.find(record => record.state === state.state)
       : false
 
     stateList.push(state)

--- a/src/components/pages/data/summary.js
+++ b/src/components/pages/data/summary.js
@@ -341,21 +341,12 @@ const StateSummary = ({
               hospitalizedCurrently={data.hospitalizedCurrently}
               inIcuCurrently={data.inIcuCurrently}
               onVentilatorCurrently={data.onVentilatorCurrently}
-              hhsHospitalization={hhsHospitalization}
               national={national}
             />
             {!national && hhsHospitalization && (
               <HospitalizationHhsCard
-                stateSlug={stateSlug}
-                stateName={stateName}
-                hospitalizedCumulative={data.hospitalizedCumulative}
-                inIcuCumulative={data.inIcuCumulative}
-                onVentilatorCumulative={data.onVentilatorCumulative}
-                hospitalizedCurrently={data.hospitalizedCurrently}
-                inIcuCurrently={data.inIcuCurrently}
-                onVentilatorCurrently={data.onVentilatorCurrently}
                 hhsHospitalization={hhsHospitalization}
-                national={national}
+                stateAbbreviation={stateAbbreviation}
               />
             )}
             <OutcomesCard

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -53,7 +53,7 @@ const DataPage = ({ data }) => {
         annotations={data.allCovidAnnotation.nodes}
         raceDataCombined={data.allCovidRaceDataCombined.nodes}
         raceDataSeparate={data.allCovidRaceDataSeparate.nodes}
-        hhsHospitalization={data.allHhsHospitalizationCovid.group}
+        hhsHospitalization={data.allHhsHospitals.nodes}
       />
     </Layout>
   )
@@ -283,16 +283,15 @@ export const query = graphql`
         }
       }
     }
-    allHhsHospitalizationCovid(sort: { fields: date, order: DESC }) {
-      group(field: state, limit: 1) {
-        nodes {
-          state
-          date
-          inpatient_beds_used_covid
-          staffed_icu_adult_patients_confirmed_and_suspected_covid
-          total_adult_patients_hospitalized_confirmed_covid
-          total_pediatric_patients_hospitalized_confirmed_covid
-        }
+
+    allHhsHospitals {
+      nodes {
+        state
+        date
+        inpatient_beds_used_covid
+        staffed_icu_adult_patients_confirmed_and_suspected_covid
+        total_adult_patients_hospitalized_confirmed_covid
+        total_pediatric_patients_hospitalized_confirmed_covid
       }
     }
   }

--- a/src/templates/state/index.js
+++ b/src/templates/state/index.js
@@ -30,7 +30,7 @@ const StateTemplate = ({ pageContext, data, path }) => {
     contentfulStateOrTerritory,
     allTweets,
     allCovidAnnotation,
-    allHhsHospitalizationCovid,
+    hhsHospitals,
   } = data
   return (
     <Layout
@@ -68,9 +68,7 @@ const StateTemplate = ({ pageContext, data, path }) => {
           annotations={allCovidAnnotation.nodes}
           raceData={getRaceData(data)}
           longTermCare={data.covidStateInfo.childLtc}
-          hhsHospitalization={
-            allHhsHospitalizationCovid && allHhsHospitalizationCovid.nodes[0]
-          }
+          hhsHospitalization={hhsHospitals}
         />
         <StateTweets
           tweets={allTweets}
@@ -320,19 +318,13 @@ export const query = graphql`
         warningTitle
       }
     }
-    allHhsHospitalizationCovid(
-      filter: { state: { eq: $state } }
-      sort: { fields: date, order: DESC }
-      limit: 1
-    ) {
-      nodes {
-        state
-        date
-        inpatient_beds_used_covid
-        staffed_icu_adult_patients_confirmed_and_suspected_covid
-        total_adult_patients_hospitalized_confirmed_covid
-        total_pediatric_patients_hospitalized_confirmed_covid
-      }
+    hhsHospitals(state: { eq: $state }) {
+      state
+      date
+      inpatient_beds_used_covid
+      staffed_icu_adult_patients_confirmed_and_suspected_covid
+      total_adult_patients_hospitalized_confirmed_covid
+      total_pediatric_patients_hospitalized_confirmed_covid
     }
   }
 `


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Filters out unused HHS nodes
- Adds field transform to default API plugin
- Rewrites some HHS queries to make them simpler