### PR TITLE
fix(crdt-historical): explicitly define ethnicity columns

### DIFF
--- a/src/components/pages/state/race-ethnicity/utils/generate-table-labels.js
+++ b/src/components/pages/state/race-ethnicity/utils/generate-table-labels.js
@@ -95,29 +95,27 @@ const generateBaseTableLabels = (
       }
     })
 
-    let labels
+    const labels = []
+
+    // Metrics in the same order as the dashboard.
+    const metricsInOrder = []
+
+    const pushMetricByContains = (listToSearch, listToPush, searchString) => {
+      /**
+       * Push metrics from one list to another only if their fieldTotal
+       * property contains a search string.
+       */
+      listToSearch.every(metric => {
+        if (metric.fieldTotal.includes(searchString)) {
+          listToPush.push(metric)
+          return false
+        }
+        return true
+      })
+    }
 
     if (raceOnly) {
       // Just looking at race data.
-
-      const pushMetricByContains = (listToSearch, listToPush, searchString) => {
-        /**
-         * Push metrics from one list to another only if their fieldTotal
-         * property contains a search string.
-         */
-        listToSearch.every(metric => {
-          if (metric.fieldTotal.includes(searchString)) {
-            listToPush.push(metric)
-            return false
-          }
-          return true
-        })
-      }
-
-      labels = []
-
-      // Metrics in the same order as the dashboard.
-      const metricsInOrder = []
 
       // _Black is the first element
       metricsInOrder.push('_Black')
@@ -162,7 +160,12 @@ const generateBaseTableLabels = (
     } else {
       // Just looking at ethnicity data.
 
-      labels = unsortedLabels // Don't need to sort for ethnicity.
+      // All other metrics, in order.
+      metricsInOrder.push('_Ethnicity_NonHispanic', '_Ethnicity_Hispanic')
+
+      metricsInOrder.forEach(metric => {
+        pushMetricByContains(unsortedLabels, labels, metric)
+      })
 
       // Prepend the totals column.
       labels.unshift({


### PR DESCRIPTION
fixes the "per100k" column labels in the historical tables for
states that report race and ethnicity separately

<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
