### PR TITLE
Kevee/federal dataset fixes

### DIFF
--- a/src/components/common/table-of-contents.js
+++ b/src/components/common/table-of-contents.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import classnames from 'classnames'
 import tocStyle from './table-of-contents.module.scss'
 
 const TableOfContents = ({ headings }) => (
@@ -21,8 +22,15 @@ const TableOfContents = ({ headings }) => (
   </div>
 )
 
-export const TableOfContentsWrapper = ({ children }) => (
-  <div className={tocStyle.tableOfContents}>{children}</div>
+export const TableOfContentsWrapper = ({ children, topMargin = false }) => (
+  <div
+    className={classnames(
+      tocStyle.tableOfContents,
+      topMargin && tocStyle.topMargin,
+    )}
+  >
+    {children}
+  </div>
 )
 
 export default TableOfContents

--- a/src/components/common/table-of-contents.module.scss
+++ b/src/components/common/table-of-contents.module.scss
@@ -20,4 +20,7 @@
       }
     }
   }
+  &.top-margin {
+    @include margin(64, top);
+  }
 }

--- a/src/components/pages/about-data/data-summary-resources.js
+++ b/src/components/pages/about-data/data-summary-resources.js
@@ -16,7 +16,7 @@ const aboutFields = [
   { name: 'Chart link', field: 'chartLink', link: true },
 ]
 
-const DataSummaryResources = ({ resources }) => {
+const DataSummaryResources = ({ resources, showSummaries = true }) => {
   if (!resources) {
     return null
   }
@@ -69,25 +69,45 @@ const DataSummaryResources = ({ resources }) => {
               ))}
             </>
           )}
