### PR TITLE
fix: Missing state grade assessments

### DIFF
--- a/src/templates/state/notes.js
+++ b/src/templates/state/notes.js
@@ -40,6 +40,8 @@ export const query = graphql`
       dateModified(formatString: "MMMM D, YYYY h:mm a")
     }
     covidGradeStateAssessment(state: { eq: $state }) {
+      taco
+      ltc
       crdt
     }
   }

--- a/src/templates/state/notes.js
+++ b/src/templates/state/notes.js
@@ -7,7 +7,12 @@ import Layout from '~components/layout'
 const StateNotesTemplate = ({ pageContext, path, data }) => {
   const state = pageContext
   const { slug } = state.childSlug
-  const { covidState, covidStateInfo, covidGradeStateAssessment } = data
+  const {
+    covidState,
+    covidStateInfo,
+    covidGradeStateAssessment,
+    assessmentDate,
+  } = data
   return (
     <Layout
       title={`${state.name} Notes`}
@@ -21,6 +26,7 @@ const StateNotesTemplate = ({ pageContext, path, data }) => {
         state={state}
         covidState={covidState}
         assessment={covidGradeStateAssessment}
+        assessmentDate={assessmentDate.date}
         hideNotesLink
       />
       <StateNotes stateName={state.name} notes={covidStateInfo.notes} />
@@ -43,6 +49,9 @@ export const query = graphql`
       taco
       ltc
       crdt
+    }
+    assessmentDate: covidGradeStateAssessment(date: { ne: null }) {
+      date
     }
   }
 `


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Fixes missing state grades on the notes page.