### PR TITLE
fix: Error where map modal wouldn't hide for US

### DIFF
--- a/src/components/pages/homepage/visualization-gallery/items/us-map/grid.js
+++ b/src/components/pages/homepage/visualization-gallery/items/us-map/grid.js
@@ -81,6 +81,7 @@ const Grid = ({ states, us, relatedPost, metric, disclaimer = false }) => {
             aria-label="close"
             onClick={event => {
               event.preventDefault()
+              setShowUs(false)
               setActiveState(false)
             }}
           >


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
