### PR TITLE
fix: Bad total facilities math in LTC

### DIFF
--- a/src/utilities/ltc-totals.js
+++ b/src/utilities/ltc-totals.js
@@ -6,7 +6,7 @@ const getTotals = state => {
   let totalFacilities = null
   categories.forEach(category => {
     if (state[`outbrkfac_${category}`]) {
-      totalFacilities = state[`outbrkfac_${category}`]
+      totalFacilities += state[`outbrkfac_${category}`]
     }
     if (
       state[`posresstaff_${category}`] ||


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Fixes missing addition in the LTC totals