### PR TITLE
chore: Add warning to every page

### DIFF
--- a/src/__tests__/components/layout/__snapshots__/header.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/header.js.snap
@@ -480,6 +480,37 @@ exports[`Components : Layout : Header renders correctly 1`] = `
         </div>
       </div>
     </div>
+    <div
+      className="shutdownBox"
+    >
+      <div
+        className="container container"
+      >
+        <div
+          className="full"
+        >
+          Starting 
+          <strong>
+            March 7, 2021
+          </strong>
+           we are
+           
+          <a
+            href="/analysis-updates/giving-thanks-and-looking-ahead-our-data-collection-work-is-done"
+          >
+            no longer collecting new data
+          </a>
+          .
+           
+          <a
+            href="/analysis-updates/federal-covid-data-101-how-to-find-data"
+          >
+            Learn about available federal data
+          </a>
+          .
+        </div>
+      </div>
+    </div>
   </div>
 </header>
 `;
@@ -961,6 +992,37 @@ exports[`Components : Layout : Header renders correctly 2`] = `
               Sample title
             </h1>
           </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="shutdownBox"
+    >
+      <div
+        className="container container"
+      >
+        <div
+          className="full"
+        >
+          Starting 
+          <strong>
+            March 7, 2021
+          </strong>
+           we are
+           
+          <a
+            href="/analysis-updates/giving-thanks-and-looking-ahead-our-data-collection-work-is-done"
+          >
+            no longer collecting new data
+          </a>
+          .
+           
+          <a
+            href="/analysis-updates/federal-covid-data-101-how-to-find-data"
+          >
+            Learn about available federal data
+          </a>
+          .
         </div>
       </div>
     </div>
@@ -1452,6 +1514,37 @@ exports[`Components : Layout : Header renders correctly 3`] = `
         </div>
       </div>
     </div>
+    <div
+      className="shutdownBox"
+    >
+      <div
+        className="container container"
+      >
+        <div
+          className="full"
+        >
+          Starting 
+          <strong>
+            March 7, 2021
+          </strong>
+           we are
+           
+          <a
+            href="/analysis-updates/giving-thanks-and-looking-ahead-our-data-collection-work-is-done"
+          >
+            no longer collecting new data
+          </a>
+          .
+           
+          <a
+            href="/analysis-updates/federal-covid-data-101-how-to-find-data"
+          >
+            Learn about available federal data
+          </a>
+          .
+        </div>
+      </div>
+    </div>
   </div>
 </header>
 `;
@@ -1936,6 +2029,37 @@ exports[`Components : Layout : Header renders correctly 4`] = `
         </div>
       </div>
     </div>
+    <div
+      className="shutdownBox"
+    >
+      <div
+        className="container container"
+      >
+        <div
+          className="full"
+        >
+          Starting 
+          <strong>
+            March 7, 2021
+          </strong>
+           we are
+           
+          <a
+            href="/analysis-updates/giving-thanks-and-looking-ahead-our-data-collection-work-is-done"
+          >
+            no longer collecting new data
+          </a>
+          .
+           
+          <a
+            href="/analysis-updates/federal-covid-data-101-how-to-find-data"
+          >
+            Learn about available federal data
+          </a>
+          .
+        </div>
+      </div>
+    </div>
   </div>
 </header>
 `;
@@ -2417,6 +2541,37 @@ exports[`Components : Layout : Header renders correctly 5`] = `
               Sample title
             </h1>
           </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="shutdownBox"
+    >
+      <div
+        className="container container"
+      >
+        <div
+          className="full"
+        >
+          Starting 
+          <strong>
+            March 7, 2021
+          </strong>
+           we are
+           
+          <a
+            href="/analysis-updates/giving-thanks-and-looking-ahead-our-data-collection-work-is-done"
+          >
+            no longer collecting new data
+          </a>
+          .
+           
+          <a
+            href="/analysis-updates/federal-covid-data-101-how-to-find-data"
+          >
+            Learn about available federal data
+          </a>
+          .
         </div>
       </div>
     </div>

