### PR TITLE
feat: Add new HHS testing card

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -322,6 +322,13 @@ const gatsbyConfig = {
     {
       resolve: 'gatsby-source-covid-tracking-api',
       options: {
+        file: './_data/hhs_testing_config.json',
+        type: 'hhsTestingConfig',
+      },
+    },
+    {
+      resolve: 'gatsby-source-covid-tracking-api',
+      options: {
         file: './_data/hhs_hospitalization.json',
         type: 'hhsHospitals',
         transformItems: items => {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -308,6 +308,13 @@ const gatsbyConfig = {
     {
       resolve: 'gatsby-source-covid-tracking-api',
       options: {
+        file: './_data/hhs_testing.json',
+        type: 'hhsTesting',
+      },
+    },
+    {
+      resolve: 'gatsby-source-covid-tracking-api',
+      options: {
         file: './_data/hhs_hospitalization.json',
         type: 'hhsHospitals',
         transformItems: items => {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -315,6 +315,13 @@ const gatsbyConfig = {
     {
       resolve: 'gatsby-source-covid-tracking-api',
       options: {
+        file: './_data/hhs_testing_notes.json',
+        type: 'hhsTestingNotes',
+      },
+    },
+    {
+      resolve: 'gatsby-source-covid-tracking-api',
+      options: {
         file: './_data/hhs_hospitalization.json',
         type: 'hhsHospitals',
         transformItems: items => {

--- a/src/components/charts/line-chart.js
+++ b/src/components/charts/line-chart.js
@@ -44,7 +44,6 @@ const LineChart = ({
   const [timeoutRef, setTimeoutRef] = useState(null)
 
   const hover = (event, dataLine) => {
-    console.log(dataLine) // todo get current date's info
     // Ensure that tooltip doesn't flash when transitioning between bars
     if (timeoutRef) {
       clearTimeout(timeoutRef)
@@ -52,7 +51,6 @@ const LineChart = ({
     const isTouchEvent = !event.clientX
     const eventX = isTouchEvent ? event.touches[0].clientX : event.clientX
     const eventY = isTouchEvent ? event.touches[0].clientY : event.clientY
-    console.log(eventX, eventY)
 
     setTooltip({
       top: isTouchEvent ? eventY - 130 : eventY + 10,

--- a/src/components/pages/data/cards/hhs-tests-viral.js
+++ b/src/components/pages/data/cards/hhs-tests-viral.js
@@ -1,14 +1,34 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import { Card, CardNote, CardBody } from '~components/common/card'
-import { Statistic } from '~components/common/statistic'
+import { Statistic, DefinitionLink } from '~components/common/statistic'
+import { AnnotationPanelContext, AnnotationButton } from './definitions-panel'
 import LastUpdatedLabel from './last-updated-label'
 
-const TestsHHSViralcard = ({ hhsTesting }) => {
+const TestsHHSViralcard = ({ hhsTesting, notes }) => {
+  const annotationContext = useContext(AnnotationPanelContext)
   return (
     <Card title="Viral (PCR) tests (HHS data)">
       <CardBody>
         <Statistic title="Total tests" value={hhsTesting.total} />
         <Statistic title="Positive tests" value={hhsTesting.positive} />
+        {notes.notes && (
+          <AnnotationButton field="Total Tests (PCR)">
+            <DefinitionLink
+              onDefinitionsToggle={() => {
+                annotationContext.setCardAnnotations({
+                  fields: ['Viral (PCR) tests (HHS data)'],
+                  highlight: 'Viral (PCR) tests (HHS data)',
+                })
+              }}
+              title="Warning"
+            />
+          </AnnotationButton>
+        )}
+        {notes.sourceNotes && (
+          <CardNote>
+            <strong>Source:</strong> {notes.sourceNotes}
+          </CardNote>
+        )}
         <CardNote>
           This data is{' '}
           <a href="https://healthdata.gov/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state">

--- a/src/components/pages/data/cards/hhs-tests-viral.js
+++ b/src/components/pages/data/cards/hhs-tests-viral.js
@@ -11,7 +11,7 @@ const TestsHHSViralcard = ({ hhsTesting, notes }) => {
     <Card title="Viral (PCR) tests (HHS data)">
       <CardBody>
         <Statistic title="Total tests" value={hhsTesting.total} />
-        <Statistic title="Positive tests" value={hhsTesting.positive} />
+        {/* <Statistic title="Positive tests" value={hhsTesting.positive} /> */}
         {notes.notes && (
           <DefinitionLink
             onDefinitionsToggle={() => {

--- a/src/components/pages/data/cards/hhs-tests-viral.js
+++ b/src/components/pages/data/cards/hhs-tests-viral.js
@@ -11,7 +11,6 @@ const TestsHHSViralcard = ({ hhsTesting, notes }) => {
     <Card title="Viral (PCR) tests (HHS data)">
       <CardBody>
         <Statistic title="Total tests" value={hhsTesting.total} />
-        {/* <Statistic title="Positive tests" value={hhsTesting.positive} /> */}
         {notes.notes && (
           <DefinitionLink
             onDefinitionsToggle={() => {

--- a/src/components/pages/data/cards/hhs-tests-viral.js
+++ b/src/components/pages/data/cards/hhs-tests-viral.js
@@ -7,7 +7,6 @@ import LastUpdatedLabel from './last-updated-label'
 
 const TestsHHSViralcard = ({ hhsTesting, notes }) => {
   const annotationContext = useContext(AnnotationPanelContext)
-  console.log(notes)
   return (
     <Card title="Viral (PCR) tests (HHS data)">
       <CardBody>

--- a/src/components/pages/data/cards/hhs-tests-viral.js
+++ b/src/components/pages/data/cards/hhs-tests-viral.js
@@ -1,4 +1,5 @@
 import React, { useContext } from 'react'
+import { Link } from 'gatsby'
 import { Card, CardNote, CardBody } from '~components/common/card'
 import { Statistic, DefinitionLink } from '~components/common/statistic'
 import { AnnotationPanelContext, AnnotationButton } from './definitions-panel'
@@ -34,6 +35,10 @@ const TestsHHSViralcard = ({ hhsTesting, notes }) => {
           <a href="https://healthdata.gov/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state">
             published by HHS
           </a>
+          . It{' '}
+          <Link to="/analysis-updates/federal-testing-datas-last-mile">
+            may differ from state-provided data
+          </Link>
           .
         </CardNote>
         <LastUpdatedLabel date={hhsTesting.date} />

--- a/src/components/pages/data/cards/hhs-tests-viral.js
+++ b/src/components/pages/data/cards/hhs-tests-viral.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Card, CardNote, CardBody } from '~components/common/card'
+import { Statistic } from '~components/common/statistic'
+import LastUpdatedLabel from './last-updated-label'
+
+const TestsHHSViralcard = ({ hhsTesting }) => {
+  return (
+    <Card title="Viral (PCR) tests (HHS data)">
+      <CardBody>
+        <Statistic title="Total tests" value={hhsTesting.total} />
+        <Statistic title="Positive tests" value={hhsTesting.positive} />
+        <CardNote>
+          This data is{' '}
+          <a href="https://healthdata.gov/dataset/covid-19-reported-patient-impact-and-hospital-capacity-state">
+            published by HHS
+          </a>
+          .
+        </CardNote>
+        <LastUpdatedLabel date={hhsTesting.date} />
+      </CardBody>
+    </Card>
+  )
+}
+
+export default TestsHHSViralcard

--- a/src/components/pages/data/cards/hhs-tests-viral.js
+++ b/src/components/pages/data/cards/hhs-tests-viral.js
@@ -2,28 +2,27 @@ import React, { useContext } from 'react'
 import { Link } from 'gatsby'
 import { Card, CardNote, CardBody } from '~components/common/card'
 import { Statistic, DefinitionLink } from '~components/common/statistic'
-import { AnnotationPanelContext, AnnotationButton } from './definitions-panel'
+import { AnnotationPanelContext } from './definitions-panel'
 import LastUpdatedLabel from './last-updated-label'
 
 const TestsHHSViralcard = ({ hhsTesting, notes }) => {
   const annotationContext = useContext(AnnotationPanelContext)
+  console.log(notes)
   return (
     <Card title="Viral (PCR) tests (HHS data)">
       <CardBody>
         <Statistic title="Total tests" value={hhsTesting.total} />
         <Statistic title="Positive tests" value={hhsTesting.positive} />
         {notes.notes && (
-          <AnnotationButton field="Total Tests (PCR)">
-            <DefinitionLink
-              onDefinitionsToggle={() => {
-                annotationContext.setCardAnnotations({
-                  fields: ['Viral (PCR) tests (HHS data)'],
-                  highlight: 'Viral (PCR) tests (HHS data)',
-                })
-              }}
-              title="Warning"
-            />
-          </AnnotationButton>
+          <DefinitionLink
+            onDefinitionsToggle={() => {
+              annotationContext.setCardAnnotations({
+                fields: ['Viral (PCR) tests (HHS data)'],
+                highlight: 'Viral (PCR) tests (HHS data)',
+              })
+            }}
+            title="Warning"
+          />
         )}
         {notes.sourceNotes && (
           <CardNote>

--- a/src/components/pages/data/state-data.js
+++ b/src/components/pages/data/state-data.js
@@ -35,6 +35,7 @@ const State = ({ state, metadata }) => {
         hhsHospitalization={state.hhsHospitalization}
         ltcFedVaccinations={state.ltcFedVaccinations}
         hhsTesting={state.hhsTesting}
+        hhsTestingNotes={state.hhsTestingNotes}
       />
 
       <a

--- a/src/components/pages/data/state-data.js
+++ b/src/components/pages/data/state-data.js
@@ -34,6 +34,7 @@ const State = ({ state, metadata }) => {
         annotations={state.annotations}
         hhsHospitalization={state.hhsHospitalization}
         ltcFedVaccinations={state.ltcFedVaccinations}
+        hhsTesting={state.hhsTesting}
       />
 
       <a

--- a/src/components/pages/data/states.js
+++ b/src/components/pages/data/states.js
@@ -14,6 +14,7 @@ const States = ({
   hhsHospitalization,
   ltcFedVaccinations,
   hhsTesting,
+  hhsTestingNotes,
 }) => {
   const stateList = []
 
@@ -65,6 +66,9 @@ const States = ({
       : false
     state.hhsTesting = hhsTesting
       ? hhsTesting.find(record => record.state === state.state)
+      : false
+    state.hhsTestingNotes = hhsTestingNotes
+      ? hhsTestingNotes.find(record => record.state === state.state)
       : false
 
     stateList.push(state)

--- a/src/components/pages/data/states.js
+++ b/src/components/pages/data/states.js
@@ -13,6 +13,7 @@ const States = ({
   raceDataSeparate,
   hhsHospitalization,
   ltcFedVaccinations,
+  hhsTesting,
 }) => {
   const stateList = []
 
@@ -61,6 +62,9 @@ const States = ({
 
     state.ltcFedVaccinations = ltcFedVaccinations
       ? ltcFedVaccinations.find(record => record.Location === state.state)
+      : false
+    state.hhsTesting = hhsTesting
+      ? hhsTesting.find(record => record.state === state.state)
       : false
 
     stateList.push(state)

--- a/src/components/pages/data/summary.js
+++ b/src/components/pages/data/summary.js
@@ -56,6 +56,7 @@ const StateSummary = ({
   hhsHospitalization,
   ltcFedVaccinations,
   hhsTesting,
+  hhsTestingNotes,
   annotations = false,
   national = false,
 }) => {
@@ -231,6 +232,18 @@ const StateSummary = ({
   if (annotations !== false) {
     addMetricTextDefinitions(definitions, annotations)
   }
+  if (
+    hhsTestingNotes &&
+    hhsTestingNotes.notes &&
+    !annotations.find(
+      annotation => annotation.field === 'Viral (PCR) tests (HHS data)',
+    )
+  ) {
+    annotations.push({
+      field: 'Viral (PCR) tests (HHS data)',
+      warning: hhsTestingNotes.notes,
+    })
+  }
 
   return (
     <DefinitionPanelContext.Provider
@@ -331,6 +344,7 @@ const StateSummary = ({
                     stateSlug={stateSlug}
                     stateName={stateName}
                     hhsTesting={hhsTesting}
+                    notes={hhsTestingNotes}
                   />
                 )}
                 <TestsAntigenCard

--- a/src/components/pages/data/summary.js
+++ b/src/components/pages/data/summary.js
@@ -13,6 +13,7 @@ import CasesCard from './cards/cases-card'
 import HospitalizationCard from './cards/hospitalization-card'
 import OutcomesCard from './cards/outcomes-card'
 import TestsAntibodyCard from './cards/tests-antibody'
+import TestsHHSViralcard from './cards/hhs-tests-viral'
 import TestsAntigenCard from './cards/tests-antigen'
 import TestsViralCard from './cards/tests-viral'
 import NationalTestsCard from './cards/tests-national'
@@ -54,6 +55,7 @@ const StateSummary = ({
   raceData,
   hhsHospitalization,
   ltcFedVaccinations,
+  hhsTesting,
   annotations = false,
   national = false,
 }) => {
@@ -324,6 +326,13 @@ const StateSummary = ({
                   unknownUnits={metadata && metadata.testUnitsUnknown}
                   annotations={annotations}
                 />
+                {hhsTesting && (
+                  <TestsHHSViralcard
+                    stateSlug={stateSlug}
+                    stateName={stateName}
+                    hhsTesting={hhsTesting}
+                  />
+                )}
                 <TestsAntigenCard
                   stateSlug={stateSlug}
                   stateName={stateName}

--- a/src/components/pages/data/summary.js
+++ b/src/components/pages/data/summary.js
@@ -73,6 +73,7 @@ const StateSummary = ({
   const {
     allContentfulDataDefinition,
     nationalSummaryFootnote,
+    hhsTestingConfig,
   } = useStaticQuery(graphql`
     {
       allContentfulDataDefinition {
@@ -94,6 +95,10 @@ const StateSummary = ({
             html
           }
         }
+      }
+
+      hhsTestingConfig(description: { eq: "Community Profile Report" }) {
+        file
       }
     }
   `)
@@ -241,7 +246,15 @@ const StateSummary = ({
   ) {
     annotations.push({
       field: 'Viral (PCR) tests (HHS data)',
-      warning: hhsTestingNotes.notes,
+      warning: (
+        <>
+          <p>{hhsTestingNotes.notes}</p>
+          <p>
+            Sourced from the{' '}
+            <a href={hhsTestingConfig.file}>Community Profile Report</a>.
+          </p>
+        </>
+      ),
     })
   }
 

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -53,6 +53,7 @@ const DataPage = ({ data }) => {
         hhsHospitalization={data.allHhsHospitals.nodes}
         ltcFedVaccinations={data.allLtcFedVaccinations.nodes}
         hhsTesting={data.allHhsTesting.nodes}
+        hhsTestingNotes={data.allHhsTestingNotes.nodes}
       />
     </Layout>
   )
@@ -299,6 +300,13 @@ export const query = graphql`
         date
         positive
         total
+      }
+    }
+    allHhsTestingNotes {
+      nodes {
+        state
+        sourceNotes
+        notes
       }
     }
     allLtcFedVaccinations {

--- a/src/pages/data/index.js
+++ b/src/pages/data/index.js
@@ -52,6 +52,7 @@ const DataPage = ({ data }) => {
         raceDataSeparate={data.allCovidRaceDataSeparate.nodes}
         hhsHospitalization={data.allHhsHospitals.nodes}
         ltcFedVaccinations={data.allLtcFedVaccinations.nodes}
+        hhsTesting={data.allHhsTesting.nodes}
       />
     </Layout>
   )
@@ -290,6 +291,14 @@ export const query = graphql`
         staffed_icu_adult_patients_confirmed_and_suspected_covid
         total_adult_patients_hospitalized_confirmed_covid
         total_pediatric_patients_hospitalized_confirmed_covid
+      }
+    }
+    allHhsTesting {
+      nodes {
+        state
+        date
+        positive
+        total
       }
     }
     allLtcFedVaccinations {

--- a/src/templates/state/index.js
+++ b/src/templates/state/index.js
@@ -36,6 +36,7 @@ const StateTemplate = ({ pageContext, data, path }) => {
     covidGradeExcludedStates,
     assessmentDate,
     hhsTesting,
+    hhsTestingNotes,
   } = data
   return (
     <Layout
@@ -83,6 +84,7 @@ const StateTemplate = ({ pageContext, data, path }) => {
           hhsHospitalization={hhsHospitals}
           ltcFedVaccinations={ltcFedVaccinations}
           hhsTesting={hhsTesting}
+          hhsTestingNotes={hhsTestingNotes}
         />
         <StateTweets
           tweets={allTweets}
@@ -343,6 +345,10 @@ export const query = graphql`
       date
       positive
       total
+    }
+    hhsTestingNotes(state: { eq: $state }) {
+      sourceNotes
+      notes
     }
     covidGradeStateAssessment(state: { eq: $state }) {
       taco

--- a/src/templates/state/index.js
+++ b/src/templates/state/index.js
@@ -35,6 +35,7 @@ const StateTemplate = ({ pageContext, data, path }) => {
     ltcFedVaccinations,
     covidGradeExcludedStates,
     assessmentDate,
+    hhsTesting,
   } = data
   return (
     <Layout
@@ -81,6 +82,7 @@ const StateTemplate = ({ pageContext, data, path }) => {
           longTermCare={data.covidStateInfo.childLtc}
           hhsHospitalization={hhsHospitals}
           ltcFedVaccinations={ltcFedVaccinations}
+          hhsTesting={hhsTesting}
         />
         <StateTweets
           tweets={allTweets}
@@ -336,6 +338,11 @@ export const query = graphql`
       staffed_icu_adult_patients_confirmed_and_suspected_covid
       total_adult_patients_hospitalized_confirmed_covid
       total_pediatric_patients_hospitalized_confirmed_covid
+    }
+    hhsTesting(state: { eq: $state }) {
+      date
+      positive
+      total
     }
     covidGradeStateAssessment(state: { eq: $state }) {
       taco


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds new `hhsTesting` data source
- Adds a new HHS Testing card