### PR TITLE
chore: Add more notes to LTC page

### DIFF
--- a/src/templates/state/long-term-care/index.js
+++ b/src/templates/state/long-term-care/index.js
@@ -52,6 +52,30 @@ export default ({ pageContext, path, data }) => {
               __html: marked(data.notes.data.Public_Notes),
             }}
           />
+          {data.notes.data.generated_facility_notes_source_links_text && (
+            <>
+              <h3>Source links</h3>
+              <div
+                dangerouslySetInnerHTML={{
+                  __html: marked(
+                    data.notes.data.generated_facility_notes_source_links_text,
+                  ),
+                }}
+              />
+            </>
+          )}
+          {data.notes.data.Generated_facility_notes_full_text && (
+            <>
+              <h3>Facility notes</h3>
+              <div
+                dangerouslySetInnerHTML={{
+                  __html: marked(
+                    data.notes.data.Generated_facility_notes_full_text,
+                  ),
+                }}
+              />
+            </>
+          )}
         </>
       ) : (
         <LongTermCareAlertNote>
@@ -205,6 +229,8 @@ export const query = graphql`
     ) {
       table
       data {
+        Generated_facility_notes_full_text
+        generated_facility_notes_source_links_text
         Public_Notes
         Alert_Message
       }


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
- Adds source links and facility notes to the LTC page of each state