### PR TITLE
chore: Remove LTC historic page lede

### DIFF
--- a/src/__tests__/components/pages/state/__snapshots__/state-notes.js.snap
+++ b/src/__tests__/components/pages/state/__snapshots__/state-notes.js.snap
@@ -12,8 +12,45 @@ exports[`Components : Pages : State : State notes renders correctly 1`] = `
     >
       <p>
         When 
+        California
          reports no data, several days of data, or unusual data (such as decreases in values that should increase), our volunteers note it here on the date the anomaly occurred. We also note here changes in our own methodology that affect the data.
       </p>
+      <p
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "This is the first paragraph for <strong>June 13</strong>.",
+          }
+        }
+      />
+      <p
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "This second line tests years, as in <strong>July 14, 2020</strong>.",
+          }
+        }
+      />
+      <p
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "You can also format with <strong>August 18 2020</strong>, I guess that is fine too.",
+          }
+        }
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Components : Pages : State : State notes renders correctly 2`] = `
+<div
+  className="container container"
+>
+  <div
+    className="centered narrow"
+  >
+    <div
+      className="content"
+    >
       <p
         dangerouslySetInnerHTML={
           Object {

--- a/src/__tests__/components/pages/state/state-notes.js
+++ b/src/__tests__/components/pages/state/state-notes.js
@@ -10,7 +10,14 @@ You can also format with August 18 2020, I guess that is fine too.`
 
 describe('Components : Pages : State : State notes', () => {
   it('renders correctly', () => {
-    const tree = renderer.create(<StateNotes notes={sampleText} />).toJSON()
+    const tree = renderer
+      .create(<StateNotes notes={sampleText} stateName="California" />)
+      .toJSON()
     expect(tree).toMatchSnapshot()
+
+    const treeHiddenLede = renderer
+      .create(<StateNotes notes={sampleText} hideLede />)
+      .toJSON()
+    expect(treeHiddenLede).toMatchSnapshot()
   })
 })

--- a/src/components/pages/state/state-notes.js
+++ b/src/components/pages/state/state-notes.js
@@ -10,7 +10,7 @@ const getBoldedText = text =>
     '**$1 $2$3**',
   )
 
-const StateNotes = ({ notes }) => {
+const StateNotes = ({ stateName, notes, hideLede = false }) => {
   const highlightedNotes = getBoldedText(notes)
   const notesArray = highlightedNotes
     .split('\n')
@@ -18,6 +18,14 @@ const StateNotes = ({ notes }) => {
   return (
     <Container centered>
       <LongContent>
+        {!hideLede && (
+          <p>
+            When {stateName} reports no data, several days of data, or unusual
+            data (such as decreases in values that should increase), our
+            volunteers note it here on the date the anomaly occurred. We also
+            note here changes in our own methodology that affect the data.
+          </p>
+        )}
         {notesArray.map(note => (
           <p
             key={note}

--- a/src/components/pages/state/state-notes.js
+++ b/src/components/pages/state/state-notes.js
@@ -10,7 +10,7 @@ const getBoldedText = text =>
     '**$1 $2$3**',
   )
 
-const StateNotes = ({ stateName, notes }) => {
+const StateNotes = ({ notes }) => {
   const highlightedNotes = getBoldedText(notes)
   const notesArray = highlightedNotes
     .split('\n')
@@ -18,12 +18,6 @@ const StateNotes = ({ stateName, notes }) => {
   return (
     <Container centered>
       <LongContent>
-        <p>
-          When {stateName} reports no data, several days of data, or unusual
-          data (such as decreases in values that should increase), our
-          volunteers note it here on the date the anomaly occurred. We also note
-          here changes in our own methodology that affect the data.
-        </p>
         {notesArray.map(note => (
           <p
             key={note}

--- a/src/templates/state/long-term-care/history.js
+++ b/src/templates/state/long-term-care/history.js
@@ -54,7 +54,7 @@ export default ({ pageContext, path, data }) => {
           {data.covidLtcNotes.alerts}
         </LongTermCareAlertNote>
       )}
-      <StateNotes notes={data.covidLtcNotes.notes} />
+      <StateNotes hideLede notes={data.covidLtcNotes.notes} />
       <TableResponsive
         labels={[
           {


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Removes the lede paragraph from the LTC historic pages