### PR TITLE
chore: Remove duplicate federal resources link

### DIFF
--- a/src/components/pages/about-data/data-summary.js
+++ b/src/components/pages/about-data/data-summary.js
@@ -36,7 +36,7 @@ const Summary = ({ summary, hideTitle = false }) => (
           <a href={summary.definitionsLink}>Definitions</a>
         </li>
       )}
-      {summary.resources && (
+      {summary.resources && !hideTitle && (
         <li>
           <Link to={`/about-data/data-summary/${summary.slug}`}>
             Related federal data


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fix redundant federal resources link