### PR TITLE
chore: Add CMS layer

### DIFF
--- a/src/components/pages/data/long-term-care/map/facility-details.js
+++ b/src/components/pages/data/long-term-care/map/facility-details.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-underscore-dangle */
 import React from 'react'
 import { graphql, useStaticQuery } from 'gatsby'
 import facilityDetailsStyle from './facility-details.module.scss'
@@ -94,7 +95,7 @@ const fields = {
   ],
 }
 
-const FacilityDetails = ({ facility, layer }) => {
+const FacilityDetails = ({ facility }) => {
   const data = useStaticQuery(graphql`
     {
       allCovidStateInfo {
@@ -112,13 +113,13 @@ const FacilityDetails = ({ facility, layer }) => {
   return (
     <>
       <h2>
-        {layer === 'cms-cases' ? (
+        {facility._layer === 'cms-facilities' ? (
           <>{facility.name}</>
         ) : (
           <>{facility.facility_name}</>
         )}
       </h2>
-      {layer === 'cms-cases' ? (
+      {facility._layer === 'cms-facilities' ? (
         <>
           <p>
             {facility.city}, {states[facility.state]}
@@ -136,7 +137,7 @@ const FacilityDetails = ({ facility, layer }) => {
       )}
 
       <dl className={facilityDetailsStyle.details}>
-        {fields[layer === 'cms-cases' ? 'cms' : 'ltc'].map(
+        {fields[facility._layer === 'cms-facilities' ? 'cms' : 'ltc'].map(
           ({ title, field }) => (
             <div key={field}>
               <dt>{title}</dt>

--- a/src/components/pages/data/long-term-care/map/infobox.js
+++ b/src/components/pages/data/long-term-care/map/infobox.js
@@ -1,4 +1,4 @@
-/* eslint-disable max-len */
+/* eslint-disable max-len,no-underscore-dangle */
 import React from 'react'
 import { graphql, useStaticQuery } from 'gatsby'
 import Infobox from '~components/common/map/infobox'
@@ -9,7 +9,7 @@ const Item = ({ title, value }) => (
   </p>
 )
 
-const LtcInfobox = ({ layer, facility, x, y }) => {
+const LtcInfobox = ({ facility, x, y }) => {
   const data = useStaticQuery(graphql`
     {
       allCovidStateInfo {
@@ -30,7 +30,7 @@ const LtcInfobox = ({ layer, facility, x, y }) => {
     facility.outbreak_resident_deaths || facility.resident_deaths
   return (
     <Infobox x={x} y={y}>
-      {layer === 'cms-cases' ? (
+      {facility._layer === 'cms-facilities' ? (
         <>
           <h3>{facility.name}</h3>
           <Item

--- a/src/components/pages/data/long-term-care/map/legend.js
+++ b/src/components/pages/data/long-term-care/map/legend.js
@@ -23,42 +23,34 @@ const Legend = ({ mapLayer }) => (
               id: 'deaths',
               name: 'Deaths',
             },
-            /* {
-              id: 'cms-cases',
-              name: 'Federal data',
-            }, */
           ]}
         />
       </Col>
       <Col width={[4, 6, 8]}>
         <div className={legendStyles.legend} aria-hidden>
-          {mapLayer === 'cms-cases' || mapLayer === 'cms-deaths' ? (
-            <div>All facilities that report to the federal government.</div>
-          ) : (
-            <>
-              {(mapLayer === 'cases' || mapLayer === 'deaths') && (
-                <>
-                  <span className={legendStyles.outbreakOnly} />
-                  State reports&nbsp;
-                  <Link to="#ltc-map-definitions">only outbreak data</Link>
-                  &nbsp;
-                  {mapLayer === 'cases' ? (
-                    <>for cases</>
-                  ) : (
-                    <>{mapLayer === 'deaths' && <>for deaths</>}</>
-                  )}{' '}
-                </>
-              )}
-              <span className={legendStyles.missing} />
-              State reports no{' '}
-              {mapLayer === 'cases' ? (
-                <>case</>
-              ) : (
-                <>{mapLayer === 'deaths' ? <>death</> : <>facility</>}</>
-              )}{' '}
-              data
-            </>
-          )}
+          <>
+            {(mapLayer === 'cases' || mapLayer === 'deaths') && (
+              <>
+                <span className={legendStyles.outbreakOnly} />
+                State reports&nbsp;
+                <Link to="#ltc-map-definitions">only outbreak data</Link>
+                &nbsp;
+                {mapLayer === 'cases' ? (
+                  <>for cases</>
+                ) : (
+                  <>{mapLayer === 'deaths' && <>for deaths</>}</>
+                )}{' '}
+              </>
+            )}
+            <span className={legendStyles.missing} />
+            State reports no{' '}
+            {mapLayer === 'cases' ? (
+              <>case</>
+            ) : (
+              <>{mapLayer === 'deaths' ? <>death</> : <>facility</>}</>
+            )}{' '}
+            data
+          </>
         </div>
       </Col>
     </Row>


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds a new CMS facility layer to the LTC map
- Support switching between LTC and CMS fields in sidebar, infobox, etc.