### PR TITLE
chore: Fix map context in HHS map

### DIFF
--- a/src/components/pages/data/hhs-facilities/map/legend.js
+++ b/src/components/pages/data/hhs-facilities/map/legend.js
@@ -2,37 +2,26 @@ import React from 'react'
 import { DateTime } from 'luxon'
 import { FormatDate } from '~components/utils/format'
 import Container from '~components/common/container'
+import LayerToggle from '~components/common/map/layer-toggle'
 import { Row, Col } from '~components/common/grid'
 import legendStyles from './legend.module.scss'
 
-const Legend = ({ mapLayer, setLayer, date }) => (
+const Legend = ({ mapLayer, date }) => (
   <Container>
     <Row className={legendStyles.wrapper}>
       <Col width={[4, 6, 6]} paddingRight={[0, 0, 0]}>
-        <div
-          className={legendStyles.toggle}
-          role="group"
-          aria-label="Toggle map layers"
-        >
-          <button
-            className={mapLayer === 'patients' && legendStyles.active}
-            type="button"
-            onClick={() => {
-              setLayer('patients')
-            }}
-          >
-            All inpatients
-          </button>
-          <button
-            className={mapLayer === 'icu' && legendStyles.active}
-            type="button"
-            onClick={() => {
-              setLayer('icu')
-            }}
-          >
-            ICU patients
-          </button>
-        </div>
+        <LayerToggle
+          layers={[
+            {
+              id: 'patients',
+              name: 'All inpatients',
+            },
+            {
+              id: 'icu',
+              name: 'ICU inpatients',
+            },
+          ]}
+        />
         <p className={legendStyles.dates}>
           {date ? (
             <>


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Fixes map context toggle in HHS map