### PR TITLE
feat: Add awards to impact section

### DIFF
--- a/src/components/pages/homepage/impact.js
+++ b/src/components/pages/homepage/impact.js
@@ -114,9 +114,10 @@ const Impact = ({ press, files }) => (
           <em>Nature</em>, and <em>JAMA</em>.
         </p>
         <p>
-          We recieved awards for our work from the{' '}
-          <strong>Society of Professional Journalists</strong> and{' '}
-          <strong>Sigma</strong>.
+          We received awards for our work from the{' '}
+          <strong>Society of Professional Journalists</strong>, the{' '}
+          <strong>Sigma Awards</strong>, and the{' '}
+          <strong>NYU Journalism Online Awards</strong>.
         </p>
         <p>
           Our data was used by <strong>two presidential administrations</strong>{' '}

--- a/src/components/pages/homepage/impact.js
+++ b/src/components/pages/homepage/impact.js
@@ -114,6 +114,11 @@ const Impact = ({ press, files }) => (
           <em>Nature</em>, and <em>JAMA</em>.
         </p>
         <p>
+          We recieved awards for our work from the{' '}
+          <strong>Society of Professional Journalists</strong> and{' '}
+          <strong>Sigma</strong>.
+        </p>
+        <p>
           Our data was used by <strong>two presidential administrations</strong>{' '}
           and an array of federal agencies, including the CDC, HHS, and FDA.
         </p>


### PR DESCRIPTION
<!--
  Check out the docs at https://covid19tracking.github.io/website-docs first.
  Make sure that running `npm run test` works locally before opening a PR.
  Link to the issue that is fixed by this PR (if there is one)
  e.g. Fixes #1234
-->
Adds list of awards to homepage impact section.