### PR TITLE
chore: Add mapbox facility list

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -252,13 +252,6 @@ const gatsbyConfig = {
     {
       resolve: 'gatsby-source-covid-tracking-api',
       options: {
-        file: './_data/long_term_care_facilities.json',
-        type: 'CovidLtcFacilities',
-      },
-    },
-    {
-      resolve: 'gatsby-source-covid-tracking-api',
-      options: {
         file: './_data/advocacy_governors.json',
         type: 'civilServiceGovernor',
       },

--- a/src/components/pages/data/long-term-care/map/index.js
+++ b/src/components/pages/data/long-term-care/map/index.js
@@ -18,6 +18,7 @@ const LTCFacilitiesMap = ({
   state = false,
   removeSidebar = false,
   button = false,
+  listFacilities = false,
 }) => {
   mapboxgl.accessToken = process.env.GATSBY_MAPBOX_API_TOKEN
   const [activeFacility, setActiveFacility] = useState(false)
@@ -127,6 +128,11 @@ const LTCFacilitiesMap = ({
         layers.forEach(layer => {
           map.setFilter(layer, ['==', ['get', 'state'], state])
         })
+        listFacilities(
+          map.queryRenderedFeatures({
+            layers,
+          }),
+        )
       }
 
       if (window.location.hash && hash.length > 2) {

--- a/src/components/pages/state/long-term-care/chart.js
+++ b/src/components/pages/state/long-term-care/chart.js
@@ -2,22 +2,9 @@ import React from 'react'
 import { DateTime } from 'luxon'
 import { Row, Col } from '~components/common/grid'
 import LineChart from '~components/charts/line-chart'
-import TooltipContents from '~components/charts/tooltip-contents'
 import colors from '~scss/colors.module.scss'
 import chartStyles from './chart.module.scss'
 import Alert from '~components/common/alert'
-
-const makeRenderTooltipContents = text => d => (
-  <TooltipContents
-    date={d.date}
-    items={[
-      {
-        text: <>{text}</>,
-        value: d.value,
-      },
-    ]}
-  />
-)
 
 const chartProps = {
   height: 180, // these control the dimensions used to render the svg but not the final size
@@ -71,7 +58,6 @@ const LongTermCareCharts = ({ data }) => {
                   data: caseData,
                 },
               ]}
-              renderTooltipContents={makeRenderTooltipContents('Cases')}
               {...chartProps}
             />
           ) : (
@@ -90,7 +76,6 @@ const LongTermCareCharts = ({ data }) => {
                   data: deathData,
                 },
               ]}
-              renderTooltipContents={makeRenderTooltipContents('Deaths')}
               {...chartProps}
             />
           ) : (

--- a/src/components/pages/state/long-term-care/facilities.js
+++ b/src/components/pages/state/long-term-care/facilities.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-param-reassign */
+/* eslint-disable */
 import React, { useState, useEffect } from 'react'
 import slugify from 'slugify'
 import { Link } from 'gatsby'
@@ -106,152 +106,34 @@ const FacilityDetails = ({ stateSlug, facility, facilityId }) => (
   </div>
 )
 
-const SearchForm = ({ hasFacilities, setSearchQuery }) => {
-  const [search, setSearch] = useState(false)
-  return (
-    <Form
-      onSubmit={event => {
-        const query = search.trim().toLowerCase()
-        event.preventDefault()
-        setSearchQuery(query.length ? query : false)
-      }}
-      noMargin
-    >
-      <Row>
-        <Col width={[3, 3, 8]}>
-          <Input
-            type="text"
-            label="Search facilities"
-            placeholder={
-              hasFacilities
-                ? 'Search by city, county, or facility name'
-                : 'Facility information not reported'
-            }
-            diabled={!hasFacilities}
-            hideLabel
-            onChange={event => {
-              setSearch(event.target.value)
-            }}
-          />
-        </Col>
-        <Col width={[1, 3, 4]}>
-          <button className={facilitiesStyles.searchButton} type="submit">
-            Search
-          </button>
-        </Col>
-      </Row>
-    </Form>
-  )
-}
-
-const probableFields = {
-  resident_positives: 'resident_probable',
-  resident_deaths: 'resident_probable_deaths',
-  outbreak_resident: 'outbreak_resident_probable',
-  outbreak_resident_deaths: 'outbreak_resident_probable_deaths',
-  resident_staff_deaths: 'resident_staff_probable_deaths',
-}
-
-const LongTermCareFacilities = ({ stateSlug, stateAbbr, facilities }) => {
-  const [sort, setSort] = useState({ field: 'facility_name', desc: false })
-  const [searchQuery, setSearchQuery] = useState(false)
+const LongTermCareFacilities = ({ stateSlug, stateAbbr }) => {
   const [openedFacility, setOpenedFacility] = useState(false)
   const [openedFacilityId, setOpenedFacilityId] = useState(false)
-  const [facilityList, setFacilityList] = useState(
-    facilities
-      .map(group => group.nodes[0])
-      .map(facility => {
-        Object.keys(probableFields).forEach(field => {
-          if (
-            facility[probableFields[field]] &&
-            !Number.isNaN(facility[field]) &&
-            !Number.isNaN(facility[probableFields[field]])
-          ) {
-            facility[field] =
-              parseInt(facility[field], 10) +
-              parseInt(facility[probableFields[field]], 10)
-          }
-        })
-        return facility
-      })
-      .sort((a, b) => (a.facility_name > b.facility_name ? -1 : 1)),
-  )
-
-  const hasCity =
-    facilities.map(group => group.nodes[0]).filter(({ city }) => city).length >
-    0
-  const hasCounty =
-    facilities.map(group => group.nodes[0]).filter(({ county }) => county)
-      .length > 0
-
-  const hasResidentData =
-    facilities
-      .map(group => group.nodes[0])
-      .filter(
-        item =>
-          item.outbreak_resident_positives ||
-          item.outbreak_resident_deaths ||
-          item.resident_positives ||
-          item.resident_deaths,
-      ).length > 0
+  const [facilityList, setFacilityList] = useState([])
+  const [hasCity, setHasCity] = useState(false)
+  const [hasCounty, setHasCounty] = useState(false)
+  const [hasResidentData, setHasResidentData] = useState(false)
 
   useEffect(() => {
-    const list = facilities
-      .map(group => group.nodes[0])
-      .sort((a, b) => {
-        if (
-          [
-            'resident_positives',
-            'resident_deaths',
-            'outbreak_resident_positives',
-            'outbreak_resident_deaths',
-          ].indexOf(sort.field) > -1
-        ) {
-          if (getNumber(a[sort.field]) === getNumber(b[sort.field])) {
-            return 0
-          }
-          if (getNumber(a[sort.field]) < getNumber(b[sort.field])) {
-            return sort.desc ? 1 : -1
-          }
-          return sort.desc ? -1 : 1
-        }
-        if (a[sort.field] === b[sort.field]) {
-          return 0
-        }
-        if (a[sort.field] < b[sort.field]) {
-          return sort.desc ? 1 : -1
-        }
-        return sort.desc ? -1 : 1
-      })
-      .filter(facility => {
-        if (!searchQuery) {
-          return true
-        }
-        return (
-          facility.facility_name.toLowerCase().search(searchQuery) > -1 ||
-          (facility.county &&
-            facility.county.toLowerCase().search(searchQuery) > -1) ||
-          (facility.city &&
-            facility.city.toLowerCase().search(searchQuery) > -1)
-        )
-      })
-    setFacilityList(list)
-  }, [sort, searchQuery])
+    setHasCity(
+      facilityList.filter(({ properties }) => properties.city).length > 0,
+    )
 
-  const handleSortClick = field => {
-    const desc = sort.field === field ? !sort.desc : true
-    setSort({
-      field,
-      desc,
-    })
-  }
+    setHasCounty(
+      facilityList.filter(({ properties }) => properties.county).length > 0,
+    )
 
-  const sortDirection = field => {
-    if (sort.field === field) {
-      return sort.desc ? 'up' : 'down'
-    }
-    return null
-  }
+    setHasResidentData(
+      facilityList.filter(
+        item =>
+          item.properties.outbreak_resident_positives ||
+          item.properties.outbreak_resident_deaths ||
+          item.properties.resident_positives ||
+          item.properties.resident_deaths,
+      ).length > 0,
+    )
+  }, [facilityList])
+
   const stateCenter = stateCenters.find(center => center.state === stateAbbr)
   return (
     <>
@@ -260,6 +142,13 @@ const LongTermCareFacilities = ({ stateSlug, stateAbbr, facilities }) => {
         zoom={stateCenter ? stateCenter.zoom : 3.5}
         removeSidebar
         state={stateAbbr}
+        listFacilities={mappedFacilities =>
+          setFacilityList(
+            mappedFacilities.sort((a, b) =>
+              a.properties.facility_name > b.properties.facility_name ? -1 : 1,
+            ),
+          )
+        }
         button={
           <Link
             className={facilitiesStyles.mapButton}
@@ -275,10 +164,6 @@ const LongTermCareFacilities = ({ stateSlug, stateAbbr, facilities }) => {
           View data as a table {}
         </DisclosureButton>
         <DisclosurePanel>
-          <SearchForm
-            hasFacilities={facilities.length > 0}
-            setSearchQuery={query => setSearchQuery(query)}
-          />
           <p>
             Do you have information about a facility on this list?{' '}
             <Link to="/nursing-homes/contact">
@@ -308,34 +193,16 @@ const LongTermCareFacilities = ({ stateSlug, stateAbbr, facilities }) => {
                   <thead>
                     <tr>
                       {hasCounty && (
-                        <Th
-                          header
-                          alignLeft
-                          sortable
-                          onClick={() => handleSortClick('county')}
-                          sortDirection={sortDirection('county')}
-                        >
+                        <Th header alignLeft>
                           County
                         </Th>
                       )}
                       {hasCity && (
-                        <Th
-                          header
-                          alignLeft
-                          sortable
-                          onClick={() => handleSortClick('city')}
-                          sortDirection={sortDirection('city')}
-                        >
+                        <Th header alignLeft>
                           City
                         </Th>
                       )}
-                      <Th
-                        header
-                        alignLeft
-                        sortable
-                        onClick={() => handleSortClick('facility_name')}
-                        sortDirection={sortDirection('facility_name')}
-                      >
+                      <Th header alignLeft>
                         Name
                       </Th>
                       <Th header alignLeft>
@@ -343,113 +210,34 @@ const LongTermCareFacilities = ({ stateSlug, stateAbbr, facilities }) => {
                       </Th>
                       {hasResidentData ? (
                         <>
-                          <Th
-                            header
-                            isFirst
-                            sortable
-                            onClick={() =>
-                              handleSortClick('resident_positives')
-                            }
-                            sortDirection={sortDirection('resident_positives')}
-                          >
+                          <Th header isFirst>
                             Resident positives
                           </Th>
-                          <Th
-                            header
-                            sortable
-                            onClick={() => handleSortClick('resident_deaths')}
-                            sortDirection={sortDirection('resident_deaths')}
-                          >
-                            Resident deaths
-                          </Th>
+                          <Th header>Resident deaths</Th>
 
-                          <Th
-                            header
-                            isFirst
-                            sortable
-                            onClick={() =>
-                              handleSortClick('outbreak_resident_positives')
-                            }
-                            sortDirection={sortDirection(
-                              'outbreak_resident_positives',
-                            )}
-                          >
+                          <Th header isFirst>
                             Outbreak Resident positives
                           </Th>
-                          <Th
-                            header
-                            sortable
-                            onClick={() =>
-                              handleSortClick('outbreak_resident_deaths')
-                            }
-                            sortDirection={sortDirection(
-                              'outbreak_resident_deaths',
-                            )}
-                          >
-                            Outbreak Resident deaths
-                          </Th>
+                          <Th header>Outbreak Resident deaths</Th>
                         </>
                       ) : (
                         <>
-                          <Th
-                            header
-                            isFirst
-                            sortable
-                            onClick={() =>
-                              handleSortClick('resident_staff_positives')
-                            }
-                            sortDirection={sortDirection(
-                              'resident_staff_positives',
-                            )}
-                          >
+                          <Th header isFirst>
                             Resident &amp; staff positives
                           </Th>
-                          <Th
-                            header
-                            sortable
-                            onClick={() =>
-                              handleSortClick('resident_staff_deaths')
-                            }
-                            sortDirection={sortDirection(
-                              'resident_staff_deaths',
-                            )}
-                          >
-                            Resident &amp; staff deaths
-                          </Th>
+                          <Th header>Resident &amp; staff deaths</Th>
 
-                          <Th
-                            header
-                            isFirst
-                            sortable
-                            onClick={() =>
-                              handleSortClick(
-                                'outbreak_resident_staff_positives',
-                              )
-                            }
-                            sortDirection={sortDirection(
-                              'outbreak_resident_staff_positives',
-                            )}
-                          >
+                          <Th header isFirst>
                             Outbreak Resident &amp; staff positives
                           </Th>
-                          <Th
-                            header
-                            sortable
-                            onClick={() =>
-                              handleSortClick('outbreak_resident_staff_deaths')
-                            }
-                            sortDirection={sortDirection(
-                              'outbreak_resident_staff_deaths',
-                            )}
-                          >
-                            Outbreak Resident &amp; staff deaths
-                          </Th>
+                          <Th header>Outbreak Resident &amp; staff deaths</Th>
                         </>
                       )}
                     </tr>
                   </thead>
                   <tbody>
-                    {facilityList.map(facility => {
+                    {facilityList.map(({ properties }) => {
+                      const facility = properties
                       const facilityId = slugify(
                         [
                           facility.county,
@@ -507,7 +295,7 @@ const LongTermCareFacilities = ({ stateSlug, stateAbbr, facilities }) => {
               </>
             ) : (
               <>
-                {facilities.length > 0 ? (
+                {facilityList.length > 0 ? (
                   <Alert>No facilities found. Please refine your search.</Alert>
                 ) : (
                   <Alert>Facility information not reported</Alert>

--- a/src/components/pages/state/long-term-care/facilities.js
+++ b/src/components/pages/state/long-term-care/facilities.js
@@ -132,7 +132,7 @@ const LongTermCareFacilities = ({ stateSlug, stateAbbr }) => {
         listFacilities={mappedFacilities =>
           setFacilityList(
             mappedFacilities.sort((a, b) =>
-              a.properties.facility_name > b.properties.facility_name ? -1 : 1,
+              a.properties.facility_name > b.properties.facility_name ? 1 : -1,
             ),
           )
         }

--- a/src/components/pages/state/long-term-care/facilities.js
+++ b/src/components/pages/state/long-term-care/facilities.js
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import React, { useState, useEffect } from 'react'
 import slugify from 'slugify'
 import { Link } from 'gatsby'
@@ -8,25 +7,13 @@ import {
   DisclosurePanel,
 } from '@reach/disclosure'
 import Alert from '~components/common/alert'
-import { Row, Col } from '~components/common/grid'
 import { Table, Th, Td } from '~components/common/table'
-import { Form, Input } from '~components/common/form'
 import Modal from '~components/common/modal'
 import { FormatDate } from '~components/utils/format'
 import LTCMap from '~components/pages/data/long-term-care/map'
 import facilitiesStyles from './facilities.module.scss'
 import SocialSharing from '~components/common/social-sharing'
 import stateCenters from '~data/visualization/state-centers.json'
-
-const getNumber = number => {
-  if (!number) {
-    return 0
-  }
-  if (number.search('<') > -1) {
-    return 0
-  }
-  return parseInt(number, 10)
-}
 
 const FacilityDetailRow = ({ type, cases, deaths }) => (
   <tr>

--- a/src/templates/state/long-term-care/index.js
+++ b/src/templates/state/long-term-care/index.js
@@ -28,10 +28,7 @@ export default ({ pageContext, path, data }) => {
             stateSlug={state.childSlug.slug}
             stateName={state.name}
             overview={data.covidStateInfo.childLtc.current}
-            showFacilities={
-              data.allCovidLtcFacilities.group &&
-              data.allCovidLtcFacilities.group.length > 0
-            }
+            showFacilities
           />
           <LongTermCareBarChart data={data.aggregate.nodes} />
           {data.covidLtcNotes.alerts && (
@@ -40,11 +37,7 @@ export default ({ pageContext, path, data }) => {
             </LongTermCareAlertNote>
           )}
           <h2 id="facilities">Facilities</h2>
-          <LongTermCareFacilities
-            stateSlug={slug}
-            facilities={data.allCovidLtcFacilities.group}
-            stateAbbr={state.state}
-          />
+          <LongTermCareFacilities stateSlug={slug} stateAbbr={state.state} />
           <h2 id="summary">Summary</h2>
           <LongTermCareSummaryTable
             aggregate={data.aggregate.nodes[0]}
@@ -151,35 +144,6 @@ export const query = graphql`
     covidLtcNotes(state: { eq: $state }) {
       notes
       alerts
-    }
-    allCovidLtcFacilities(
-      sort: { fields: date, order: DESC }
-      filter: { state: { eq: $state } }
-    ) {
-      group(field: facility_name, limit: 1) {
-        nodes {
-          facility_name
-          city
-          date
-          county
-          outbreak_resident_positives
-          outbreak_resident_deaths
-          outbreak_resident_staff_positives
-          outbreak_resident_staff_deaths
-          resident_deaths
-          resident_positives
-          ctp_facility_category
-          outbreak_status
-          resident_staff_positives
-          resident_staff_deaths
-          staff_deaths
-          outbreak_resident_probable
-          outbreak_resident_probable_deaths
-          resident_probable
-          resident_probable_deaths
-          resident_staff_probable_deaths
-        }
-      }
     }
   }
 `

--- a/src/utilities/schema.js
+++ b/src/utilities/schema.js
@@ -9,26 +9,6 @@ module.exports = ({ actions }) => {
       outbrkfac_other: Int
       outbrkfac_nh: Int
     }
-    type CovidLtcFacilities implements Node {
-      outbreak_resident_deaths: String
-      outbreak_resident_positives: String
-      outbreak_resident_probable: String
-      outbreak_resident_probable_deaths: String
-      outbreak_resident_staff_deaths: String
-      outbreak_resident_staff_positives: String
-      outbreak_residents_tested: String
-      outbreak_staff_deaths: String
-      outbreak_staff_positive: String
-      outbreak_staff_probable: String
-      resident_census: String
-      resident_deaths: String
-      resident_positives: String
-      resident_probable: String
-      resident_probable_deaths: String
-      resident_staff_deaths: String
-      resident_staff_positives: String
-      resident_staff_probable_deaths: String
-    }
     type CovidLtcStates implements Node {
       data_timestamp: String
       data_type: String


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Moves facility listing to mapbox as a source
- Removes broken tooltip from LTC charts