### PR TITLE
fix: Don't show category headers when no resources exist

### DIFF
--- a/src/components/pages/about-data/federal-resources.js
+++ b/src/components/pages/about-data/federal-resources.js
@@ -182,12 +182,16 @@ const FederalResources = () => {
       </TableOfContentsWrapper>
       {categories.map(({ title, slug, summaries }) => (
         <>
-          <h2 className={summaryStyle.category} id={slug}>
-            {title}
-          </h2>
-          {summaries.map(summary => (
-            <Resources summary={summary} />
-          ))}
+          {summaries && summaries.find(summary => summary.resources) && (
+            <>
+              <h2 className={summaryStyle.category} id={slug}>
+                {title}
+              </h2>
+              {summaries.map(summary => (
+                <Resources summary={summary} />
+              ))}
+            </>
+          )}
         </>
       ))}
     </>


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
