### PR TITLE
chore: remove daily tweet

### DIFF
--- a/src/pages/data/charts.js
+++ b/src/pages/data/charts.js
@@ -4,7 +4,6 @@ import Layout from '~components/layout'
 import Container from '~components/common/container'
 import ContentfulContent from '~components/common/contentful-content'
 import ChartList from '~components/pages/data/charts/chart-list'
-import ChartTweet from '~components/pages/data/charts/tweet'
 import ChartPreamble from '~components/pages/data/charts/preamble'
 
 const ChartsPage = ({ data }) => (
@@ -18,13 +17,7 @@ const ChartsPage = ({ data }) => (
         id={data.chartDisclaimer.contentful_id}
       />
     </Container>
-    <h2>United States Overview</h2>
-    <ChartPreamble
-      usHistory={data.allCovidUsDaily.nodes}
-      stateHistory={data.allCovidStateDaily.nodes}
-    />
 
-    <ChartTweet />
     <h2>Our chart gallery</h2>
     <ChartList />
 

--- a/src/pages/data/charts.js
+++ b/src/pages/data/charts.js
@@ -4,6 +4,7 @@ import Layout from '~components/layout'
 import Container from '~components/common/container'
 import ContentfulContent from '~components/common/contentful-content'
 import ChartList from '~components/pages/data/charts/chart-list'
+import ChartPreamble from '~components/pages/data/charts/preamble'
 
 const ChartsPage = ({ data }) => (
   <Layout title="Charts" returnLinks={[{ link: '/data' }]} showWarning>
@@ -16,6 +17,11 @@ const ChartsPage = ({ data }) => (
         id={data.chartDisclaimer.contentful_id}
       />
     </Container>
+    <h2>United States Overview</h2>
+    <ChartPreamble
+      usHistory={data.allCovidUsDaily.nodes}
+      stateHistory={data.allCovidStateDaily.nodes}
+    />
 
     <h2>Our chart gallery</h2>
     <ChartList />

--- a/src/pages/data/charts.js
+++ b/src/pages/data/charts.js
@@ -4,7 +4,6 @@ import Layout from '~components/layout'
 import Container from '~components/common/container'
 import ContentfulContent from '~components/common/contentful-content'
 import ChartList from '~components/pages/data/charts/chart-list'
-import ChartPreamble from '~components/pages/data/charts/preamble'
 
 const ChartsPage = ({ data }) => (
   <Layout title="Charts" returnLinks={[{ link: '/data' }]} showWarning>

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -7,7 +7,6 @@ import States from '~components/pages/data/states'
 import { DownloadDataRow } from '~components/pages/state/download-data'
 import Summary from '~components/pages/data/summary'
 import SummaryCharts from '~components/pages/data/summary-charts'
-import DailyTweet from '~components/pages/data/daily-tweet'
 
 const DataPage = ({ data }) => {
   const stateNavList = []
@@ -25,8 +24,6 @@ const DataPage = ({ data }) => {
         content={data.dataPreamble.content.childMarkdownRemark.html}
         id={data.dataPreamble.contentful_id}
       />
-
-      <DailyTweet />
       <DownloadDataRow
         slug="all-states"
         lastUpdateEt={data.lastUpdate.nodes[0].date}


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Removes daily tweet from data page