### PR TITLE
chore: Remove link to status page

### DIFF
--- a/src/components/pages/data/api/change-log.js
+++ b/src/components/pages/data/api/change-log.js
@@ -15,16 +15,6 @@ const ChangeLog = () => (
             <span aria-hidden />
           </a>
         </li>
-        <li>
-          <a
-            href="https://covidtrackingproject.statuspage.io/"
-            target="_blank"
-            rel="noreferrer"
-          >
-            Status page
-            <span aria-hidden />
-          </a>
-        </li>
       </ul>
     </div>
   </>


### PR DESCRIPTION
Removes the status page link