### PR TITLE
chore: Remove Tableau outage warning

### DIFF
--- a/src/components/charts/tableau.js
+++ b/src/components/charts/tableau.js
@@ -35,7 +35,7 @@ const TableauCharts = ({
 
   return (
     <>
-      <div className={tableauStyle.warning}>
+      {/* <div className={tableauStyle.warning}>
         A{' '}
         <a
           href="https://trust.tableau.com/incidents/pyxx725nky8s"
@@ -45,7 +45,7 @@ const TableauCharts = ({
           major outage at Tableau
         </a>{' '}
         may cause this chart to not load.
-      </div>
+  </div> */}
       <div
         className={classnames(
           className,


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
