### PR TITLE
feat: Add markdown support for captions

### DIFF
--- a/src/components/pages/blog/blog-content.js
+++ b/src/components/pages/blog/blog-content.js
@@ -86,9 +86,14 @@ const BlogContent = ({ content }) => {
             fullWidthMobile,
             imageLink,
           } = target
+          const longCaption =
+            target.childContentfulContentBlockImageLongCaptionTextNode &&
+            target.childContentfulContentBlockImageLongCaptionTextNode
+              .childMarkdownRemark.rawMarkdownBody
           return (
             <ImageContentBlock
               image={image}
+              longCaption={longCaption}
               caption={caption}
               keepSize={keepSize}
               fullWidthMobile={fullWidthMobile}

--- a/src/components/pages/blog/content-blocks/image-content-block.js
+++ b/src/components/pages/blog/content-blocks/image-content-block.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import classnames from 'classnames'
 import Img from 'gatsby-image'
+import marked from 'marked'
 import ImageCredit from '~components/common/image-credit'
 import imageContentBlockStyles from './image-content-block.module.scss'
 
@@ -56,7 +57,7 @@ const ImageContentBlock = ({
       <ImageBlock image={image} imageUrl={imageUrl} keepSize={keepSize} />
     )}
 
-    {caption && <ImageCredit>{caption}</ImageCredit>}
+    {caption && <ImageCredit>{marked.inlineLexer(caption, [])}</ImageCredit>}
   </div>
 )
 

--- a/src/components/pages/blog/content-blocks/image-content-block.js
+++ b/src/components/pages/blog/content-blocks/image-content-block.js
@@ -28,6 +28,7 @@ const ImageContentBlock = ({
   caption,
   image,
   className,
+  longCaption = false,
   keepSize = false,
   fullWidthMobile = false,
   imageUrl,
@@ -57,7 +58,16 @@ const ImageContentBlock = ({
       <ImageBlock image={image} imageUrl={imageUrl} keepSize={keepSize} />
     )}
 
-    {caption && <ImageCredit>{marked.inlineLexer(caption, [])}</ImageCredit>}
+    {caption && !longCaption && <ImageCredit>{caption}</ImageCredit>}
+    {longCaption && (
+      <ImageCredit>
+        <div
+          dangerouslySetInnerHTML={{
+            __html: marked.inlineLexer(longCaption, []),
+          }}
+        />
+      </ImageCredit>
+    )}
   </div>
 )
 

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -207,6 +207,11 @@ export const query = graphql`
             fullWidthMobile
             caption
             imageLink
+            childContentfulContentBlockImageLongCaptionTextNode {
+              childMarkdownRemark {
+                rawMarkdownBody
+              }
+            }
             image {
               file {
                 url


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds markdown support for a new "Long caption" field in image blocks.