### PR TITLE
chore: Add date to LTC preamble

### DIFF
--- a/src/components/pages/state/long-term-care/preamble.js
+++ b/src/components/pages/state/long-term-care/preamble.js
@@ -3,6 +3,8 @@ import { Link } from 'gatsby'
 import OverviewWrapper from '~components/common/overview-wrapper'
 import LongTermCareOverview from './overview'
 import downloadDataStyles from '../download-data.module.scss'
+import longTermCarePreambleStyle from './preamble.module.scss'
+import { FormatDate } from '~components/utils/format'
 
 const LongTermCarePreamble = ({
   state,
@@ -24,8 +26,14 @@ const LongTermCarePreamble = ({
         overview={overview}
         stateSlug={stateSlug}
       />
-      <div className={downloadDataStyles.container}>
+      <div className={longTermCarePreambleStyle.container}>
         <p>
+          <span>
+            Last updated{' '}
+            <strong>
+              <FormatDate date={overview.date} format="LLLL d, yyyy" />
+            </strong>
+          </span>
           <a
             href="https://github.com/COVID19Tracking/long-term-care-data/blob/master/state_overview.csv"
             className={downloadDataStyles.button}

--- a/src/components/pages/state/long-term-care/preamble.module.scss
+++ b/src/components/pages/state/long-term-care/preamble.module.scss
@@ -6,7 +6,8 @@
     justify-content: right;
   }
   p {
-    margin: 1rem 0 0;
+    @include margin(16, top);
+    margin-bottom: 0;
     > span {
       margin-right: 1rem;
       display: inline-block;

--- a/src/components/pages/state/long-term-care/preamble.module.scss
+++ b/src/components/pages/state/long-term-care/preamble.module.scss
@@ -1,0 +1,15 @@
+.container {
+  display: flex;
+  align-items: center;
+  justify-content: left;
+  @media (min-width: $viewport-lg) {
+    justify-content: right;
+  }
+  p {
+    margin: 1rem 0 0;
+    > span {
+      margin-right: 1rem;
+      display: inline-block;
+    }
+  }
+}


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Adds last updated date to LTC state pages