### PR TITLE
chore: Add nesting to TOC

### DIFF
--- a/src/__tests__/components/common/__snapshots__/table-of-contents.js.snap
+++ b/src/__tests__/components/common/__snapshots__/table-of-contents.js.snap
@@ -8,14 +8,16 @@ exports[`Components : Common: Table of Contents renders correctly 1`] = `
     Table of contents
   </h2>
   <ul>
-    <li>
-      <a
-        href="#a"
-      >
+    <li
+      className={false}
+    >
+      <strong>
         A
-      </a>
+      </strong>
     </li>
-    <li>
+    <li
+      className="subItem"
+    >
       <a
         href="#b"
       >

--- a/src/__tests__/components/common/table-of-contents.js
+++ b/src/__tests__/components/common/table-of-contents.js
@@ -8,8 +8,8 @@ describe('Components : Common: Table of Contents', () => {
       .create(
         <TableOfContents
           headings={[
-            { id: 'a', value: 'A' },
-            { id: 'b', value: 'B' },
+            { id: 'a', value: 'A', depth: 1 },
+            { id: 'b', value: 'B', depth: 2 },
           ]}
         />,
       )

--- a/src/components/common/table-of-contents.js
+++ b/src/components/common/table-of-contents.js
@@ -6,8 +6,15 @@ const TableOfContents = ({ headings }) => (
     <h2>Table of contents</h2>
     <ul>
       {headings.map(heading => (
-        <li key={`toc-${heading.id}`}>
-          <a href={`#${heading.id}`}>{heading.value}</a>
+        <li
+          key={`toc-${heading.id}`}
+          className={heading.depth > 1 && tocStyle.subItem}
+        >
+          {heading.depth === 1 ? (
+            <strong>{heading.value}</strong>
+          ) : (
+            <a href={`#${heading.id}`}>{heading.value}</a>
+          )}
         </li>
       ))}
     </ul>

--- a/src/components/common/table-of-contents.module.scss
+++ b/src/components/common/table-of-contents.module.scss
@@ -12,6 +12,9 @@
     margin-bottom: 0;
     li {
       @include margin(16, bottom);
+      &.sub-item {
+        @include margin(32, left);
+      }
       &:last-child {
         margin-bottom: 0;
       }

--- a/src/templates/content.js
+++ b/src/templates/content.js
@@ -50,9 +50,10 @@ export const query = graphql`
       body {
         childMarkdownRemark {
           html
-          headings(depth: h2) {
+          headings {
             id
             value
+            depth
           }
         }
       }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Adds support for h1 in TOCs. Fixes #1337