### PR TITLE
feat: Add landing page per dataset

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -34,6 +34,12 @@ exports.createPages = async ({ graphql, actions }) => {
           }
         }
       }
+      allContentfulDataSummary {
+        nodes {
+          id
+          slug
+        }
+      }
       allContentfulPage {
         nodes {
           id
@@ -106,6 +112,14 @@ exports.createPages = async ({ graphql, actions }) => {
     createPage({
       path: node.slug,
       component: path.resolve(`./src/templates/content.js`),
+      context: node,
+    })
+  })
+
+  result.data.allContentfulDataSummary.nodes.forEach(node => {
+    createPage({
+      path: `/about-data/data-summary/${node.slug}`,
+      component: path.resolve(`./src/templates/data-summary.js`),
       context: node,
     })
   })

--- a/src/components/pages/about-data/data-summary-resources.js
+++ b/src/components/pages/about-data/data-summary-resources.js
@@ -11,6 +11,7 @@ const DataSummaryResources = ({ resources }) => {
       {resources.map(resource => (
         <div className={dataSummaryStyle.resource}>
           <h3>{resource.name}</h3>
+          <p>Last updated {resource.updatedAt}</p>
           <div
             dangerouslySetInnerHTML={{
               __html: resource.description.childMarkdownRemark.html,
@@ -30,14 +31,11 @@ const DataSummaryResources = ({ resources }) => {
               </a>
             </p>
           )}
-          {resource.screenshots.map(screenshot => (
-            <div className={dataSummaryStyle.screenshot}>
-              <img src={screenshot.fixed.src} alt={screenshot.title} />
-            </div>
-          ))}
           {resource.relatedPosts && (
             <>
-              <h4>Our related posts</h4>
+              <h4 className={dataSummaryStyle.relatedPosts}>
+                Our related posts
+              </h4>
               <ul>
                 {resource.relatedPosts.map(post => (
                   <li>

--- a/src/components/pages/about-data/data-summary-resources.js
+++ b/src/components/pages/about-data/data-summary-resources.js
@@ -1,0 +1,57 @@
+import { Link } from 'gatsby'
+import React from 'react'
+import dataSummaryStyle from './data-summary.module.scss'
+
+const DataSummaryResources = ({ resources }) => (
+  <>
+    {resources.map(resource => (
+      <div>
+        <h3>{resource.name}</h3>
+        <div
+          dangerouslySetInnerHTML={{
+            __html: resource.description.childMarkdownRemark.html,
+          }}
+        />
+        {resource.linkUrl && resource.linkTitle && (
+          <p>
+            <strong>Link:</strong>{' '}
+            <a href={resource.linkUrl}>{resource.linkTitle}</a>
+          </p>
+        )}
+        {resource.downloadLinkUrl && resource.downloadLinkTitle && (
+          <p>
+            <strong>Download link:</strong>{' '}
+            <a href={resource.downloadLinkUrl}>{resource.downloadLinkTitle}</a>
+          </p>
+        )}
+        {resource.screenshots.map(screenshot => (
+          <div className={dataSummaryStyle.screenshot}>
+            <img src={screenshot.fixed.src} alt={screenshot.title} />
+          </div>
+        ))}
+        {resource.relatedPosts && (
+          <>
+            <h3>Our related posts</h3>
+            <ul>
+              {resource.relatedPosts.map(post => (
+                <li>
+                  <Link
+                    to={
+                      post.sys.contentType.id === 'blog'
+                        ? `/analysis-updates/${post.slug}`
+                        : `/${post.slug}`
+                    }
+                  >
+                    {post.title}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </>
+        )}
+      </div>
+    ))}
+  </>
+)
+
+export default DataSummaryResources

--- a/src/components/pages/about-data/data-summary-resources.js
+++ b/src/components/pages/about-data/data-summary-resources.js
@@ -2,56 +2,63 @@ import { Link } from 'gatsby'
 import React from 'react'
 import dataSummaryStyle from './data-summary.module.scss'
 
-const DataSummaryResources = ({ resources }) => (
-  <>
-    {resources.map(resource => (
-      <div>
-        <h3>{resource.name}</h3>
-        <div
-          dangerouslySetInnerHTML={{
-            __html: resource.description.childMarkdownRemark.html,
-          }}
-        />
-        {resource.linkUrl && resource.linkTitle && (
-          <p>
-            <strong>Link:</strong>{' '}
-            <a href={resource.linkUrl}>{resource.linkTitle}</a>
-          </p>
-        )}
-        {resource.downloadLinkUrl && resource.downloadLinkTitle && (
-          <p>
-            <strong>Download link:</strong>{' '}
-            <a href={resource.downloadLinkUrl}>{resource.downloadLinkTitle}</a>
-          </p>
-        )}
-        {resource.screenshots.map(screenshot => (
-          <div className={dataSummaryStyle.screenshot}>
-            <img src={screenshot.fixed.src} alt={screenshot.title} />
-          </div>
-        ))}
-        {resource.relatedPosts && (
-          <>
-            <h3>Our related posts</h3>
-            <ul>
-              {resource.relatedPosts.map(post => (
-                <li>
-                  <Link
-                    to={
-                      post.sys.contentType.id === 'blog'
-                        ? `/analysis-updates/${post.slug}`
-                        : `/${post.slug}`
-                    }
-                  >
-                    {post.title}
-                  </Link>
-                </li>
-              ))}
-            </ul>
-          </>
-        )}
-      </div>
-    ))}
-  </>
-)
+const DataSummaryResources = ({ resources }) => {
+  if (!resources) {
+    return null
+  }
+  return (
+    <>
+      {resources.map(resource => (
+        <div>
+          <h3>{resource.name}</h3>
+          <div
+            dangerouslySetInnerHTML={{
+              __html: resource.description.childMarkdownRemark.html,
+            }}
+          />
+          {resource.linkUrl && resource.linkTitle && (
+            <p>
+              <strong>Link:</strong>{' '}
+              <a href={resource.linkUrl}>{resource.linkTitle}</a>
+            </p>
+          )}
+          {resource.downloadLinkUrl && resource.downloadLinkTitle && (
+            <p>
+              <strong>Download link:</strong>{' '}
+              <a href={resource.downloadLinkUrl}>
+                {resource.downloadLinkTitle}
+              </a>
+            </p>
+          )}
+          {resource.screenshots.map(screenshot => (
+            <div className={dataSummaryStyle.screenshot}>
+              <img src={screenshot.fixed.src} alt={screenshot.title} />
+            </div>
+          ))}
+          {resource.relatedPosts && (
+            <>
+              <h3>Our related posts</h3>
+              <ul>
+                {resource.relatedPosts.map(post => (
+                  <li>
+                    <Link
+                      to={
+                        post.sys.contentType.id === 'blog'
+                          ? `/analysis-updates/${post.slug}`
+                          : `/${post.slug}`
+                      }
+                    >
+                      {post.title}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </div>
+      ))}
+    </>
+  )
+}
 
 export default DataSummaryResources

--- a/src/components/pages/about-data/data-summary-resources.js
+++ b/src/components/pages/about-data/data-summary-resources.js
@@ -9,7 +9,7 @@ const DataSummaryResources = ({ resources }) => {
   return (
     <>
       {resources.map(resource => (
-        <div>
+        <div className={dataSummaryStyle.resource}>
           <h3>{resource.name}</h3>
           <div
             dangerouslySetInnerHTML={{
@@ -37,13 +37,13 @@ const DataSummaryResources = ({ resources }) => {
           ))}
           {resource.relatedPosts && (
             <>
-              <h3>Our related posts</h3>
+              <h4>Our related posts</h4>
               <ul>
                 {resource.relatedPosts.map(post => (
                   <li>
                     <Link
                       to={
-                        post.sys.contentType.id === 'blog'
+                        post.sys.contentType.sys.id === 'blog'
                           ? `/analysis-updates/${post.slug}`
                           : `/${post.slug}`
                       }

--- a/src/components/pages/about-data/data-summary.js
+++ b/src/components/pages/about-data/data-summary.js
@@ -11,6 +11,48 @@ const categoryOrder = [
   'miscellaneous-repositories',
 ]
 
+const Summary = ({ summary, hideTitle = false }) => (
+  <div className={summaryStyle.summary} id={summary.slug}>
+    {!hideTitle && (
+      <h3 className={summaryStyle.header}>
+        <Link to={`/about-data/data-summary/${summary.slug}`}>
+          {summary.title}
+        </Link>
+      </h3>
+    )}
+    <div
+      dangerouslySetInnerHTML={{
+        __html:
+          summary.childContentfulDataSummaryDescriptionTextNode
+            .childMarkdownRemark.html,
+      }}
+    />
+    <ul className={summaryStyle.links}>
+      <li>
+        <a href={summary.sourceLink}>Data source</a>
+      </li>
+      {summary.downloadLink && (
+        <li>
+          <a href={summary.downloadLink}>Download data</a>
+        </li>
+      )}
+      {summary.definitionsLink && (
+        <li>
+          <a href={summary.definitionsLink}>Definitions</a>
+        </li>
+      )}
+    </ul>
+    <h4 className={summaryStyle.header}>How to use it</h4>
+    <div
+      dangerouslySetInnerHTML={{
+        __html:
+          summary.childContentfulDataSummaryUseTextNode.childMarkdownRemark
+            .html,
+      }}
+    />
+  </div>
+)
+
 const DataSummary = () => {
   const data = useStaticQuery(graphql`
     {
@@ -68,43 +110,7 @@ const DataSummary = () => {
         <>
           <h2 className={summaryStyle.category}>{title}</h2>
           {summaries.map(summary => (
-            <div
-              key={summary.slug}
-              className={summaryStyle.summary}
-              id={summary.slug}
-            >
-              <h3 className={summaryStyle.header}>{summary.title}</h3>
-              <div
-                dangerouslySetInnerHTML={{
-                  __html:
-                    summary.childContentfulDataSummaryDescriptionTextNode
-                      .childMarkdownRemark.html,
-                }}
-              />
-              <ul className={summaryStyle.links}>
-                <li>
-                  <a href={summary.sourceLink}>Data source</a>
-                </li>
-                {summary.downloadLink && (
-                  <li>
-                    <a href={summary.downloadLink}>Download data</a>
-                  </li>
-                )}
-                {summary.definitionsLink && (
-                  <li>
-                    <a href={summary.definitionsLink}>Definitions</a>
-                  </li>
-                )}
-              </ul>
-              <h4 className={summaryStyle.header}>How to use it</h4>
-              <div
-                dangerouslySetInnerHTML={{
-                  __html:
-                    summary.childContentfulDataSummaryUseTextNode
-                      .childMarkdownRemark.html,
-                }}
-              />
-            </div>
+            <Summary key={summary.slug} summary={summary} />
           ))}
         </>
       ))}
@@ -113,3 +119,5 @@ const DataSummary = () => {
 }
 
 export default DataSummary
+
+export { Summary }

--- a/src/components/pages/about-data/data-summary.js
+++ b/src/components/pages/about-data/data-summary.js
@@ -15,9 +15,13 @@ const Summary = ({ summary, hideTitle = false }) => (
   <div className={summaryStyle.summary} id={summary.slug}>
     {!hideTitle && (
       <h3 className={summaryStyle.header}>
-        <Link to={`/about-data/data-summary/${summary.slug}`}>
-          {summary.title}
-        </Link>
+        {summary.resources ? (
+          <Link to={`/about-data/data-summary/${summary.slug}`}>
+            {summary.title}
+          </Link>
+        ) : (
+          <>{summary.title}</>
+        )}
       </h3>
     )}
     <div
@@ -75,6 +79,9 @@ const DataSummary = () => {
               childMarkdownRemark {
                 html
               }
+            }
+            resources {
+              id
             }
           }
         }

--- a/src/components/pages/about-data/data-summary.module.scss
+++ b/src/components/pages/about-data/data-summary.module.scss
@@ -41,3 +41,7 @@ ul.toc {
   text-align: center;
   @include margin(32, top bottom);
 }
+
+.resource {
+  @include margin(64, bottom);
+}

--- a/src/components/pages/about-data/data-summary.module.scss
+++ b/src/components/pages/about-data/data-summary.module.scss
@@ -45,3 +45,7 @@ ul.toc {
 .resource {
   @include margin(64, bottom);
 }
+
+.related-posts {
+  margin-bottom: 0;
+}

--- a/src/components/pages/about-data/data-summary.module.scss
+++ b/src/components/pages/about-data/data-summary.module.scss
@@ -36,3 +36,8 @@ ul.toc {
     }
   }
 }
+
+.screenshot {
+  text-align: center;
+  @include margin(32, top bottom);
+}

--- a/src/templates/data-summary.js
+++ b/src/templates/data-summary.js
@@ -44,6 +44,7 @@ export const query = graphql`
       }
       resources {
         name
+        updatedAt(formatString: "MMMM d, yyyy")
         linkUrl
         linkTitle
         downloadLinkTitle
@@ -63,12 +64,6 @@ export const query = graphql`
               }
             }
           }
-        }
-        screenshots {
-          fixed {
-            src
-          }
-          title
         }
       }
     }

--- a/src/templates/data-summary.js
+++ b/src/templates/data-summary.js
@@ -1,0 +1,76 @@
+import React from 'react'
+import { graphql } from 'gatsby'
+import { Summary } from '~components/pages/about-data/data-summary'
+import DataSummaryResources from '~components/pages/about-data/data-summary-resources'
+import Layout from '../components/layout'
+
+const DataSummaryPage = ({ data, path }) => {
+  return (
+    <Layout
+      title={data.contentfulDataSummary.title}
+      path={path}
+      returnLinks={[
+        { link: '/about-data' },
+        { link: '/about-data/data-summary', title: 'Add Datasets' },
+      ]}
+    >
+      <Summary hideTitle summary={data.contentfulDataSummary} />
+      <h2>Where to find this data</h2>
+      <DataSummaryResources resources={data.contentfulDataSummary.resources} />
+    </Layout>
+  )
+}
+
+export default DataSummaryPage
+
+export const query = graphql`
+  query($id: String!) {
+    contentfulDataSummary(id: { eq: $id }) {
+      id
+      title
+      slug
+      sourceLink
+      downloadLink
+      definitionsLink
+      childContentfulDataSummaryUseTextNode {
+        childMarkdownRemark {
+          html
+        }
+      }
+      childContentfulDataSummaryDescriptionTextNode {
+        childMarkdownRemark {
+          html
+        }
+      }
+      resources {
+        name
+        linkUrl
+        linkTitle
+        downloadLinkTitle
+        downloadLinkUrl
+        description {
+          childMarkdownRemark {
+            html
+          }
+        }
+        relatedPosts {
+          title
+          slug
+          sys {
+            contentType {
+              sys {
+                id
+              }
+            }
+          }
+        }
+        screenshots {
+          fixed {
+            src
+          }
+          title
+        }
+      }
+    }
+  }
+`


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds a single page per dataset summary
- Includes resources on the dataset's page
- Moves dataset summary into reusable component