### PR TITLE
feat: Fuller-width for tableau charts

### DIFF
--- a/src/components/charts/tableau.js
+++ b/src/components/charts/tableau.js
@@ -9,6 +9,7 @@ const TableauCharts = ({
   height,
   mobileHeight = false,
   viewUrlMobile = false,
+  className = false,
 }) => {
   const chartRef = useRef(false)
   const mobileChartRef = useRef(false)
@@ -36,6 +37,7 @@ const TableauCharts = ({
     <>
       <div
         className={classnames(
+          className,
           tableauStyle.chart,
           viewUrlMobile && tableauStyle.hasMobileView,
         )}
@@ -44,7 +46,12 @@ const TableauCharts = ({
       />
       {viewUrlMobile && (
         <div
-          className={classnames(tableauStyle.chart, tableauStyle.mobile)}
+          className={classnames(
+            className,
+
+            tableauStyle.chart,
+            tableauStyle.mobile,
+          )}
           id={`chart-mobile-${id}`}
           ref={mobileChartRef}
         />

--- a/src/components/pages/blog/blog-content.js
+++ b/src/components/pages/blog/blog-content.js
@@ -74,6 +74,7 @@ const BlogContent = ({ content }) => {
               viewUrlMobile={mobileUrl}
               height={height}
               mobileHeight={mobileHeight}
+              className={blogContentStyles.image}
             />
           )
         }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Make tableau charts wider than the text area in blog posts