--- a/src/__tests__/components/layout/__snapshots__/index.js.snap
+++ b/src/__tests__/components/layout/__snapshots__/index.js.snap
@@ -488,6 +488,37 @@ Array [
           </div>
         </div>
       </div>
+      <div
+        className="shutdownBox"
+      >
+        <div
+          className="container container"
+        >
+          <div
+            className="full"
+          >
+            Starting 
+            <strong>
+              March 7, 2021
+            </strong>
+             we are
+             
+            <a
+              href="/analysis-updates/giving-thanks-and-looking-ahead-our-data-collection-work-is-done"
+            >
+              no longer collecting new data
+            </a>
+            .
+             
+            <a
+              href="/analysis-updates/federal-covid-data-101-how-to-find-data"
+            >
+              Learn about available federal data
+            </a>
+            .
+          </div>
+        </div>
+      </div>
     </div>
   </header>,
   <main
@@ -1148,6 +1179,37 @@ Array [
                 Another title
               </h1>
             </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className="shutdownBox"
+      >
+        <div
+          className="container container"
+        >
+          <div
+            className="full"
+          >
+            Starting 
+            <strong>
+              March 7, 2021
+            </strong>
+             we are
+             
+            <a
+              href="/analysis-updates/giving-thanks-and-looking-ahead-our-data-collection-work-is-done"
+            >
+              no longer collecting new data
+            </a>
+            .
+             
+            <a
+              href="/analysis-updates/federal-covid-data-101-how-to-find-data"
+            >
+              Learn about available federal data
+            </a>
+            .
           </div>
         </div>
       </div>

--- a/src/components/layout/header/header.module.scss
+++ b/src/components/layout/header/header.module.scss
@@ -243,3 +243,8 @@
     padding: 0 spacer(8);
   }
 }
+
+.shutdown-box {
+  background: $color-honey-300;
+  @include padding(16, top bottom);
+}

--- a/src/components/layout/header/index.js
+++ b/src/components/layout/header/index.js
@@ -41,6 +41,7 @@ const Header = withSearch(
     hero,
     centerTitle,
     flipColors = false,
+    hideWarning = false,
     forceSubNavigationKey,
   }) => {
     const data = useStaticQuery(graphql`
@@ -273,6 +274,21 @@ const Header = withSearch(
               )}
               {hero}
             </Container>
+            {!hideWarning && (
+              <div className={headerStyle.shutdownBox}>
+                <Container>
+                  Starting <strong>March 7, 2021</strong> we are{' '}
+                  <Link to="/analysis-updates/giving-thanks-and-looking-ahead-our-data-collection-work-is-done">
+                    no longer collecting new data
+                  </Link>
+                  .{' '}
+                  <Link to="/analysis-updates/federal-covid-data-101-how-to-find-data">
+                    Learn about available federal data
+                  </Link>
+                  .
+                </Container>
+              </div>
+            )}
           </div>
         </header>
       </>

--- a/src/components/layout/index.js
+++ b/src/components/layout/index.js
@@ -24,6 +24,7 @@ const Layout = ({
   socialCard,
   hero,
   centerTitle,
+  hidewarning = false,
   flipColors = false,
   noContainer = false,
   forceSubNavigationKey = false,
@@ -55,6 +56,7 @@ const Layout = ({
         centerTitle={centerTitle}
         forceSubNavigationKey={forceSubNavigationKey}
         flipColors={flipColors}
+        hidewarning={hidewarning}
       />
       <main id="main">
         <SkipNavContent />

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,7 +14,7 @@ const Homepage = () => (
   <>
     <SEO title="The COVID Tracking Project" />
     <SkipNavigation />
-    <Header siteTitle="The COVID Tracking Project" noMargin />
+    <Header siteTitle="The COVID Tracking Project" noMargin hideWarning />
     <SkipNavContent />
     <h1 className="a11y-only">The COVID Tracking Project</h1>
 


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds a warning to every page but the homepage about our shutdown