### PR TITLE
chore: Cleanup CI work, remove test coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,10 +20,12 @@ jobs:
       - run:
           name: test
           command: 'yarn run test'
-       - run:
+      - run:
           name: lint
           command: 'yarn run test:lint'
-     
+      - store_test_results:
+        path: ./
+
 workflows:
   version: 2
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,4 @@
 version: 2.1
-orbs:
-  coveralls: coveralls/coveralls@1.0.4
-
-references:
-  workspace_root: &workspace_root /tmp/workspace
 
 executors:
   main-executor:
@@ -13,61 +8,24 @@ executors:
           TZ: 'America/New_York'
           NODE_OPTIONS: '--max_old_space_size=4096'
           GATSBY_CPU_COUNT: 2
-    working_directory: *workspace_root
 
 jobs:
-  setup:
+  test:
     executor: main-executor
     steps:
       - checkout
-      - run:
-          name: install
-          command: 'yarn install'
-      - run:
-          name: fetch-api-repo
-          command: 'yarn run setup:api-repo'
-      - run:
-          name: fetch-data-repo
-          command: 'yarn run setup:data-repo'
-      - persist_to_workspace:
-          root: *workspace_root
-          paths:
-            - _api
-            - _data
-  gatsby-test:
-    executor: main-executor
-    steps:
-      - checkout
-      - attach_workspace:
-          at: *workspace_root
       - run:
           name: install
           command: 'yarn install'
       - run:
           name: test
-          command: 'yarn run test:coverage'
-      - coveralls/upload:
-        path_to_lcov: './junit.xml'
-  gatsby-lint:
-    executor: main-executor
-    steps:
-      - checkout
-      - attach_workspace:
-          at: *workspace_root
-      - run:
-          name: install
-          command: 'yarn install'
-      - run:
+          command: 'yarn run test'
+       - run:
           name: lint
           command: 'yarn run test:lint'
+     
 workflows:
   version: 2
-  build_and_test:
+  test:
     jobs:
-      - setup
-      - gatsby-lint:
-          requires:
-            - setup
-      - gatsby-test:
-          requires:
-            - setup
+      - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           name: lint
           command: 'yarn run test:lint'
       - store_test_results:
-        path: ./
+          path: ./
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,9 @@ jobs:
           name: install
           command: 'yarn install'
       - run:
+          name: setup
+          command: 'yarn setup:api-repo'
+      - run:
           name: test
           command: 'yarn run test'
       - run:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ To run the website locally, use:
 ```shell
 yarn develop
 ```
+
 The project takes 8-10 minutes to build.
 
 The site is now running at `http://localhost:8000`. Any changes you make to code is live-updated. There is a GraphQL preview tool available at `http://localhost:8000/___graphql` to see what data is exposed to the website.
@@ -56,8 +57,6 @@ Components live in `src/components` and are organized as follows:
 - `/utils` - Utilities. (If a particular component doesn't have any associated styles, there's a good chance it's a utility.)
 
 ## Testing
-
-[![Coverage Status](https://coveralls.io/repos/github/COVID19Tracking/website/badge.svg?branch=master)](https://coveralls.io/github/COVID19Tracking/website?branch=master)
 
 We use Jest for automated testing, and all test files for Gatsby are located in `./src/__tests__`. Test files are structured following their related components. To run tests, use `yarn test`.
 


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Removes unneeded setup step
- Removes unused coverage reporter