-          {resource.relatedPosts && (
+          {showSummaries && resource.data_summary && (
+            <>
+              <h4 className={dataSummaryStyle.relatedPosts}>
+                Our related datasets
+              </h4>
+              <ul>
+                {resource.data_summary.map(summary => (
+                  <li>
+                    <Link to={`/about-data/data-summary/${summary.slug}`}>
+                      {summary.title}
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+          {(resource.relatedPosts || resource.youtubeVideoTitle) && (
             <>
               <h4 className={dataSummaryStyle.relatedPosts}>
                 Our related posts
               </h4>
               <ul>
-                {resource.relatedPosts.map(post => (
-                  <li>
-                    <Link
-                      to={
-                        post.sys.contentType.sys.id === 'blog'
-                          ? `/analysis-updates/${post.slug}`
-                          : `/${post.slug}`
-                      }
-                    >
-                      {post.title}
-                    </Link>
-                  </li>
-                ))}
+                {resource.relatedPosts && (
+                  <>
+                    {resource.relatedPosts.map(post => (
+                      <li>
+                        <Link
+                          to={
+                            post.sys.contentType.sys.id === 'blog'
+                              ? `/analysis-updates/${post.slug}`
+                              : `/${post.slug}`
+                          }
+                        >
+                          {post.title}
+                        </Link>
+                      </li>
+                    ))}
+                  </>
+                )}
                 {resource.youtubeVideoTitle && (
                   <li>
                     <a href={resource.youtubeVideoUrl}>

--- a/src/components/pages/about-data/data-summary.js
+++ b/src/components/pages/about-data/data-summary.js
@@ -99,7 +99,7 @@ const DataSummary = () => {
 
   return (
     <>
-      <TableOfContentsWrapper>
+      <TableOfContentsWrapper topMargin>
         <ul className={summaryStyle.toc}>
           {categories.map(({ title, summaries }) => (
             <>

--- a/src/components/pages/about-data/data-summary.js
+++ b/src/components/pages/about-data/data-summary.js
@@ -14,17 +14,7 @@ const categoryOrder = [
 
 const Summary = ({ summary, hideTitle = false }) => (
   <div className={summaryStyle.summary} id={summary.slug}>
-    {!hideTitle && (
-      <h3 className={summaryStyle.header}>
-        {summary.resources ? (
-          <Link to={`/about-data/data-summary/${summary.slug}`}>
-            {summary.title}
-          </Link>
-        ) : (
-          <>{summary.title}</>
-        )}
-      </h3>
-    )}
+    {!hideTitle && <h3 className={summaryStyle.header}>{summary.title}</h3>}
     <div
       dangerouslySetInnerHTML={{
         __html:
@@ -44,6 +34,13 @@ const Summary = ({ summary, hideTitle = false }) => (
       {summary.definitionsLink && (
         <li>
           <a href={summary.definitionsLink}>Definitions</a>
+        </li>
+      )}
+      {summary.resources && (
+        <li>
+          <Link to={`/about-data/data-summary/${summary.slug}`}>
+            Related federal data
+          </Link>
         </li>
       )}
     </ul>

--- a/src/components/pages/about-data/federal-resources.js
+++ b/src/components/pages/about-data/federal-resources.js
@@ -18,7 +18,7 @@ const Resources = ({ summary }) => {
   if (!summary.resources) {
     return null
   }
-  return <DataSummaryResources resources={summary.resources} />
+  return <DataSummaryResources resources={summary.resources} showSummaries />
 }
 
 const FederalResources = () => {
@@ -41,6 +41,10 @@ const FederalResources = () => {
                 childMarkdownRemark {
                   html
                 }
+              }
+              data_summary {
+                title
+                slug
               }
               relatedPosts {
                 title

--- a/src/components/pages/about-data/federal-resources.js
+++ b/src/components/pages/about-data/federal-resources.js
@@ -20,6 +20,7 @@ const Resources = ({ summary }) => {
   }
   return (
     <div className={summaryStyle.summary} id={summary.slug}>
+      <h2>{summary.title}</h2>
       <DataSummaryResources resources={summary.resources} />
     </div>
   )

--- a/src/components/pages/about-data/federal-resources.js
+++ b/src/components/pages/about-data/federal-resources.js
@@ -120,7 +120,7 @@ const FederalResources = () => {
 
   return (
     <>
-      <TableOfContentsWrapper>
+      <TableOfContentsWrapper topMargin>
         <ul className={summaryStyle.toc}>
           {categories.map(({ title, summaries }) => (
             <>

--- a/src/components/pages/about-data/federal-resources.js
+++ b/src/components/pages/about-data/federal-resources.js
@@ -150,7 +150,7 @@ const FederalResources = () => {
             </>
           ))}
           <li>
-            <strong>Federal Trackers</strong>
+            <strong>Federal trackers</strong>
             <ul>
               {data.allContentfulFederalTrackers.nodes.map(tracker => (
                 <li>
@@ -162,7 +162,7 @@ const FederalResources = () => {
             </ul>
           </li>
           <li>
-            <strong>Federal Data Portals</strong>
+            <strong>Federal data portals</strong>
             <ul>
               {data.allContentfulFederalDataPortal.nodes.map(tracker => (
                 <li>

--- a/src/components/pages/about-data/federal-resources.js
+++ b/src/components/pages/about-data/federal-resources.js
@@ -37,6 +37,7 @@ const FederalResources = () => {
             title
             slug
             resources {
+              contentful_id
               name
               updatedAt(formatString: "MMMM D, yyyy")
               linkUrl
@@ -92,11 +93,30 @@ const FederalResources = () => {
     }
   `)
 
-  const categories = categoryOrder.map(slug =>
-    data.allContentfulDataSummaryCategory.nodes.find(
+  const categories = categoryOrder.map(slug => {
+    const result = data.allContentfulDataSummaryCategory.nodes.find(
       node => node.slug === slug,
-    ),
-  )
+    )
+    result.summaries.forEach((summary, summaryIndex) => {
+      if (summary.resources) {
+        summary.resources.forEach((resource, resourceIndex) => {
+          result.summaries.forEach((otherSummary, otherSummaryIndex) => {
+            if (otherSummary.resources) {
+              otherSummary.resources.forEach(otherResource => {
+                if (
+                  otherSummaryIndex !== summaryIndex &&
+                  otherResource.contentful_id === resource.contentful_id
+                ) {
+                  delete result.summaries[summaryIndex].resources[resourceIndex]
+                }
+              })
+            }
+          })
+        })
+      }
+    })
+    return result
+  })
 
   return (
     <>

--- a/src/components/pages/about-data/federal-resources.js
+++ b/src/components/pages/about-data/federal-resources.js
@@ -20,7 +20,7 @@ const Resources = ({ summary }) => {
   }
   return (
     <div className={summaryStyle.summary} id={summary.slug}>
-      <h2>{summary.title}</h2>
+      <h2 className={summaryStyle.category}>{summary.title}</h2>
       <DataSummaryResources resources={summary.resources} />
     </div>
   )

--- a/src/components/pages/about-data/federal-resources.js
+++ b/src/components/pages/about-data/federal-resources.js
@@ -18,12 +18,7 @@ const Resources = ({ summary }) => {
   if (!summary.resources) {
     return null
   }
-  return (
-    <div className={summaryStyle.summary} id={summary.slug}>
-      <h2 className={summaryStyle.category}>{summary.title}</h2>
-      <DataSummaryResources resources={summary.resources} />
-    </div>
-  )
+  return <DataSummaryResources resources={summary.resources} />
 }
 
 const FederalResources = () => {
@@ -122,11 +117,13 @@ const FederalResources = () => {
     <>
       <TableOfContentsWrapper topMargin>
         <ul className={summaryStyle.toc}>
-          {categories.map(({ title, summaries }) => (
+          {categories.map(({ title, slug, summaries }) => (
             <>
               {summaries && summaries.find(summary => summary.resources) && (
                 <li>
-                  <strong>{title}</strong>
+                  <strong>
+                    <Link to={`#${slug}`}>{title}</Link>
+                  </strong>
                   <ul>
                     {summaries.map(summary => (
                       <>
@@ -150,7 +147,9 @@ const FederalResources = () => {
             </>
           ))}
           <li>
-            <strong>Federal trackers</strong>
+            <strong>
+              <Link to="#federal-trackers">Federal trackers</Link>
+            </strong>
             <ul>
               {data.allContentfulFederalTrackers.nodes.map(tracker => (
                 <li>
@@ -162,7 +161,9 @@ const FederalResources = () => {
             </ul>
           </li>
           <li>
-            <strong>Federal data portals</strong>
+            <strong>
+              <Link to="#federal-portals">Federal data portals</Link>
+            </strong>
             <ul>
               {data.allContentfulFederalDataPortal.nodes.map(tracker => (
                 <li>
@@ -175,8 +176,11 @@ const FederalResources = () => {
           </li>
         </ul>
       </TableOfContentsWrapper>
-      {categories.map(({ summaries }) => (
+      {categories.map(({ title, slug, summaries }) => (
         <>
+          <h2 className={summaryStyle.category} id={slug}>
+            {title}
+          </h2>
           {summaries.map(summary => (
             <Resources summary={summary} />
           ))}

--- a/src/components/pages/about-data/federal-trackers.js
+++ b/src/components/pages/about-data/federal-trackers.js
@@ -40,7 +40,7 @@ const FederalTrackers = () => {
   return (
     <>
       <h2 id="federal-trackers" className={summaryStyle.category}>
-        Federal Trackers
+        Federal trackers
       </h2>
       {data.allContentfulFederalTrackers.nodes.map(summary => (
         <>
@@ -76,7 +76,7 @@ const FederalTrackers = () => {
         </>
       ))}
       <h2 id="federal-portals" className={summaryStyle.category}>
-        Federal Data Portals
+        Federal data portals
       </h2>
       {data.allContentfulFederalDataPortal.nodes.map(summary => (
         <>

--- a/src/pages/about-data/federal-resources.js
+++ b/src/pages/about-data/federal-resources.js
@@ -1,13 +1,35 @@
 import React from 'react'
+import { graphql } from 'gatsby'
 import FederalResources from '~components/pages/about-data/federal-resources'
 import FederalTrackers from '~components/pages/about-data/federal-trackers'
 import Layout from '~components/layout'
+import ContentfulContent from '~components/common/contentful-content'
 
-const FederalResourcesPage = () => (
+const FederalResourcesPage = ({ data }) => (
   <Layout title="Federal Resources" centered>
+    <ContentfulContent
+      content={
+        data.contentfulSnippet.childContentfulSnippetContentTextNode
+          .childMarkdownRemark.html
+      }
+      id={data.contentfulSnippet.contentful_id}
+    />
     <FederalResources />
     <FederalTrackers />
   </Layout>
 )
 
 export default FederalResourcesPage
+
+export const query = graphql`
+  {
+    contentfulSnippet(slug: { eq: "federal-resources-prelude" }) {
+      contentful_id
+      childContentfulSnippetContentTextNode {
+        childMarkdownRemark {
+          html
+        }
+      }
+    }
+  }
+`


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fixes header order in federal resources
- Filters out duplicate resources