### PR TITLE
chore: Fix text align and put caption into tag

### DIFF
--- a/src/components/pages/blog/content-blocks/table-content-block.js
+++ b/src/components/pages/blog/content-blocks/table-content-block.js
@@ -67,12 +67,18 @@ const TableContentBlock = ({ table, caption }) => {
             </tr>
           ))}
         </tbody>
+        {caption && (
+          <caption className={tableStyle.caption}>
+            <ImageCredit>
+              <div
+                dangerouslySetInnerHTML={{
+                  __html: marked.inlineLexer(caption, []),
+                }}
+              />
+            </ImageCredit>
+          </caption>
+        )}
       </table>
-      {caption && (
-        <ImageCredit className={tableStyle.caption}>
-          <div dangerouslySetInnerHTML={{ __html: marked(caption) }} />
-        </ImageCredit>
-      )}
     </>
   )
 }

--- a/src/components/pages/blog/content-blocks/table-content-block.module.scss
+++ b/src/components/pages/blog/content-blocks/table-content-block.module.scss
@@ -61,3 +61,8 @@
     }
   }
 }
+
+.caption {
+  caption-side: bottom;
+  text-align: left;
+}


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Puts the caption into a real `<caption>` tag and fixes full width.