### PR TITLE
fix(crdt-historical): remove empty table rows

### DIFF
--- a/src/components/pages/state/race-ethnicity/filtered-notice.js
+++ b/src/components/pages/state/race-ethnicity/filtered-notice.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import Alert from '~components/common/alert'
+import { FormatDate } from '~components/utils/format'
+
+const FilteredNotice = ({ earliestDay, currentMetric, stateName }) => {
+  return (
+    <Alert>
+      Prior to <FormatDate date={earliestDay.Date} format="LLLL d, yyyy" />,{' '}
+      {stateName} did not report race/ethnicity data for{' '}
+      {currentMetric.toLowerCase()}.
+    </Alert>
+  )
+}
+
+export default FilteredNotice


### PR DESCRIPTION
* removes empty table rows from states that began reporting late
* adds a `FilteredNotice` component to indicate the omission to users

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
