### PR TITLE
fix: Wrong history link

### DIFF
--- a/src/components/pages/data/long-term-care/download-links.js
+++ b/src/components/pages/data/long-term-care/download-links.js
@@ -39,7 +39,9 @@ const DataLongTermCareLinks = () => (
         >
           Download state notes
         </CtaAnchorLink>
-        <CtaLink to="/nursing-homes/history">View historical totals</CtaLink>
+        <CtaLink to="/nursing-homes-long-term-care-facilities/history">
+          View historical totals
+        </CtaLink>
         <CtaAnchorLink
           href="https://docs.google.com/spreadsheets/d/e/2PACX-1vRa9HnmEl83YXHfbgSPpt0fJe4SyuYLc0GuBAglF4yMYaoKSPRCyXASaWXMrTu1WEYp1oeJZIYHpj7t/pubhtml"
           block
@@ -48,7 +50,7 @@ const DataLongTermCareLinks = () => (
         </CtaAnchorLink>
         <p className={linksStyle.contact}>
           Do you have information about a long-term-care facility?{' '}
-          <Link to="/nursing-homes/contact">
+          <Link to="/nursing-homes-long-term-care-facilities/contact">
             We would love to hear from you
           </Link>
           .

--- a/static/_redirects
+++ b/static/_redirects
@@ -45,3 +45,4 @@
 /data/long-term-care                          /nursing-homes-long-term-care-facilities
 /data/long-term-care/contact                  /nursing-homes-long-term-care-facilities/contact
 /data/long-term-care/history                  /nursing-homes-long-term-care-facilities/history
+/nursing-homes/history                        /nursing-homes-long-term-care-facilities/history


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Fixes history link for LTC